### PR TITLE
feat(cli): embed git commit info in version at build time

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -23,7 +23,11 @@ const __dirname = dirname(__filename);
 
 const packageJsonPath = join(__dirname, "../package.json");
 const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-const version = `v${packageJson.version}`;
+
+// __GIT_INFO__ is replaced at compile time by tsup/esbuild
+declare const __GIT_INFO__: string;
+const gitInfo = typeof __GIT_INFO__ !== "undefined" ? __GIT_INFO__ : "";
+const version = `v${packageJson.version}${gitInfo}`;
 
 const registry = new CommandRegistry();
 registry.registerCommand(statusCommand);

--- a/cli/tsup.config.ts
+++ b/cli/tsup.config.ts
@@ -1,4 +1,15 @@
+import { execSync } from "node:child_process";
 import { defineConfig } from "tsup";
+
+function getGitInfo(): string {
+	try {
+		const hash = execSync("git rev-parse --short HEAD", { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+		const dirty = execSync("git status --porcelain", { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+		return dirty ? `+${hash}-dirty` : `+${hash}`;
+	} catch {
+		return "";
+	}
+}
 
 export default defineConfig({
 	clean: true,
@@ -16,6 +27,10 @@ export default defineConfig({
 	esbuildOptions(options) {
 		options.banner = {
 			js: "import { createRequire } from 'module';const require = createRequire(import.meta.url);",
+		};
+		options.define = {
+			...options.define,
+			__GIT_INFO__: JSON.stringify(getGitInfo()),
 		};
 	},
 });


### PR DESCRIPTION
## Summary
- Embed git commit hash and dirty status in CLI version output at build time
- Uses esbuild's `define` option to inject `__GIT_INFO__` constant during compilation

## Version Format
- Clean build: `v1.1.0-beta.11+abc1234`
- Dirty build: `v1.1.0-beta.11+abc1234-dirty`
- No git repo: `v1.1.0-beta.11` (e.g., npm install)

## Implementation
- `tsup.config.ts`: Captures git info at build time and injects via `options.define`
- `src/index.ts`: Uses the compile-time constant `__GIT_INFO__`

This helps identify exact builds during development and debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)