### PR TITLE
fix: remove duplicate github/context declarations

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -200,7 +200,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { github, context } = require('@actions/github');
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const body = [
               `🎉 Release completed: \`${process.env.PACKAGE}\` v${process.env.NEW_VERSION}`,
@@ -224,7 +223,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { github, context } = require('@actions/github');
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const actor = process.env.REQUESTED_BY ? `@${process.env.REQUESTED_BY}` : 'Requester';
             const version = process.env.NEW_VERSION || 'unknown version';

--- a/.github/workflows/release-command.yml
+++ b/.github/workflows/release-command.yml
@@ -25,7 +25,6 @@ jobs:
           script: |
             const allowedPackages = ['cli', 'js'];
             const allowedBumps = ['patch', 'minor', 'major'];
-            const { github, context } = require('@actions/github');
 
             const body = context.payload.comment.body.trim();
             const match = body.match(/!release\s+(\S+)\s+(\S+)/i);


### PR DESCRIPTION
The actions/github-script@v7 automatically provides github and context variables. Manually requiring them causes:
SyntaxError: Identifier 'github' has already been declared

Fixed in:
- release-command.yml: removed require statement
- package-release.yml: removed require statements in both comment steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)