### PR TITLE
docs(cli): clarify that deploy command supports both create and update

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -486,7 +486,7 @@ phala cvms get app_123456
 phala deploy [options]
 ```
 
-Create a new CVM with automatic resource matching. This is the recommended command for most users as it simplifies deployment by automatically selecting optimal resources based on availability.
+Deploy a new CVM or update an existing one. Creates a new CVM by default. If `--cvm-id` is provided or a CVM ID is configured in `phala.toml`, updates the existing CVM instead.
 
 **Key Features:**
 - **Auto Resource Matching**: Backend automatically finds the best available node based on your requirements
@@ -517,23 +517,36 @@ Create a new CVM with automatic resource matching. This is the recommended comma
 **Examples:**
 
 ```bash
+# --- New Deployment ---
+
 # Simplest - auto-select everything
 phala deploy
 
 # Specify instance type and region
 phala deploy --instance-type tdx.medium --region us-west
 
-# Manual resource specification
-phala deploy --vcpu 4 --memory 8G --disk-size 100G
+# With environment file
+phala deploy -e .env
 
 # With on-chain KMS
 phala deploy --kms-id ethereum --private-key <key> --rpc-url <url>
 
-# Deploy to specific node (advanced)
-phala deploy --node-id 6
-
 # Interactive mode for guided setup
 phala deploy --interactive
+
+# --- Update Existing CVM ---
+
+# Update by CVM ID (app_id, UUID, or name)
+phala deploy --cvm-id app_abc123
+
+# Update with new compose file and environment variables
+phala deploy --cvm-id my-app --compose ./new-docker-compose.yml -e .env
+
+# Update and wait for completion
+phala deploy --cvm-id app_abc123 --wait
+
+# If phala.toml has cvm_id configured, just run deploy to update
+phala deploy
 ```
 
 **Error Handling:**

--- a/cli/src/commands/deploy/command.ts
+++ b/cli/src/commands/deploy/command.ts
@@ -13,7 +13,8 @@ import {
 
 export const deployCommandMeta: CommandMeta = {
 	name: "deploy",
-	description: "Create a new CVM with on-chain KMS in one step.",
+	description:
+		"Deploy a new CVM or update an existing one. Creates a new CVM by default; updates when --cvm-id is provided or found in phala.toml.",
 	stability: "stable",
 	arguments: [],
 	options: [
@@ -175,8 +176,9 @@ export const deployCommandMeta: CommandMeta = {
 		},
 	],
 	examples: [
+		// --- New Deployment Examples ---
 		{
-			name: "Deploy with auto-selection (simplest)",
+			name: "Deploy new CVM with auto-selection (simplest)",
 			value: "phala deploy",
 		},
 		{
@@ -188,10 +190,6 @@ export const deployCommandMeta: CommandMeta = {
 			value: "phala deploy -e .env",
 		},
 		{
-			name: "Deploy with env file and overrides",
-			value: "phala deploy -e .env -e NODE_ENV=production",
-		},
-		{
 			name: "Deploy with specific instance type",
 			value: "phala deploy --instance-type tdx.medium",
 		},
@@ -200,21 +198,26 @@ export const deployCommandMeta: CommandMeta = {
 			value: "phala deploy --region us-west",
 		},
 		{
-			name: "Deploy with instance type and region",
-			value: "phala deploy --instance-type tdx.small --region eu-central",
-		},
-		{
-			name: "Deploy with manual resource specs (deprecated, use --instance-type)",
-			value: "phala deploy --vcpu 4 --memory 8G --disk-size 100G",
-		},
-		{
 			name: "Deploy with on-chain KMS",
 			value:
 				"phala deploy --kms-id ethereum --private-key <key> --rpc-url <url>",
 		},
+		// --- Update Existing CVM Examples ---
 		{
-			name: "Deploy to specific node (advanced)",
-			value: "phala deploy --node-id 6",
+			name: "Update existing CVM by ID",
+			value: "phala deploy --cvm-id app_abc123",
+		},
+		{
+			name: "Update CVM with new compose file and env",
+			value: "phala deploy --cvm-id my-app --compose ./new-docker-compose.yml -e .env",
+		},
+		{
+			name: "Update CVM and wait for completion",
+			value: "phala deploy --cvm-id app_abc123 --wait",
+		},
+		{
+			name: "Update CVM configured in phala.toml (auto-detected)",
+			value: "phala deploy",
 		},
 	],
 };


### PR DESCRIPTION
## Summary
- Update deploy command description to clarify it can both create new CVMs and update existing ones
- Add examples showing update scenarios with `--cvm-id`
- Update README documentation

Users were confused that `phala deploy` can be used for updating existing CVMs, not just creating new ones.

## Test plan
- [x] Verified `phala deploy --help` shows updated description and examples
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)