### PR TITLE
feat(cli): add privacy settings to deploy command

### DIFF
--- a/cli/src/commands/cvms/logs-handler.ts
+++ b/cli/src/commands/cvms/logs-handler.ts
@@ -1,6 +1,27 @@
-import { CvmIdSchema } from "@phala/cloud";
+import { CvmIdSchema, safeGetCvmInfo } from "@phala/cloud";
 import type { CommandContext } from "@/src/core/types";
 import { logger, setJsonMode } from "@/src/utils/logger";
+import { getClient } from "@/src/lib/client";
+
+/**
+ * Check if logs are disabled for a CVM and warn the user if so.
+ * @returns true if logs are disabled, false otherwise
+ */
+async function checkAndWarnIfLogsDisabled(appId: string): Promise<boolean> {
+	try {
+		const client = await getClient();
+		const result = await safeGetCvmInfo(client, { id: appId });
+		if (result.success && result.data.public_logs === false) {
+			logger.warn("Logs are disabled for this CVM (public_logs=false).");
+			logger.warn("To enable logs, run:");
+			logger.warn(`  phala deploy --cvm-id ${appId} --public-logs`);
+			return true;
+		}
+	} catch (e) {
+		logger.debug?.(`Failed to check CVM info: ${e}`);
+	}
+	return false;
+}
 
 export interface LogsHandlerConfig<TOptions> {
 	logType: "container" | "serial";
@@ -104,11 +125,19 @@ export function createLogsHandler<TInput extends BaseLogsInput, TOptions>(
 			if (logs.trim()) {
 				console.log(logs);
 			} else {
-				logger.info("No logs available");
+				const logsDisabled = await checkAndWarnIfLogsDisabled(appId);
+				if (!logsDisabled) {
+					logger.info("No logs available");
+				}
 			}
 
 			return 0;
 		} catch (error) {
+			const logsDisabled = await checkAndWarnIfLogsDisabled(appId);
+			if (logsDisabled) {
+				return 1;
+			}
+
 			logger.logDetailedError(error);
 			context.fail(
 				`Failed to fetch ${logTypeName} logs: ${

--- a/cli/src/commands/deploy/command.ts
+++ b/cli/src/commands/deploy/command.ts
@@ -174,6 +174,26 @@ export const deployCommandMeta: CommandMeta = {
 			type: "boolean",
 			target: "nonDevOs",
 		},
+		{
+			name: "public-logs",
+			description:
+				"Make CVM logs publicly accessible (default: true for --dev-os, false otherwise)",
+			type: "boolean",
+			target: "publicLogs",
+		},
+		{
+			name: "public-sysinfo",
+			description:
+				"Make CVM system info publicly accessible (default: true)",
+			type: "boolean",
+			target: "publicSysinfo",
+		},
+		{
+			name: "listed",
+			description: "List CVM on the public Trust Center (default: false)",
+			type: "boolean",
+			target: "listed",
+		},
 	],
 	examples: [
 		// --- New Deployment Examples ---
@@ -220,6 +240,19 @@ export const deployCommandMeta: CommandMeta = {
 			name: "Update CVM configured in phala.toml (auto-detected)",
 			value: "phala deploy",
 		},
+		// --- Privacy Settings Examples ---
+		{
+			name: "Deploy with explicit privacy settings",
+			value: "phala deploy --public-logs=false --public-sysinfo=false",
+		},
+		{
+			name: "Deploy and list on Trust Center",
+			value: "phala deploy --listed",
+		},
+		{
+			name: "Update existing CVM visibility",
+			value: "phala deploy --cvm-id app_123 --public-logs=false",
+		},
 	],
 };
 
@@ -249,6 +282,9 @@ export const deployCommandSchema = z.object({
 	sshPubkey: z.string().optional(),
 	devOs: z.boolean().default(false),
 	nonDevOs: z.boolean().default(false),
+	publicLogs: z.boolean().optional(),
+	publicSysinfo: z.boolean().optional(),
+	listed: z.boolean().optional(),
 });
 
 export type DeployCommandInput = z.infer<typeof deployCommandSchema>;

--- a/cli/src/commands/deploy/handler.test.ts
+++ b/cli/src/commands/deploy/handler.test.ts
@@ -13,6 +13,11 @@ describe("buildProvisionPayload", () => {
 	const defaultDockerCompose =
 		"version: '3'\nservices:\n  app:\n    image: nginx";
 	const defaultEnvs = [{ key: "NODE_ENV", value: "production" }];
+	const defaultPrivacySettings = {
+		publicLogs: false,
+		publicSysinfo: true,
+		listed: false,
+	};
 
 	describe("prefer_dev flag handling (--dev-os / --non-dev-os)", () => {
 		test("should set prefer_dev to true when devOs is true", () => {
@@ -26,6 +31,7 @@ describe("buildProvisionPayload", () => {
 				defaultName,
 				defaultDockerCompose,
 				defaultEnvs,
+				defaultPrivacySettings,
 			);
 
 			expect(payload.prefer_dev).toBe(true);
@@ -42,6 +48,7 @@ describe("buildProvisionPayload", () => {
 				defaultName,
 				defaultDockerCompose,
 				defaultEnvs,
+				defaultPrivacySettings,
 			);
 
 			expect(payload.prefer_dev).toBe(false);
@@ -58,6 +65,7 @@ describe("buildProvisionPayload", () => {
 				defaultName,
 				defaultDockerCompose,
 				defaultEnvs,
+				defaultPrivacySettings,
 			);
 
 			expect("prefer_dev" in payload).toBe(false);
@@ -71,6 +79,7 @@ describe("buildProvisionPayload", () => {
 				defaultName,
 				defaultDockerCompose,
 				defaultEnvs,
+				defaultPrivacySettings,
 			);
 
 			expect("prefer_dev" in payload).toBe(false);
@@ -89,6 +98,7 @@ describe("buildProvisionPayload", () => {
 				defaultName,
 				defaultDockerCompose,
 				defaultEnvs,
+				defaultPrivacySettings,
 			);
 
 			// devOs is checked first in if-else chain
@@ -105,6 +115,7 @@ describe("buildProvisionPayload", () => {
 				defaultName,
 				defaultDockerCompose,
 				defaultEnvs,
+				defaultPrivacySettings,
 			);
 
 			expect(payload.name).toBe(defaultName);
@@ -135,6 +146,7 @@ describe("buildProvisionPayload", () => {
 				defaultName,
 				defaultDockerCompose,
 				defaultEnvs,
+				defaultPrivacySettings,
 			);
 
 			expect(payload.instance_type).toBe("tdx.small");
@@ -156,6 +168,7 @@ describe("buildProvisionPayload", () => {
 				defaultName,
 				defaultDockerCompose,
 				defaultEnvs,
+				defaultPrivacySettings,
 			);
 
 			expect("instance_type" in payload).toBe(false);
@@ -179,6 +192,7 @@ describe("buildProvisionPayload", () => {
 				defaultName,
 				defaultDockerCompose,
 				[],
+				defaultPrivacySettings,
 			);
 
 			expect(
@@ -199,6 +213,7 @@ describe("buildProvisionPayload", () => {
 				defaultName,
 				defaultDockerCompose,
 				defaultEnvs,
+				defaultPrivacySettings,
 			);
 
 			// vcpu/memory should be included
@@ -219,6 +234,7 @@ describe("buildProvisionPayload", () => {
 				defaultName,
 				defaultDockerCompose,
 				defaultEnvs,
+				defaultPrivacySettings,
 			);
 
 			expect(payload.vcpu).toBe(4);
@@ -236,6 +252,7 @@ describe("buildProvisionPayload", () => {
 				defaultName,
 				defaultDockerCompose,
 				defaultEnvs,
+				defaultPrivacySettings,
 			);
 
 			expect(payload.memory).toBe(8192);
@@ -250,6 +267,7 @@ describe("buildProvisionPayload", () => {
 				defaultName,
 				defaultDockerCompose,
 				defaultEnvs,
+				defaultPrivacySettings,
 			);
 			expect(payload.memory).toBe(2048);
 
@@ -259,6 +277,7 @@ describe("buildProvisionPayload", () => {
 				defaultName,
 				defaultDockerCompose,
 				defaultEnvs,
+				defaultPrivacySettings,
 			);
 			expect(payload.memory).toBe(4096);
 
@@ -268,6 +287,7 @@ describe("buildProvisionPayload", () => {
 				defaultName,
 				defaultDockerCompose,
 				defaultEnvs,
+				defaultPrivacySettings,
 			);
 			expect(payload.memory).toBe(2048);
 
@@ -277,8 +297,56 @@ describe("buildProvisionPayload", () => {
 				defaultName,
 				defaultDockerCompose,
 				defaultEnvs,
+				defaultPrivacySettings,
 			);
 			expect(payload.memory).toBe(1024);
+		});
+	});
+
+	describe("privacy settings", () => {
+		test("should include public_logs and public_sysinfo in compose_file", () => {
+			const options = {};
+			const privacySettings = {
+				publicLogs: true,
+				publicSysinfo: false,
+				listed: true,
+			};
+
+			const payload = buildProvisionPayload(
+				options,
+				defaultName,
+				defaultDockerCompose,
+				defaultEnvs,
+				privacySettings,
+			);
+
+			expect(
+				(payload.compose_file as Record<string, unknown>).public_logs,
+			).toBe(true);
+			expect(
+				(payload.compose_file as Record<string, unknown>).public_sysinfo,
+			).toBe(false);
+			expect(payload.listed).toBe(true);
+		});
+
+		test("should include default privacy settings", () => {
+			const options = {};
+
+			const payload = buildProvisionPayload(
+				options,
+				defaultName,
+				defaultDockerCompose,
+				defaultEnvs,
+				defaultPrivacySettings,
+			);
+
+			expect(
+				(payload.compose_file as Record<string, unknown>).public_logs,
+			).toBe(false);
+			expect(
+				(payload.compose_file as Record<string, unknown>).public_sysinfo,
+			).toBe(true);
+			expect(payload.listed).toBe(false);
 		});
 	});
 });

--- a/cli/src/commands/deploy/handler.ts
+++ b/cli/src/commands/deploy/handler.ts
@@ -37,6 +37,7 @@ import {
 	safeGetKmsList,
 	safeProvisionCvm,
 	safeProvisionCvmComposeFileUpdate,
+	safeUpdateCvmVisibility,
 	convertToHostname,
 	isValidHostname,
 } from "@phala/cloud";
@@ -44,6 +45,9 @@ import dedent from "dedent";
 import fs from "fs-extra";
 import inquirer from "inquirer";
 import type { DeployCommandInput } from "./command";
+import type { RuntimeProjectConfig } from "@/src/utils/project-config";
+
+type PrivacyConfig = Pick<RuntimeProjectConfig, "public_logs" | "public_sysinfo" | "listed">;
 
 interface Options {
 	name?: string;
@@ -72,6 +76,9 @@ interface Options {
 	sshPubkey?: string;
 	devOs?: boolean;
 	nonDevOs?: boolean;
+	publicLogs?: boolean;
+	publicSysinfo?: boolean;
+	listed?: boolean;
 	[key: string]: unknown;
 }
 
@@ -545,6 +552,28 @@ const validateCpuMemoryDiskSize = async (options: Options) => {
 	};
 };
 
+interface PrivacySettings {
+	publicLogs: boolean;
+	publicSysinfo: boolean;
+	listed: boolean;
+}
+
+/**
+ * Resolve privacy settings with priority: CLI flags > phala.toml > dev mode defaults
+ */
+const resolvePrivacySettings = (
+	options: Options,
+	projectConfig?: PrivacyConfig,
+): PrivacySettings => {
+	const isDevMode = options.devOs === true;
+
+	return {
+		publicLogs: options.publicLogs ?? projectConfig?.public_logs ?? isDevMode,
+		publicSysinfo: options.publicSysinfo ?? projectConfig?.public_sysinfo ?? true,
+		listed: options.listed ?? projectConfig?.listed ?? false,
+	};
+};
+
 /**
  * Build provision payload from options
  * All parameters are optional - backend will auto-match resources
@@ -554,6 +583,7 @@ export const buildProvisionPayload = (
 	name: string,
 	dockerComposeYml: string,
 	envs: EnvVar[],
+	privacySettings: PrivacySettings,
 ) => {
 	const payload: Record<string, unknown> = {
 		name: name,
@@ -561,7 +591,10 @@ export const buildProvisionPayload = (
 			name: "", // Required by backend schema, defaults to empty string
 			docker_compose_file: dockerComposeYml,
 			allowed_envs: envs?.map((e) => e.key) || [],
+			public_logs: privacySettings.publicLogs,
+			public_sysinfo: privacySettings.publicSysinfo,
 		},
+		listed: privacySettings.listed,
 	};
 
 	// Only add user-specified parameters - let backend auto-match the rest
@@ -615,6 +648,7 @@ const deployNewCvm = async (
 	client: Client,
 	stdout: NodeJS.WriteStream,
 	stderr: NodeJS.WriteStream,
+	projectConfig?: PrivacyConfig,
 ) => {
 	const name = await validateName(validatedOptions);
 
@@ -628,11 +662,15 @@ const deployNewCvm = async (
 		});
 	}
 
+	// Resolve privacy settings based on options, phala.toml, and dev mode
+	const privacySettings = resolvePrivacySettings(validatedOptions, projectConfig);
+
 	const payload = buildProvisionPayload(
 		validatedOptions,
 		name,
 		docker_compose_yml,
 		envsWithSshKey,
+		privacySettings,
 	);
 
 	stdout.write(`Provisioning CVM ${name}...\n`);
@@ -911,6 +949,26 @@ const updateCvm = async (
 			`Failed to commit CVM compose file update: ${commitResult.error.message}`,
 		);
 	}
+
+	// Update visibility if explicitly specified
+	if (
+		validatedOptions.publicLogs !== undefined ||
+		validatedOptions.publicSysinfo !== undefined
+	) {
+		const visibilityResult = await safeUpdateCvmVisibility(client, {
+			id: validatedOptions.uuid,
+			public_logs: validatedOptions.publicLogs ?? cvm.public_logs,
+			public_sysinfo: validatedOptions.publicSysinfo ?? cvm.public_sysinfo,
+		});
+		if (!visibilityResult.success) {
+			logger.warn(
+				`Failed to update visibility: ${visibilityResult.error.message}`,
+			);
+		} else {
+			logger.info("CVM visibility settings updated");
+		}
+	}
+
 	// Wait for update to complete if --wait flag is set
 	if (validatedOptions.wait) {
 		logger.info("Waiting for update to complete...");
@@ -1022,6 +1080,7 @@ export async function runDeploy(
 				client,
 				context.stdout,
 				context.stderr,
+				context.projectConfig,
 			);
 		}
 	} catch (error) {

--- a/cli/src/utils/project-config.ts
+++ b/cli/src/utils/project-config.ts
@@ -18,6 +18,10 @@ export const ProjectConfigSchema: z.ZodTypeAny = CvmIdObjectSchema.extend({
 	// Deploy configuration
 	compose_file: z.string().optional(),
 	env_file: z.string().optional(),
+	// Privacy settings
+	public_logs: z.boolean().optional(),
+	public_sysinfo: z.boolean().optional(),
+	listed: z.boolean().optional(),
 });
 
 export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;
@@ -29,6 +33,10 @@ export type RuntimeProjectConfig = Partial<ProjectConfig> & {
 	gateway_port?: number;
 	compose_file?: string;
 	env_file?: string;
+	// Privacy settings
+	public_logs?: boolean;
+	public_sysinfo?: boolean;
+	listed?: boolean;
 };
 
 const CONFIG_FILE_NAME = "phala.toml";


### PR DESCRIPTION
## Summary

- Add `--public-logs`, `--public-sysinfo`, and `--listed` flags to `phala deploy` command
- Support privacy settings in `phala.toml` configuration file
- Add warning when fetching logs from CVMs with `public_logs=false`
- Allow updating visibility settings on existing CVMs via `--cvm-id`

## Details

**New CLI flags:**
| Flag | Description | Default |
|------|-------------|---------|
| `--public-logs` | Make CVM logs publicly accessible | `true` for `--dev-os`, `false` otherwise |
| `--public-sysinfo` | Make CVM system info publicly accessible | `true` |
| `--listed` | List CVM on public Trust Center | `false` |

**Priority order:** CLI flags > phala.toml > dev mode defaults

**phala.toml support:**
```toml
public_logs = false
public_sysinfo = true
listed = false
```

Closes #148

## Test plan

- [x] Type check passes
- [x] Unit tests pass (36 tests)
- [ ] Manual testing: `phala deploy` with default settings
- [ ] Manual testing: `phala deploy --public-logs=false --public-sysinfo=false`
- [ ] Manual testing: `phala deploy --cvm-id <id> --public-logs` to update existing CVM
- [ ] Manual testing: `phala cvms logs <id>` with logs disabled shows warning

🤖 Generated with [Claude Code](https://claude.ai/code)