### PR TITLE
fix(cli): change deploy command JSON output default to false

### DIFF
--- a/cli/src/commands/deploy/command.ts
+++ b/cli/src/commands/deploy/command.ts
@@ -221,7 +221,7 @@ export const deployCommandMeta: CommandMeta = {
 
 export const deployCommandSchema = z.object({
 	compose: z.string().optional(),
-	json: z.boolean().default(true),
+	json: z.boolean().default(false),
 	debug: z.boolean().default(false),
 	apiKey: z.string().optional(),
 	name: z.string().optional(),


### PR DESCRIPTION
## Summary
- Changed `--json` flag default from `true` to `false` in the deploy command
- Makes deploy command consistent with all other CLI commands that default to human-readable output

## Background
The deploy command was incorrectly returning JSON output by default, while all other commands (cvms list, cvms get, status, etc.) default to human-readable text output.

| Command | Previous Default | New Default |
|---------|-----------------|-------------|
| `deploy` | `true` ❌ | `false` ✅ |
| All others | `false` ✅ | `false` ✅ |

## Test plan
- [x] Run `phala deploy` without `--json` flag → should show human-readable output
- [x] Run `phala deploy --json` → should show JSON output
- [x] Run `phala deploy --no-json` → should show human-readable output

🤖 Generated with [Claude Code](https://claude.com/claude-code)