### PR TITLE
fix(workflow): fix YAML syntax error in release-command

### DIFF
--- a/.github/workflows/release-command.yml
+++ b/.github/workflows/release-command.yml
@@ -512,13 +512,7 @@ jobs:
               --base main \
               --head "$RELEASE_BRANCH" \
               --title "chore(${PACKAGE}): release v${NEW_VERSION}" \
-              --body "Automated release PR for ${PACKAGE} v${NEW_VERSION}
-
-This PR was created by the release workflow to update:
-- \`${PACKAGE}/package.json\` version to ${NEW_VERSION}
-- \`${PACKAGE}/CHANGELOG.md\` with release notes
-
-The package has already been published to npm.")
+              --body "Automated release PR for ${PACKAGE} v${NEW_VERSION}. Updates package.json and CHANGELOG.md. The package has already been published to npm.")
 
             echo "release_pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
             echo "used_release_branch=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Fix YAML parsing error on line 521 of release-command.yml.

The multiline string in the `--body` parameter of `gh pr create` was causing YAML parsing issues because lines starting at column 0 within a literal block (`|`) are misinterpreted as YAML keys.

Simplified the body to a single line to avoid the parsing issue.

This fix is required to make the `!release` command work again via issue comments.