### PR TITLE
fix(release): handle main branch protection and improve release UX

### DIFF
--- a/.github/workflows/release-command.yml
+++ b/.github/workflows/release-command.yml
@@ -496,9 +496,39 @@ jobs:
         run: git tag "$TAG_NAME"
 
       - name: Push changes
+        id: push
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git push origin HEAD:${SOURCE_REF}
-          git push origin "$TAG_NAME"
+          if [ "$SOURCE_REF" = "main" ]; then
+            # Main branch has protection rules - create a release branch and PR
+            RELEASE_BRANCH="release/${PACKAGE}-v${NEW_VERSION}"
+            git checkout -b "$RELEASE_BRANCH"
+            git push origin "$RELEASE_BRANCH"
+            git push origin "$TAG_NAME"
+
+            # Create PR to merge release branch back to main
+            PR_URL=$(gh pr create \
+              --base main \
+              --head "$RELEASE_BRANCH" \
+              --title "chore(${PACKAGE}): release v${NEW_VERSION}" \
+              --body "Automated release PR for ${PACKAGE} v${NEW_VERSION}
+
+This PR was created by the release workflow to update:
+- \`${PACKAGE}/package.json\` version to ${NEW_VERSION}
+- \`${PACKAGE}/CHANGELOG.md\` with release notes
+
+The package has already been published to npm.")
+
+            echo "release_pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+            echo "used_release_branch=true" >> "$GITHUB_OUTPUT"
+            echo "release_branch=$RELEASE_BRANCH" >> "$GITHUB_OUTPUT"
+          else
+            # Feature branch - push directly
+            git push origin HEAD:${SOURCE_REF}
+            git push origin "$TAG_NAME"
+            echo "used_release_branch=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create GitHub release
         id: release
@@ -526,6 +556,8 @@ jobs:
             const fileList = `${{ steps.pack_info.outputs.file_list }}`.split('\n').slice(0, 15).join('\n');
             const totalFiles = Number('${{ steps.pack_info.outputs.total_files }}');
             const hasMore = totalFiles > 15;
+            const usedReleaseBranch = '${{ steps.push.outputs.used_release_branch }}' === 'true';
+            const releasePrUrl = '${{ steps.push.outputs.release_pr_url }}';
 
             const body = [
               `🎉 Release completed: \`${process.env.PACKAGE}\` v${process.env.NEW_VERSION}`,
@@ -534,6 +566,14 @@ jobs:
               `- npm: [${{ steps.pkgmeta.outputs.npm_name }}](${{ steps.pkgmeta.outputs.npm_url }})`,
               `- GitHub Release: [link](${{ steps.release.outputs.html_url }})`,
               `- Workflow logs: ${runUrl}`,
+            ];
+
+            if (usedReleaseBranch && releasePrUrl) {
+              body.push('');
+              body.push(`> ⚠️ **Action Required**: Please merge the [release PR](${releasePrUrl}) to update \`main\` branch with version changes.`);
+            }
+
+            body.push(
               '',
               '### 📦 Package Info',
               `- Package size: **${{ steps.pack_info.outputs.package_size }}**`,
@@ -548,13 +588,13 @@ jobs:
               hasMore ? `... and ${totalFiles - 15} more files` : '',
               '```',
               '</details>'
-            ].join('\n');
+            );
 
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: Number(process.env.ISSUE_NUMBER),
-              body
+              body: body.join('\n')
             });
 
       - name: Comment failure

--- a/cli/tsup.config.ts
+++ b/cli/tsup.config.ts
@@ -7,6 +7,13 @@ function getGitInfo(): string {
 			encoding: "utf-8",
 			stdio: ["pipe", "pipe", "pipe"],
 		}).trim();
+
+		// In CI, workspace dependency resolution modifies package.json after commit,
+		// making the repo appear "dirty" even though it's a clean release build
+		if (process.env.CI) {
+			return `+${hash}`;
+		}
+
 		const dirty = execSync("git status --porcelain", {
 			encoding: "utf-8",
 			stdio: ["pipe", "pipe", "pipe"],

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -208,8 +208,17 @@ async function main() {
       console.log(`✓ Using version: ${newVersion}`);
     } else {
       // Cannot auto-increment stable releases
-      console.error('❌ Error: Cannot auto-increment stable release versions.');
-      console.error('   Please manually increment the version in package.json or use a prerelease tag.');
+      console.error('❌ Error: Version conflict detected.');
+      console.error(`   Version ${newVersion} already exists on npm for ${npmPackageName}.`);
+      console.error('');
+      console.error('   This can happen when:');
+      console.error('   - A release was made from another branch with the same version');
+      console.error('   - The local package.json version is out of sync with npm');
+      console.error('');
+      console.error('   Possible solutions:');
+      console.error('   1. Use a higher release type (e.g., minor instead of patch)');
+      console.error('   2. Use a prerelease tag (e.g., !release cli patch beta)');
+      console.error('   3. Manually update the version in package.json before releasing');
       process.exit(1);
     }
   } else {


### PR DESCRIPTION
- Create PR instead of direct push when releasing from main branch (branch protection rules require changes through PRs)
- Skip dirty check in CI builds to avoid false "-dirty" suffix (workspace dependency resolution modifies package.json after commit)
- Improve version conflict error message with context and solutions