### PR TITLE
feat(cli): add --dry-run option to ssh and cp commands

### DIFF
--- a/cli/src/commands/cp/command.ts
+++ b/cli/src/commands/cp/command.ts
@@ -58,6 +58,12 @@ export const cpCommandMeta: CommandMeta = {
 			type: "boolean",
 			target: "verbose",
 		},
+		{
+			name: "dry-run",
+			description: "Print the SCP command without executing it",
+			type: "boolean",
+			target: "dryRun",
+		},
 	],
 	examples: [
 		{
@@ -85,6 +91,10 @@ export const cpCommandMeta: CommandMeta = {
 			name: "Copy with custom SSH key",
 			value: "phala cp -i ~/.ssh/custom_key app_123:/root/file.txt ./file.txt",
 		},
+		{
+			name: "Print the SCP command without executing",
+			value: "phala cp ./local.txt app_123:/root/remote.txt --dry-run",
+		},
 	],
 };
 
@@ -96,6 +106,7 @@ export const cpCommandSchema = z.object({
 	gatewayDomain: z.string().optional(),
 	recursive: z.boolean().default(false),
 	verbose: z.boolean().default(false),
+	dryRun: z.boolean().default(false),
 });
 
 export type CpCommandInput = z.infer<typeof cpCommandSchema>;

--- a/cli/src/commands/cp/index.ts
+++ b/cli/src/commands/cp/index.ts
@@ -14,6 +14,7 @@ import {
 	getSshKeyFile,
 	parseGatewayDomain,
 	selectPort,
+	shellEscape,
 } from "@/src/utils/ssh-utils";
 import { cpCommandMeta, cpCommandSchema, type CpCommandInput } from "./command";
 
@@ -160,6 +161,13 @@ async function runCpCommand(
 			: destination.path;
 
 		scpArgs.push(scpSource, scpDestination);
+
+		// Dry run: print the command and exit
+		if (input.dryRun) {
+			const escapedArgs = scpArgs.map((arg) => shellEscape(arg));
+			context.stdout.write(`scp ${escapedArgs.join(" ")}\n`);
+			return 0;
+		}
 
 		const direction = source.isRemote ? "download" : "upload";
 		const localPath = source.isRemote ? destination.path : source.path;

--- a/cli/src/commands/ssh/command.ts
+++ b/cli/src/commands/ssh/command.ts
@@ -50,6 +50,12 @@ export const sshCommandMeta: CommandMeta = {
 			type: "boolean",
 			target: "verbose",
 		},
+		{
+			name: "dry-run",
+			description: "Print the SSH command without executing it",
+			type: "boolean",
+			target: "dryRun",
+		},
 	],
 	examples: [
 		{
@@ -72,6 +78,10 @@ export const sshCommandMeta: CommandMeta = {
 			name: "Connect with verbose output for debugging",
 			value: "phala ssh app_123 -v",
 		},
+		{
+			name: "Print the SSH command without executing",
+			value: "phala ssh app_123 --dry-run",
+		},
 	],
 };
 
@@ -82,6 +92,7 @@ export const sshCommandSchema = z.object({
 	gatewayDomain: z.string().optional(),
 	timeout: z.string().default("30"),
 	verbose: z.boolean().default(false),
+	dryRun: z.boolean().default(false),
 });
 
 export type SshCommandInput = z.infer<typeof sshCommandSchema>;

--- a/cli/src/commands/ssh/index.ts
+++ b/cli/src/commands/ssh/index.ts
@@ -13,6 +13,7 @@ import {
 	getSshKeyFile,
 	parseGatewayDomain,
 	selectPort,
+	shellEscape,
 } from "@/src/utils/ssh-utils";
 import {
 	sshCommandMeta,
@@ -107,6 +108,13 @@ async function runSshCommand(
 		}
 
 		sshArgs.push(`root@${hostname}`);
+
+		// Dry run: print the command and exit
+		if (input.dryRun) {
+			const escapedArgs = sshArgs.map((arg) => shellEscape(arg));
+			context.stdout.write(`ssh ${escapedArgs.join(" ")}\n`);
+			return 0;
+		}
 
 		// Spawn SSH process
 		const ssh = spawn("ssh", sshArgs, { stdio: "inherit" });

--- a/cli/src/utils/ssh-utils.ts
+++ b/cli/src/utils/ssh-utils.ts
@@ -138,6 +138,20 @@ export function selectPort(
 }
 
 /**
+ * Escape a string for safe use in shell commands.
+ * Uses single quotes and escapes any embedded single quotes.
+ */
+export function shellEscape(arg: string): string {
+	// If the arg contains no special characters, return as-is
+	if (/^[a-zA-Z0-9_./:@=-]+$/.test(arg)) {
+		return arg;
+	}
+	// Escape single quotes by ending the quoted string, adding escaped quote, and resuming
+	// e.g., "it's" becomes 'it'\''s'
+	return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+/**
  * Build common SSH options for ssh/scp commands
  */
 export function buildSshOptions(verbose: boolean, timeout: string): string[] {


### PR DESCRIPTION
## Summary
- Add `--dry-run` option to `phala ssh` command
- Add `--dry-run` option to `phala cp` command
- Prints the full SSH/SCP command without executing it

## Test plan
- [x] `phala ssh <cvm-id> -g example.com --dry-run` prints the SSH command
- [x] `phala cp ./file.txt <cvm-id>:/path --dry-run` prints the SCP command

🤖 Generated with [Claude Code](https://claude.com/claude-code)