### PR TITLE
chore: add tmp/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 CLAUDE.md
 node_modules
+tmp/


### PR DESCRIPTION
## Summary
- Add `tmp/` directory to `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)