### PR TITLE
feat: add comment-triggered release workflows

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -1,0 +1,243 @@
+name: Package Release
+
+on:
+  repository_dispatch:
+    types:
+      - release-package
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Package to publish
+        type: choice
+        options:
+          - cli
+          - js
+        required: true
+      release_type:
+        description: Version bump type
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        required: true
+      ref:
+        description: Branch/ref to release from
+        default: main
+        required: false
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+env:
+  NODE_VERSION: '20'
+
+jobs:
+  release:
+    concurrency:
+      group: release-${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.package) || (github.event_name == 'workflow_dispatch' && inputs.package) || 'manual' }}-${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.ref) || (github.event_name == 'workflow_dispatch' && inputs.ref) || 'main' }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.package) || (github.event_name == 'workflow_dispatch' && inputs.package) || '' }}
+      RELEASE_TYPE: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.release_type) || (github.event_name == 'workflow_dispatch' && inputs.release_type) || '' }}
+      SOURCE_REF: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.ref) || (github.event_name == 'workflow_dispatch' && inputs.ref) || 'main' }}
+      ISSUE_NUMBER: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.issue_number) || '' }}
+      REQUESTED_BY: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.requested_by) || '' }}
+      REQUEST_URL: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.request_url) || '' }}
+      PR_TITLE: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.pr_title) || '' }}
+      PR_URL: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.pr_url) || '' }}
+      PR_BRANCH: ${{ (github.event_name == 'repository_dispatch' && github.event.client_payload.pr_branch) || '' }}
+    steps:
+
+      - name: Validate context
+        run: |
+          set -e
+          if [ -z "${PACKAGE:-}" ]; then
+            echo "PACKAGE is not set"
+            exit 1
+          fi
+          case "$PACKAGE" in
+            cli|js) ;;
+            *)
+              echo "Unsupported package: $PACKAGE"
+              exit 1
+              ;;
+          esac
+
+          if [ -z "${RELEASE_TYPE:-}" ]; then
+            echo "RELEASE_TYPE is not set"
+            exit 1
+          fi
+
+          case "$RELEASE_TYPE" in
+            patch|minor|major) ;;
+            *)
+              echo "Unsupported release type: $RELEASE_TYPE"
+              exit 1
+              ;;
+          esac
+
+          if [ -z "${SOURCE_REF:-}" ]; then
+            echo "SOURCE_REF is not set"
+            exit 1
+          fi
+
+          if [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "NPM_TOKEN secret is required"
+            exit 1
+          fi
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ env.SOURCE_REF }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org/
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        working-directory: ${{ env.PACKAGE }}
+        run: bun install --frozen-lockfile
+
+      - name: Bump package version
+        id: bump
+        run: node scripts/bump-version.js "$PACKAGE" "$RELEASE_TYPE"
+
+      - name: Export version metadata
+        run: |
+          echo "NEW_VERSION=${{ steps.bump.outputs.version }}" >> "$GITHUB_ENV"
+          echo "TAG_NAME=${PACKAGE}-v${{ steps.bump.outputs.version }}" >> "$GITHUB_ENV"
+
+      - name: Capture package metadata
+        id: pkgmeta
+        run: |
+          npm_name=$(node -e "console.log(require('./${PACKAGE}/package.json').name)")
+          npm_url=$(node -e "const name = require('./${PACKAGE}/package.json').name; console.log('https://www.npmjs.com/package/' + encodeURIComponent(name));")
+          echo "npm_name=$npm_name" >> "$GITHUB_OUTPUT"
+          echo "npm_url=$npm_url" >> "$GITHUB_OUTPUT"
+
+      - name: Run lint
+        working-directory: ${{ env.PACKAGE }}
+        run: bun run lint
+
+      - name: Run type check
+        working-directory: ${{ env.PACKAGE }}
+        run: bun run type-check
+
+      - name: Run tests
+        working-directory: ${{ env.PACKAGE }}
+        run: bun run test
+
+      - name: Build package
+        working-directory: ${{ env.PACKAGE }}
+        run: bun run build
+
+      - name: Commit version change
+        run: |
+          git add "${PACKAGE}/package.json"
+          if [ -f "${PACKAGE}/package-lock.json" ]; then
+            git add "${PACKAGE}/package-lock.json"
+          fi
+          if [ -f "${PACKAGE}/bun.lock" ]; then
+            git add "${PACKAGE}/bun.lock"
+          fi
+          if [ -f "${PACKAGE}/bun.lockb" ]; then
+            git add "${PACKAGE}/bun.lockb"
+          fi
+
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 1
+          fi
+
+          git commit -m "chore(${PACKAGE}): release v${NEW_VERSION}"
+
+      - name: Publish to npm
+        working-directory: ${{ env.PACKAGE }}
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create tag
+        run: git tag "$TAG_NAME"
+
+      - name: Push changes
+        run: |
+          git push origin HEAD:${SOURCE_REF}
+          git push origin "$TAG_NAME"
+
+      - name: Create GitHub release
+        id: release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ env.TAG_NAME }}
+          release_name: ${{ steps.pkgmeta.outputs.npm_name }} v${{ env.NEW_VERSION }}
+          body: |
+            - Package: [${{ steps.pkgmeta.outputs.npm_name }}](${{ steps.pkgmeta.outputs.npm_url }})
+            - Version: v${{ env.NEW_VERSION }}
+            - Triggered by: ${{ env.REQUESTED_BY || 'workflow_dispatch' }}
+          draft: false
+          prerelease: false
+
+      - name: Comment success
+        if: ${{ success() && env.ISSUE_NUMBER != '' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { github, context } = require('@actions/github');
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `🎉 Release completed: \`${process.env.PACKAGE}\` v${process.env.NEW_VERSION}`,
+              '',
+              `- Branch: \`${process.env.SOURCE_REF}\``,
+              `- npm: [${{ steps.pkgmeta.outputs.npm_name }}](${{ steps.pkgmeta.outputs.npm_url }})`,
+              `- GitHub Release: [link](${{ steps.release.outputs.html_url }})`,
+              `- Workflow logs: ${runUrl}`
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.ISSUE_NUMBER),
+              body
+            });
+
+      - name: Comment failure
+        if: ${{ failure() && env.ISSUE_NUMBER != '' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { github, context } = require('@actions/github');
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const actor = process.env.REQUESTED_BY ? `@${process.env.REQUESTED_BY}` : 'Requester';
+            const version = process.env.NEW_VERSION || 'unknown version';
+            const body = [
+              `❌ ${actor} release failed: \`${process.env.PACKAGE}\` ${version}`,
+              '',
+              `Branch: \`${process.env.SOURCE_REF}\``,
+              `Please review the workflow logs: ${runUrl}`
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.ISSUE_NUMBER),
+              body
+            });

--- a/.github/workflows/release-command.yml
+++ b/.github/workflows/release-command.yml
@@ -1,0 +1,142 @@
+name: Release Command
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  handle:
+    if: >
+      (contains(github.event.comment.body, '!release') ||
+       contains(github.event.comment.body, '!Release') ||
+       contains(github.event.comment.body, '!RELEASE')) &&
+      github.event.comment.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Process release command
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const allowedPackages = ['cli', 'js'];
+            const allowedBumps = ['patch', 'minor', 'major'];
+            const { github, context } = require('@actions/github');
+
+            const body = context.payload.comment.body.trim();
+            const match = body.match(/!release\s+(\S+)\s+(\S+)/i);
+
+            if (!match) {
+              return;
+            }
+
+            const packageName = match[1].toLowerCase();
+            const releaseType = match[2].toLowerCase();
+
+            const allowedAssociation = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            const association = context.payload.comment.author_association;
+            const actor = context.payload.comment.user.login;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = context.payload.issue.number;
+
+            const invalidPackage = !allowedPackages.includes(packageName);
+            const invalidBump = !allowedBumps.includes(releaseType);
+
+            if (invalidPackage || invalidBump) {
+              const message = [
+                `⚠️ @${actor} I couldn't parse the release command.`,
+                '',
+                'Expected format: `!release <cli|js> <patch|minor|major>`'
+              ];
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body: message.join('\n')
+              });
+              return;
+            }
+
+            if (!allowedAssociation.includes(association)) {
+              const message = [
+                `⛔ @${actor} you do not have permission to trigger releases.`,
+                '',
+                'Please contact the repository maintainers if this is unexpected.'
+              ];
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body: message.join('\n')
+              });
+              return;
+            }
+
+            const payload = {
+              package: packageName,
+              release_type: releaseType,
+              comment_id: context.payload.comment.id,
+              issue_number: issueNumber,
+              requested_by: actor,
+              request_url: context.payload.comment.html_url,
+              ref: 'main'
+            };
+
+            if (context.payload.issue.pull_request) {
+              const { data: pr } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: issueNumber
+              });
+
+              if (!pr.head.repo || pr.head.repo.full_name !== `${owner}/${repo}`) {
+                const message = [
+                  `⛔ @${actor} releases from forked branches are not supported.`,
+                  '',
+                  'Please push the branch to this repository or run the release manually in Actions.'
+                ];
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  body: message.join('\n')
+                });
+                return;
+              }
+
+              payload.ref = pr.head.ref;
+              payload.pr_branch = pr.head.ref;
+              payload.pr_title = pr.title;
+              payload.pr_url = pr.html_url;
+            }
+
+            await github.rest.repos.createDispatchEvent({
+              owner,
+              repo,
+              event_type: 'release-package',
+              client_payload: payload
+            });
+
+            const lines = [
+              `🚀 @${actor} release command accepted: \`${packageName}\` \`${releaseType}\`.`,
+              '',
+              'The release workflow is queued; results will be posted here.'
+            ];
+
+            if (payload.pr_branch) {
+              lines.splice(2, 0, `Target branch: \`${payload.pr_branch}\` (open PR). Version commits will be pushed to this branch.`);
+            }
+
+            const message = lines.join('\n');
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              body: message
+            });


### PR DESCRIPTION
Add workflow files to enable PR comment-based releases:
- release-command.yml: Listens for !release comments
- package-release.yml: Executes the release process

These must be on main branch for issue_comment triggers to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)