### PR TITLE
fix(cli): use real Phala gateway domain in help examples

### DIFF
--- a/cli/src/commands/cp/command.ts
+++ b/cli/src/commands/cp/command.ts
@@ -82,7 +82,7 @@ export const cpCommandMeta: CommandMeta = {
 		{
 			name: "Offline mode: copy without API (using phala.toml gateway)",
 			value:
-				"phala cp -g dstack-gateway.example.com -p 16185 ./file.txt app_123:/root/",
+				"phala cp -g dstack-pha-prod7.phala.network -p 16185 ./file.txt app_123:/root/",
 		},
 		{
 			name: "Upload directory recursively",

--- a/cli/src/commands/ssh/command.ts
+++ b/cli/src/commands/ssh/command.ts
@@ -71,7 +71,7 @@ export const sshCommandMeta: CommandMeta = {
 		},
 		{
 			name: "Offline mode: connect without API (using phala.toml gateway)",
-			value: "phala ssh app_123 -g dstack-gateway.example.com -p 16185",
+			value: "phala ssh app_123 -g dstack-pha-prod7.phala.network -p 16185",
 		},
 		{
 			name: "Connect with custom SSH key",


### PR DESCRIPTION
## Summary
- Replace placeholder domain `dstack-gateway.example.com` with `dstack-pha-prod7.phala.network` in CLI help examples
- Affects `phala ssh` and `phala cp` command documentation

Fixes #139

## Test plan
- [x] Run `phala ssh --help` and verify example shows real gateway domain
- [x] Run `phala cp --help` and verify example shows real gateway domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)