### PR TITLE
fix: add actions:write permission for repository_dispatch

### DIFF
--- a/.github/workflows/release-command.yml
+++ b/.github/workflows/release-command.yml
@@ -8,6 +8,7 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
+  actions: write
 
 jobs:
   handle:


### PR DESCRIPTION
The createDispatchEvent API requires actions:write permission to trigger workflow_dispatch events. Without it, the error occurs: "Resource not accessible by integration (403)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)