### PR TITLE
doc(cli): document --json flag for machine-readable output

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -281,6 +281,19 @@ You can also override the API endpoint using the `PHALA_CLOUD_API_PREFIX` enviro
 PHALA_CLOUD_API_PREFIX="https://cloud-api.phala.ai" phala cvms list
 ```
 
+#### JSON Output Mode
+
+All commands support the `--json` flag for machine-readable output, useful for automation and CI/CD pipelines.
+
+**Example:**
+```bash
+# Get CVM list as JSON
+phala cvms list --json
+
+# Parse with jq
+phala status --json | jq '.username'
+```
+
 ### Docker Management Commands
 
 Commands for managing Docker images for TEE deployments.


### PR DESCRIPTION
## Summary
- Documents the `--json` flag that is available across CLI commands
- Provides examples of JSON output usage for automation and scripting
- Closes #87

## Details
The `--json` flag enables machine-readable output that:
- Suppresses all human-readable output (spinners, tables, colors)
- Disables interactive prompts (non-interactive mode)
- Outputs only valid JSON to stdout
- Is useful for parsing with `jq` or other JSON tools in CI/CD pipelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)