### PR TITLE
feat(cli): warn when ssh/cp target CVM is not a dev image

### DIFF
--- a/cli/src/commands/cp/index.ts
+++ b/cli/src/commands/cp/index.ts
@@ -12,6 +12,7 @@ import {
 	buildSshOptions,
 	fetchCvmInfo,
 	getSshKeyFile,
+	isDevImage,
 	parseGatewayDomain,
 	selectPort,
 	shellEscape,
@@ -100,6 +101,13 @@ async function runCpCommand(
 				const cvmInfo = await fetchCvmInfo(client, cvmId);
 				instanceId = cvmInfo.appId;
 				gatewayDomain = cvmInfo.gatewayDomain;
+
+				// Warn if not a dev image
+				if (!isDevImage(cvmInfo.baseImage)) {
+					logger.warn(
+						"This CVM is not using a dev image. SCP access may not be available.",
+					);
+				}
 			} catch (error) {
 				if (error instanceof NoGatewayError) {
 					logger.error(error.message);

--- a/cli/src/commands/ssh/index.ts
+++ b/cli/src/commands/ssh/index.ts
@@ -11,6 +11,7 @@ import {
 	buildSshOptions,
 	fetchCvmInfo,
 	getSshKeyFile,
+	isDevImage,
 	parseGatewayDomain,
 	selectPort,
 	shellEscape,
@@ -59,6 +60,13 @@ async function runSshCommand(
 				const cvmInfo = await fetchCvmInfo(client, cvmId);
 				instanceId = cvmInfo.appId;
 				gatewayDomain = cvmInfo.gatewayDomain;
+
+				// Warn if not a dev image
+				if (!isDevImage(cvmInfo.baseImage)) {
+					logger.warn(
+						"This CVM is not using a dev image. SSH access may not be available.",
+					);
+				}
 			} catch (error) {
 				if (error instanceof NoGatewayError) {
 					logger.error(error.message);

--- a/cli/src/utils/ssh-utils.ts
+++ b/cli/src/utils/ssh-utils.ts
@@ -92,6 +92,16 @@ export function getSshKeyFile(specifiedKey?: string): string | undefined {
 }
 
 /**
+ * Check if the base image is a dev image (contains "dev" in the name)
+ */
+export function isDevImage(baseImage: string | null | undefined): boolean {
+	if (!baseImage) {
+		return false;
+	}
+	return baseImage.toLowerCase().includes("dev");
+}
+
+/**
  * Fetch CVM info from API and validate it's ready for connection
  * @throws {NoGatewayError} if CVM has no gateway
  * @throws {CvmNotRunningError} if CVM is not running
@@ -111,6 +121,7 @@ export async function fetchCvmInfo(client: Client, cvmId: string) {
 		appId: cvm.app_id,
 		gatewayDomain: cvm.gateway_domain,
 		status: cvm.status,
+		baseImage: cvm.base_image,
 	};
 }
 

--- a/cli/test/e2e-full/full-lifecycle.test.ts
+++ b/cli/test/e2e-full/full-lifecycle.test.ts
@@ -500,6 +500,18 @@ describe.skipIf(skipTests)("Phala Cloud CLI - Full Lifecycle E2E Test", () => {
 			expect(versionData.env).toBe(initialNonce);
 			expect(versionData.newEnv).toBe("");  // Not set in initial deployment
 
+			// Test SSH and CP dry-run
+			for (const [cmd, binary] of [
+				[`ssh ${appId} --dry-run`, "ssh"],
+				[`cp ${appId}:/tmp/test.txt ./local.txt --dry-run`, "scp"],
+			] as const) {
+				const { stdout } = await runCliCommand(logger, cmd, `Testing ${binary} dry-run`);
+				expect(stdout).toContain(binary);
+				expect(stdout).toContain("root@");
+				expect(stdout).toContain("ProxyCommand");
+				logger.success(`${binary} dry-run verified`);
+			}
+
 			logger.success("Phase 4 completed: CVM is fully operational");
 		},
 		{ timeout: 600000 }, // 10 minutes


### PR DESCRIPTION
## Summary
- Add dev image check to `ssh` and `cp` commands
- Warn users when target CVM is not using a dev image (SSH may not be available)
- Add E2E test for SSH/CP dry-run

## Test plan
- [x] Type check passes
- [x] Unit tests pass
- [x] E2E dry-run test added

🤖 Generated with [Claude Code](https://claude.com/claude-code)