### PR TITLE
feat(cli): add stability classification to commands

### DIFF
--- a/cli/src/commands/auth/command.ts
+++ b/cli/src/commands/auth/command.ts
@@ -5,5 +5,6 @@ export const authGroup: CommandGroup = {
 	meta: {
 		name: "auth",
 		description: "Authenticate with Phala Cloud",
+		stability: "deprecated",
 	},
 };

--- a/cli/src/commands/auth/login/command.ts
+++ b/cli/src/commands/auth/login/command.ts
@@ -3,8 +3,8 @@ import type { CommandMeta } from "@/src/core/types";
 
 export const loginCommandMeta: CommandMeta = {
 	name: "login",
-	description:
-		"[DEPRECATED] Authenticate with Phala Cloud (use 'phala login' instead)",
+	description: "Authenticate with Phala Cloud (use 'phala login' instead)",
+	stability: "deprecated",
 	arguments: [
 		{
 			name: "api-key",

--- a/cli/src/commands/auth/logout/command.ts
+++ b/cli/src/commands/auth/logout/command.ts
@@ -3,8 +3,8 @@ import type { CommandMeta } from "@/src/core/types";
 
 export const logoutCommandMeta: CommandMeta = {
 	name: "logout",
-	description:
-		"[DEPRECATED] Remove the stored API key (use 'phala logout' instead)",
+	description: "Remove the stored API key (use 'phala logout' instead)",
+	stability: "deprecated",
 };
 
 export const logoutCommandSchema = z.object({});

--- a/cli/src/commands/auth/status/command.ts
+++ b/cli/src/commands/auth/status/command.ts
@@ -8,8 +8,8 @@ import {
 
 export const authStatusCommandMeta: CommandMeta = {
 	name: "status",
-	description:
-		"[DEPRECATED] Check authentication status (use 'phala status' instead)",
+	description: "Check authentication status (use 'phala status' instead)",
+	stability: "deprecated",
 	options: [...commonAuthOptions, jsonOption, debugOption],
 };
 

--- a/cli/src/commands/completion/index.ts
+++ b/cli/src/commands/completion/index.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineCommand } from "@/src/core/define-command";
-import type { CommandContext } from "@/src/core/types";
+import type { CommandContext, CommandMeta } from "@/src/core/types";
 import {
 	getCompletions,
 	generateCompletionScript,
@@ -26,10 +26,10 @@ function getCliVersion(): string {
 }
 
 // Hidden command for shell completion
-const completeCommandMeta = {
+const completeCommandMeta: CommandMeta = {
 	name: "__complete",
 	description: "Internal command for shell completion",
-	hidden: true,
+	stability: "stable",
 	arguments: [
 		{
 			name: "line",
@@ -69,18 +69,19 @@ export const completeCommand = defineCommand({
 });
 
 // User-facing completion setup command
-const completionCommandMeta = {
+const completionCommandMeta: CommandMeta = {
 	name: "completion",
 	description: "Generate shell completion scripts",
+	stability: "stable",
 	options: [
 		{
 			name: "shell",
-			type: "string" as const,
+			type: "string",
 			description: "Shell type (bash, zsh, fish)",
 		},
 		{
 			name: "fig",
-			type: "boolean" as const,
+			type: "boolean",
 			description: "Generate Fig/Amazon Q completion spec",
 		},
 	],

--- a/cli/src/commands/config/command.ts
+++ b/cli/src/commands/config/command.ts
@@ -5,5 +5,6 @@ export const configGroup: CommandGroup = {
 	meta: {
 		name: "config",
 		description: "Manage your local configuration",
+		stability: "stable",
 	},
 };

--- a/cli/src/commands/config/get/command.ts
+++ b/cli/src/commands/config/get/command.ts
@@ -4,6 +4,7 @@ import type { CommandMeta } from "@/src/core/types";
 export const configGetCommandMeta: CommandMeta = {
 	name: "get",
 	description: "Get a configuration value",
+	stability: "stable",
 	arguments: [
 		{
 			name: "key",

--- a/cli/src/commands/config/list/command.ts
+++ b/cli/src/commands/config/list/command.ts
@@ -5,6 +5,7 @@ export const configListCommandMeta: CommandMeta = {
 	name: "list",
 	aliases: ["ls"],
 	description: "List all configuration values",
+	stability: "stable",
 	options: [
 		{
 			name: "json",

--- a/cli/src/commands/config/set/command.ts
+++ b/cli/src/commands/config/set/command.ts
@@ -4,6 +4,7 @@ import type { CommandMeta } from "@/src/core/types";
 export const configSetCommandMeta: CommandMeta = {
 	name: "set",
 	description: "Set a configuration value",
+	stability: "stable",
 	arguments: [
 		{
 			name: "key",

--- a/cli/src/commands/cp/command.ts
+++ b/cli/src/commands/cp/command.ts
@@ -4,6 +4,7 @@ import type { CommandMeta } from "@/src/core/types";
 export const cpCommandMeta: CommandMeta = {
 	name: "cp",
 	description: "Copy files to/from a CVM via SCP",
+	stability: "unstable",
 	arguments: [
 		{
 			name: "source",

--- a/cli/src/commands/cvms/attestation/command.ts
+++ b/cli/src/commands/cvms/attestation/command.ts
@@ -6,6 +6,7 @@ import { jsonOption } from "@/src/commands/status/command";
 export const cvmsAttestationCommandMeta: CommandMeta = {
 	name: "attestation",
 	description: "Get attestation information for a CVM",
+	stability: "unstable",
 	arguments: [cvmIdArgument],
 	options: [jsonOption, interactiveOption],
 	examples: [

--- a/cli/src/commands/cvms/command.ts
+++ b/cli/src/commands/cvms/command.ts
@@ -5,5 +5,6 @@ export const cvmsGroup: CommandGroup = {
 	meta: {
 		name: "cvms",
 		description: "Manage Phala Confidential Virtual Machines (CVMs)",
+		stability: "unstable",
 	},
 };

--- a/cli/src/commands/cvms/create/command.ts
+++ b/cli/src/commands/cvms/create/command.ts
@@ -8,7 +8,8 @@ import {
 
 export const cvmsCreateCommandMeta: CommandMeta = {
 	name: "create",
-	description: '[DEPRECATED] Create a new CVM (use "phala deploy" instead)',
+	description: 'Create a new CVM (use "phala deploy" instead)',
+	stability: "deprecated",
 	options: [
 		{
 			name: "name",

--- a/cli/src/commands/cvms/delete/command.ts
+++ b/cli/src/commands/cvms/delete/command.ts
@@ -5,6 +5,7 @@ import { cvmIdArgument, interactiveOption } from "@/src/core/common-flags";
 export const cvmsDeleteCommandMeta: CommandMeta = {
 	name: "delete",
 	description: "Delete a CVM",
+	stability: "unstable",
 	arguments: [cvmIdArgument],
 	options: [
 		interactiveOption,

--- a/cli/src/commands/cvms/get/command.ts
+++ b/cli/src/commands/cvms/get/command.ts
@@ -6,6 +6,7 @@ import { jsonOption } from "@/src/commands/status/command";
 export const cvmsGetCommandMeta: CommandMeta = {
 	name: "get",
 	description: "Get details of a CVM",
+	stability: "unstable",
 	arguments: [cvmIdArgument],
 	options: [jsonOption, interactiveOption],
 	examples: [

--- a/cli/src/commands/cvms/list-node/command.ts
+++ b/cli/src/commands/cvms/list-node/command.ts
@@ -4,6 +4,7 @@ import type { CommandMeta } from "@/src/core/types";
 export const cvmsListNodesCommandMeta: CommandMeta = {
 	name: "list-nodes",
 	description: "List all available worker nodes.",
+	stability: "unstable",
 };
 
 export const cvmsListNodesCommandSchema = z.object({});

--- a/cli/src/commands/cvms/list/command.ts
+++ b/cli/src/commands/cvms/list/command.ts
@@ -6,6 +6,7 @@ export const cvmsListCommandMeta: CommandMeta = {
 	name: "list",
 	aliases: ["ls"],
 	description: "List all CVMs",
+	stability: "unstable",
 	options: [jsonOption],
 	examples: [
 		{

--- a/cli/src/commands/cvms/replicate/command.ts
+++ b/cli/src/commands/cvms/replicate/command.ts
@@ -4,6 +4,7 @@ import type { CommandMeta } from "@/src/core/types";
 export const cvmsReplicateCommandMeta: CommandMeta = {
 	name: "replicate",
 	description: "Create a replica of an existing CVM",
+	stability: "unstable",
 	arguments: [
 		{
 			name: "cvm-id",

--- a/cli/src/commands/cvms/resize/command.ts
+++ b/cli/src/commands/cvms/resize/command.ts
@@ -5,6 +5,7 @@ import { cvmIdArgument, interactiveOption } from "@/src/core/common-flags";
 export const cvmsResizeCommandMeta: CommandMeta = {
 	name: "resize",
 	description: "Resize resources for a CVM",
+	stability: "unstable",
 	arguments: [cvmIdArgument],
 	options: [
 		interactiveOption,

--- a/cli/src/commands/cvms/restart/command.ts
+++ b/cli/src/commands/cvms/restart/command.ts
@@ -5,6 +5,7 @@ import { cvmIdArgument, interactiveOption } from "@/src/core/common-flags";
 export const cvmsRestartCommandMeta: CommandMeta = {
 	name: "restart",
 	description: "Restart a CVM",
+	stability: "stable",
 	arguments: [cvmIdArgument],
 	options: [interactiveOption],
 	examples: [

--- a/cli/src/commands/cvms/start/command.ts
+++ b/cli/src/commands/cvms/start/command.ts
@@ -5,6 +5,7 @@ import { cvmIdArgument, interactiveOption } from "@/src/core/common-flags";
 export const cvmsStartCommandMeta: CommandMeta = {
 	name: "start",
 	description: "Start a stopped CVM",
+	stability: "stable",
 	arguments: [cvmIdArgument],
 	options: [interactiveOption],
 	examples: [

--- a/cli/src/commands/cvms/stop/command.ts
+++ b/cli/src/commands/cvms/stop/command.ts
@@ -5,6 +5,7 @@ import { cvmIdArgument, interactiveOption } from "@/src/core/common-flags";
 export const cvmsStopCommandMeta: CommandMeta = {
 	name: "stop",
 	description: "Stop a running CVM",
+	stability: "stable",
 	arguments: [cvmIdArgument],
 	options: [interactiveOption],
 	examples: [

--- a/cli/src/commands/cvms/upgrade/command.ts
+++ b/cli/src/commands/cvms/upgrade/command.ts
@@ -4,8 +4,8 @@ import { cvmIdArgument, interactiveOption } from "@/src/core/common-flags";
 
 export const cvmsUpgradeCommandMeta: CommandMeta = {
 	name: "upgrade",
-	description:
-		'[DEPRECATED] Upgrade a CVM to a new version (use "phala deploy" instead)',
+	description: 'Upgrade a CVM to a new version (use "phala deploy" instead)',
+	stability: "deprecated",
 	arguments: [cvmIdArgument],
 	options: [
 		interactiveOption,

--- a/cli/src/commands/deploy/command.ts
+++ b/cli/src/commands/deploy/command.ts
@@ -14,6 +14,7 @@ import {
 export const deployCommandMeta: CommandMeta = {
 	name: "deploy",
 	description: "Create a new CVM with on-chain KMS in one step.",
+	stability: "stable",
 	arguments: [],
 	options: [
 		...commonAuthOptions,

--- a/cli/src/commands/docker/build/command.ts
+++ b/cli/src/commands/docker/build/command.ts
@@ -4,6 +4,7 @@ import type { CommandMeta } from "@/src/core/types";
 export const dockerBuildCommandMeta: CommandMeta = {
 	name: "build",
 	description: "Build a Docker image",
+	stability: "unstable",
 	options: [
 		{
 			name: "image",

--- a/cli/src/commands/docker/command.ts
+++ b/cli/src/commands/docker/command.ts
@@ -5,5 +5,6 @@ export const dockerGroup: CommandGroup = {
 	meta: {
 		name: "docker",
 		description: "Login to Docker Hub and manage Docker images",
+		stability: "unstable",
 	},
 };

--- a/cli/src/commands/docker/generate/command.ts
+++ b/cli/src/commands/docker/generate/command.ts
@@ -4,6 +4,7 @@ import type { CommandMeta } from "@/src/core/types";
 export const dockerGenerateCommandMeta: CommandMeta = {
 	name: "generate",
 	description: "Generate a Docker Compose file",
+	stability: "unstable",
 	options: [
 		{
 			name: "image",

--- a/cli/src/commands/docker/index.ts
+++ b/cli/src/commands/docker/index.ts
@@ -11,6 +11,7 @@ import { dockerRunCommand } from "./run/index";
 const dockerRootMeta: CommandMeta = {
 	name: "docker",
 	description: "Login to Docker Hub and manage Docker images",
+	stability: "unstable",
 };
 
 const dockerRootSchema = z.object({});

--- a/cli/src/commands/docker/login/command.ts
+++ b/cli/src/commands/docker/login/command.ts
@@ -4,6 +4,7 @@ import type { CommandMeta } from "@/src/core/types";
 export const dockerLoginCommandMeta: CommandMeta = {
 	name: "login",
 	description: "Login to Docker Hub",
+	stability: "unstable",
 	options: [
 		{
 			name: "username",

--- a/cli/src/commands/docker/push/command.ts
+++ b/cli/src/commands/docker/push/command.ts
@@ -4,6 +4,7 @@ import type { CommandMeta } from "@/src/core/types";
 export const dockerPushCommandMeta: CommandMeta = {
 	name: "push",
 	description: "Push a Docker image to Docker Hub",
+	stability: "unstable",
 	options: [
 		{
 			name: "image",

--- a/cli/src/commands/docker/run/command.ts
+++ b/cli/src/commands/docker/run/command.ts
@@ -4,6 +4,7 @@ import type { CommandMeta } from "@/src/core/types";
 export const dockerRunCommandMeta: CommandMeta = {
 	name: "run",
 	description: "Run a Docker Compose setup",
+	stability: "unstable",
 	options: [
 		{
 			name: "compose",

--- a/cli/src/commands/login/command.ts
+++ b/cli/src/commands/login/command.ts
@@ -4,6 +4,7 @@ import type { CommandMeta } from "@/src/core/types";
 export const loginCommandMeta: CommandMeta = {
 	name: "login",
 	description: "Authenticate with Phala Cloud",
+	stability: "stable",
 	arguments: [
 		{
 			name: "api-key",

--- a/cli/src/commands/logout/command.ts
+++ b/cli/src/commands/logout/command.ts
@@ -4,6 +4,7 @@ import type { CommandMeta } from "@/src/core/types";
 export const logoutCommandMeta: CommandMeta = {
 	name: "logout",
 	description: "Remove the stored API key",
+	stability: "stable",
 };
 
 export const logoutCommandSchema = z.object({});

--- a/cli/src/commands/nodes/command.ts
+++ b/cli/src/commands/nodes/command.ts
@@ -5,5 +5,6 @@ export const nodesGroup: CommandGroup = {
 	meta: {
 		name: "nodes",
 		description: "List and manage TEE nodes",
+		stability: "unstable",
 	},
 };

--- a/cli/src/commands/nodes/list/command.ts
+++ b/cli/src/commands/nodes/list/command.ts
@@ -5,6 +5,7 @@ export const nodesListCommandMeta: CommandMeta = {
 	name: "list",
 	aliases: ["ls"],
 	description: "List all available worker nodes",
+	stability: "unstable",
 	options: [
 		{
 			name: "json",

--- a/cli/src/commands/nodes/list/index.ts
+++ b/cli/src/commands/nodes/list/index.ts
@@ -90,6 +90,7 @@ async function runNodesListCommand(
 const nodesRootCommandMeta: CommandMeta = {
 	name: "nodes",
 	description: "List and manage TEE nodes",
+	stability: "unstable",
 };
 
 export const nodesListCommand = defineCommand({

--- a/cli/src/commands/simulator/command.ts
+++ b/cli/src/commands/simulator/command.ts
@@ -5,5 +5,6 @@ export const simulatorGroup: CommandGroup = {
 	meta: {
 		name: "simulator",
 		description: "TEE simulator commands",
+		stability: "unstable",
 	},
 };

--- a/cli/src/commands/simulator/index.ts
+++ b/cli/src/commands/simulator/index.ts
@@ -13,6 +13,7 @@ import { simulatorStopCommand } from "./stop";
 const simulatorRootMeta: CommandMeta = {
 	name: "simulator",
 	description: "TEE simulator commands",
+	stability: "unstable",
 };
 
 const simulatorStatusSchema = z.object({});

--- a/cli/src/commands/simulator/start/command.ts
+++ b/cli/src/commands/simulator/start/command.ts
@@ -4,6 +4,7 @@ import type { CommandMeta } from "@/src/core/types";
 export const simulatorStartCommandMeta: CommandMeta = {
 	name: "start",
 	description: "Start the TEE simulator",
+	stability: "unstable",
 	options: [
 		{
 			name: "port",

--- a/cli/src/commands/simulator/stop/command.ts
+++ b/cli/src/commands/simulator/stop/command.ts
@@ -4,6 +4,7 @@ import type { CommandMeta } from "@/src/core/types";
 export const simulatorStopCommandMeta: CommandMeta = {
 	name: "stop",
 	description: "Stop the TEE simulator",
+	stability: "unstable",
 };
 
 export const simulatorStopCommandSchema = z.object({});

--- a/cli/src/commands/ssh/command.ts
+++ b/cli/src/commands/ssh/command.ts
@@ -4,6 +4,7 @@ import type { CommandMeta } from "@/src/core/types";
 export const sshCommandMeta: CommandMeta = {
 	name: "ssh",
 	description: "Connect to a CVM via SSH",
+	stability: "unstable",
 	arguments: [
 		{
 			name: "cvm-id",

--- a/cli/src/commands/status/command.ts
+++ b/cli/src/commands/status/command.ts
@@ -22,6 +22,7 @@ export const debugOption = {
 export const statusCommandMeta: CommandMeta = {
 	name: "status",
 	description: "Check Phala Cloud status and authentication",
+	stability: "stable",
 	options: [...commonAuthOptions, jsonOption, debugOption],
 	examples: [
 		{

--- a/cli/src/core/dispatcher.ts
+++ b/cli/src/core/dispatcher.ts
@@ -112,6 +112,10 @@ export async function dispatchCommand(
 			return 0;
 		}
 
+		if (definition.meta.stability === "deprecated") {
+			stderr.write(chalk.yellow("Warning: This command is deprecated and may be removed in a future version.\n"));
+		}
+
 		const schemaInput = buildCommandSchemaInput(
 			definition.meta,
 			parsedArguments,

--- a/cli/src/core/help.ts
+++ b/cli/src/core/help.ts
@@ -1,6 +1,12 @@
 import { globalCommandOptions } from "./common-flags";
-import type { CommandDefinition, CommandOption, CommandPath } from "./types";
+import type { CommandDefinition, CommandOption, CommandPath, CommandStability } from "./types";
 import type { CommandRegistry } from "./registry";
+
+function formatStabilityIndicator(stability: CommandStability): string {
+	if (stability === "unstable") return " [UNSTABLE]";
+	if (stability === "deprecated") return " [DEPRECATED]";
+	return "";
+}
 
 interface GlobalHelpOptions {
 	readonly registry: CommandRegistry;
@@ -28,10 +34,12 @@ export function formatGlobalHelp(options: GlobalHelpOptions): string {
 	lines.push("Available commands:");
 
 	for (const node of registry.getChildren()) {
-		const description =
-			node.command?.meta.description ?? node.group?.meta.description ?? "";
+		const meta = node.command?.meta ?? node.group?.meta;
+		const description = meta?.description ?? "";
+		const stability = meta?.stability;
+		const indicator = stability ? formatStabilityIndicator(stability) : "";
 		const name = node.name ?? "";
-		lines.push(`  ${name.padEnd(18)}${description}`.trimEnd());
+		lines.push(`  ${name.padEnd(18)}${description}${indicator}`.trimEnd());
 	}
 
 	lines.push("");
@@ -69,10 +77,12 @@ export function formatGroupHelp(options: GroupHelpOptions): string {
 	if (children.length > 0) {
 		lines.push("Available commands:");
 		for (const child of children) {
-			const description =
-				child.command?.meta.description ?? child.group?.meta.description ?? "";
+			const meta = child.command?.meta ?? child.group?.meta;
+			const description = meta?.description ?? "";
+			const stability = meta?.stability;
+			const indicator = stability ? formatStabilityIndicator(stability) : "";
 			const name = child.name ?? "";
-			lines.push(`  ${name.padEnd(18)}${description}`.trimEnd());
+			lines.push(`  ${name.padEnd(18)}${description}${indicator}`.trimEnd());
 		}
 		lines.push("");
 	}
@@ -90,7 +100,8 @@ export function formatGroupHelp(options: GroupHelpOptions): string {
 export function formatCommandHelp(options: CommandHelpOptions): string {
 	const { executableName, definition, registry } = options;
 	const usage = buildUsageLine({ executableName, definition });
-	const lines: string[] = [usage, "", definition.meta.description];
+	const indicator = formatStabilityIndicator(definition.meta.stability);
+	const lines: string[] = [usage, "", `${definition.meta.description}${indicator}`];
 
 	const args = definition.meta.arguments ?? [];
 	if (args.length > 0) {
@@ -135,10 +146,12 @@ export function formatCommandHelp(options: CommandHelpOptions): string {
 		lines.push("");
 		lines.push("Subcommands:");
 		for (const child of children) {
-			const description =
-				child.command?.meta.description ?? child.group?.meta.description ?? "";
+			const meta = child.command?.meta ?? child.group?.meta;
+			const description = meta?.description ?? "";
+			const stability = meta?.stability;
+			const childIndicator = stability ? formatStabilityIndicator(stability) : "";
 			const name = child.name ?? "";
-			lines.push(`  ${name.padEnd(18)}${description}`.trimEnd());
+			lines.push(`  ${name.padEnd(18)}${description}${childIndicator}`.trimEnd());
 		}
 	}
 

--- a/cli/src/core/types.ts
+++ b/cli/src/core/types.ts
@@ -4,6 +4,8 @@ import type { RuntimeProjectConfig } from "@/src/utils/project-config";
 
 export type CommandPath = readonly string[];
 
+export type CommandStability = "stable" | "unstable" | "deprecated";
+
 export interface CommandArgument {
 	readonly name: string;
 	readonly description?: string;
@@ -49,6 +51,7 @@ export interface CommandExample {
 export interface CommandMeta {
 	readonly name: string;
 	readonly description: string;
+	readonly stability: CommandStability;
 	readonly aliases?: readonly string[];
 	readonly arguments?: readonly CommandArgument[];
 	readonly options?: readonly CommandOption[];


### PR DESCRIPTION
## Summary
- Add `CommandStability` type (`stable` | `unstable` | `deprecated`) to CLI commands
- Display `[UNSTABLE]` and `[DEPRECATED]` indicators in help output
- Show runtime warning when executing deprecated commands

Closes #118

## Sample Output

### `phala --help`
```
Usage: phala <command> [options]

Available commands:
  status            Check Phala Cloud status and authentication
  deploy            Create a new CVM with on-chain KMS in one step.
  login             Authenticate with Phala Cloud
  logout            Remove the stored API key
  completion        Generate shell completion scripts
  ssh               Connect to a CVM via SSH [UNSTABLE]
  cp                Copy files to/from a CVM via SCP [UNSTABLE]
  auth              Authenticate with Phala Cloud [DEPRECATED]
  config            Manage your local configuration
  cvms              Manage Phala Confidential Virtual Machines (CVMs) [UNSTABLE]
  docker            Login to Docker Hub and manage Docker images [UNSTABLE]
  nodes             List and manage TEE nodes [UNSTABLE]
  simulator         TEE simulator commands [UNSTABLE]

Global options:
  -h, --help              Show help information for the current command
  -v, --version           Show CLI version
```

### `phala cvms --help`
```
Usage: phala cvms <command> [options]

Manage Phala Confidential Virtual Machines (CVMs)

Available commands:
  attestation       Get attestation information for a CVM [UNSTABLE]
  create            Create a new CVM (use "phala deploy" instead) [DEPRECATED]
  delete            Delete a CVM [UNSTABLE]
  get               Get details of a CVM [UNSTABLE]
  list              List all CVMs [UNSTABLE]
  list-nodes        List all available worker nodes. [UNSTABLE]
  replicate         Create a replica of an existing CVM [UNSTABLE]
  resize            Resize resources for a CVM [UNSTABLE]
  restart           Restart a CVM
  start             Start a stopped CVM
  stop              Stop a running CVM
  upgrade           Upgrade a CVM to a new version (use "phala deploy" instead) [DEPRECATED]

Global options:
  -h, --help              Show help information for the current command
  -v, --version           Show CLI version
```

## Test plan
- [x] Type check passes
- [x] Build succeeds
- [x] Unit tests pass
- [x] Help output displays stability indicators correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)