### PR TITLE
fix(cli): improve package manager detection and self update version check

### DIFF
--- a/cli/src/commands/self/update/index.ts
+++ b/cli/src/commands/self/update/index.ts
@@ -1,10 +1,11 @@
 import prompts from "prompts";
 import { execa } from "execa";
 import semver from "semver";
+import chalk from "chalk";
 import { defineCommand } from "@/src/core/define-command";
 import type { CommandContext } from "@/src/core/types";
 import { logger, setJsonMode } from "@/src/utils/logger";
-import { getConfigValue } from "@/src/utils/config";
+import { getConfigValue, saveConfig } from "@/src/utils/config";
 import {
 	detectPackageManager,
 	detectRuntimeFromProcess,
@@ -21,6 +22,70 @@ import {
 
 function isNonEmptyString(value: unknown): value is string {
 	return typeof value === "string" && value.trim().length > 0;
+}
+
+function encodeNpmPackageName(packageName: string): string {
+	return packageName.startsWith("@")
+		? packageName.replace("/", "%2F")
+		: packageName;
+}
+
+interface VersionCheckResult {
+	latestVersion: string | null;
+	error?: string;
+}
+
+async function fetchLatestVersion(
+	packageName: string,
+	channel: string,
+): Promise<VersionCheckResult> {
+	const encodedName = encodeNpmPackageName(packageName);
+	const url = `https://registry.npmjs.org/${encodedName}`;
+
+	const controller = new AbortController();
+	const timeoutHandle = setTimeout(() => controller.abort(), 5000);
+
+	try {
+		const response = await fetch(url, {
+			signal: controller.signal,
+			headers: { accept: "application/json" },
+		});
+
+		if (!response.ok) {
+			return {
+				latestVersion: null,
+				error: `Registry returned ${response.status}`,
+			};
+		}
+
+		const body = (await response.json()) as { "dist-tags"?: unknown };
+		if (!body || typeof body !== "object") {
+			return { latestVersion: null, error: "Invalid registry response" };
+		}
+
+		const distTags = body["dist-tags"];
+		if (!distTags || typeof distTags !== "object") {
+			return { latestVersion: null, error: "No dist-tags in response" };
+		}
+
+		const selected =
+			(distTags as Record<string, unknown>)[channel] ??
+			(distTags as Record<string, unknown>).latest;
+
+		if (typeof selected !== "string") {
+			return { latestVersion: null, error: `Channel "${channel}" not found` };
+		}
+
+		const latestVersion = semver.valid(selected);
+		return { latestVersion };
+	} catch (error) {
+		if (error instanceof Error && error.name === "AbortError") {
+			return { latestVersion: null, error: "Request timed out" };
+		}
+		return { latestVersion: null, error: String(error) };
+	} finally {
+		clearTimeout(timeoutHandle);
+	}
 }
 
 function getErrorCode(error: unknown): string | undefined {
@@ -115,6 +180,63 @@ async function runSelfUpdate(
 	const currentVersion = context.cli?.packageVersion ?? "0.0.0";
 	const channel = resolveChannel(input.channel, currentVersion, context.env);
 
+	// Fetch latest version from npm registry
+	if (!input.json) {
+		context.stderr.write(chalk.gray("Checking for updates...\n"));
+	}
+
+	const { latestVersion, error: fetchError } = await fetchLatestVersion(
+		packageName,
+		channel,
+	);
+
+	// Update the cache with fresh data
+	if (latestVersion) {
+		const now = Date.now();
+		const channelKey = channel.replace(/[^a-zA-Z0-9_-]/g, "_");
+		saveConfig({
+			[`updateCheckLastAt_${channelKey}`]: now,
+			[`updateCheckLatest_${channelKey}`]: latestVersion,
+			...(channel === "latest"
+				? { updateCheckLastAt: now, updateCheckLatest: latestVersion }
+				: {}),
+		});
+	}
+
+	const currentValid = semver.valid(currentVersion);
+	const isUpToDate =
+		latestVersion && currentValid && !semver.gt(latestVersion, currentValid);
+
+	// Display version info
+	if (!input.json) {
+		if (fetchError) {
+			context.stderr.write(
+				chalk.yellow(
+					`Warning: Could not fetch latest version: ${fetchError}\n`,
+				),
+			);
+			context.stderr.write(chalk.gray(`Current version: v${currentVersion}\n`));
+		} else if (latestVersion) {
+			context.stderr.write(chalk.gray(`Current version: v${currentVersion}\n`));
+			context.stderr.write(
+				chalk.gray(
+					`Latest version:  v${latestVersion}${channel !== "latest" ? ` (${channel})` : ""}\n`,
+				),
+			);
+			if (isUpToDate) {
+				context.stderr.write(
+					chalk.green("You are already on the latest version.\n"),
+				);
+			} else {
+				context.stderr.write(
+					chalk.yellow(
+						`Update available: v${currentVersion} → v${latestVersion}\n`,
+					),
+				);
+			}
+		}
+	}
+
 	const spec =
 		channel === "latest"
 			? `${packageName}@latest`
@@ -123,12 +245,18 @@ async function runSelfUpdate(
 	const { command, args } = getGlobalInstallArgs(packageManager, spec);
 
 	if (input.json && input.dryRun) {
-		context.success({ command: commandString, dryRun: true });
+		context.success({
+			command: commandString,
+			dryRun: true,
+			currentVersion,
+			latestVersion,
+			isUpToDate,
+		});
 		return 0;
 	}
 
 	if (input.dryRun) {
-		context.stdout.write(`${commandString}\n`);
+		context.stderr.write(chalk.gray(`Command: ${commandString}\n`));
 		return 0;
 	}
 
@@ -141,6 +269,9 @@ async function runSelfUpdate(
 				command: commandString,
 				ran: false,
 				reason: "nonInteractive",
+				currentVersion,
+				latestVersion,
+				isUpToDate,
 			});
 			return 0;
 		}
@@ -148,18 +279,29 @@ async function runSelfUpdate(
 		return 1;
 	}
 
+	// If already up to date, ask if user still wants to reinstall
+	const promptMessage = isUpToDate
+		? `Already up to date. Reinstall anyway with "${commandString}"?`
+		: `Run "${commandString}"?`;
+
 	const shouldRun =
 		input.yes ||
 		(await prompts({
 			type: "confirm",
 			name: "ok",
-			message: `Run "${commandString}"?`,
-			initial: true,
+			message: promptMessage,
+			initial: !isUpToDate,
 		}).then((r) => r.ok === true));
 
 	if (!shouldRun) {
 		if (input.json) {
-			context.success({ command: commandString, ran: false });
+			context.success({
+				command: commandString,
+				ran: false,
+				currentVersion,
+				latestVersion,
+				isUpToDate,
+			});
 		}
 		return 0;
 	}
@@ -167,7 +309,13 @@ async function runSelfUpdate(
 	try {
 		await execa(command, args, { stdio: "inherit" });
 		if (input.json) {
-			context.success({ command: commandString, ran: true });
+			context.success({
+				command: commandString,
+				ran: true,
+				currentVersion,
+				latestVersion,
+				isUpToDate,
+			});
 			return 0;
 		}
 		logger.success("Update completed");

--- a/cli/src/core/package-manager.test.ts
+++ b/cli/src/core/package-manager.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import {
+	detectPackageManagerFromPath,
+	detectPackageManager,
+	detectRuntimeFromProcess,
+} from "./package-manager";
+
+describe("detectPackageManagerFromPath", () => {
+	test("detects bun from ~/.bun/bin/ path", () => {
+		expect(detectPackageManagerFromPath("/Users/user/.bun/bin/phala")).toBe(
+			"bun",
+		);
+		expect(detectPackageManagerFromPath("/home/user/.bun/bin/phala")).toBe(
+			"bun",
+		);
+	});
+
+	test("detects pnpm from path containing pnpm", () => {
+		expect(
+			detectPackageManagerFromPath(
+				"/Users/user/.local/share/pnpm/global/5/node_modules/.bin/phala",
+			),
+		).toBe("pnpm");
+		expect(
+			detectPackageManagerFromPath(
+				"/home/user/pnpm/global/node_modules/phala/dist/index.js",
+			),
+		).toBe("pnpm");
+	});
+
+	test("detects yarn from ~/.yarn/ path", () => {
+		expect(detectPackageManagerFromPath("/Users/user/.yarn/bin/phala")).toBe(
+			"yarn",
+		);
+		expect(
+			detectPackageManagerFromPath(
+				"/home/user/yarn/global/node_modules/phala/dist/index.js",
+			),
+		).toBe("yarn");
+	});
+
+	test("returns undefined for npm or unknown paths", () => {
+		expect(
+			detectPackageManagerFromPath(
+				"/usr/local/lib/node_modules/phala/dist/index.js",
+			),
+		).toBeUndefined();
+		expect(
+			detectPackageManagerFromPath(
+				"/home/user/.npm-global/lib/node_modules/phala/dist/index.js",
+			),
+		).toBeUndefined();
+	});
+
+	test("handles Windows-style paths", () => {
+		expect(
+			detectPackageManagerFromPath("C:\\Users\\user\\.bun\\bin\\phala"),
+		).toBe("bun");
+	});
+});
+
+describe("detectPackageManager", () => {
+	test("returns bun when runtime is bun", () => {
+		expect(detectPackageManager({}, "bun")).toBe("bun");
+	});
+
+	test("detects from npm_config_user_agent", () => {
+		expect(
+			detectPackageManager({ npm_config_user_agent: "pnpm/8.0.0" }, "node"),
+		).toBe("pnpm");
+		expect(
+			detectPackageManager({ npm_config_user_agent: "yarn/1.22.0" }, "node"),
+		).toBe("yarn");
+		expect(
+			detectPackageManager({ npm_config_user_agent: "npm/10.0.0" }, "node"),
+		).toBe("npm");
+		expect(
+			detectPackageManager({ npm_config_user_agent: "bun/1.0.0" }, "node"),
+		).toBe("bun");
+	});
+
+	test("falls back to npm when no detection succeeds", () => {
+		expect(detectPackageManager({}, "node")).toBe("npm");
+	});
+});
+
+describe("detectRuntimeFromProcess", () => {
+	test("detects current runtime", () => {
+		const runtime = detectRuntimeFromProcess();
+		// In bun test environment, this should be "bun"
+		expect(["node", "bun"]).toContain(runtime);
+	});
+});

--- a/cli/src/core/package-manager.ts
+++ b/cli/src/core/package-manager.ts
@@ -8,12 +8,35 @@ export function detectRuntimeFromProcess(): RuntimeName {
 	return typeof (process.versions as any).bun === "string" ? "bun" : "node";
 }
 
+/**
+ * Detect package manager from the executable path.
+ * Global installs typically reside in package-manager-specific directories.
+ */
+export function detectPackageManagerFromPath(
+	execPath: string,
+): PackageManagerName | undefined {
+	// Normalize path separators for cross-platform support
+	const normalizedPath = execPath.replace(/\\/g, "/");
+
+	// bun: ~/.bun/bin/ or similar
+	if (/[/\\]\.bun[/\\]/.test(normalizedPath)) return "bun";
+
+	// pnpm: ~/.local/share/pnpm/ or pnpm/global/
+	if (/pnpm/.test(normalizedPath)) return "pnpm";
+
+	// yarn: ~/.yarn/ or yarn/global/
+	if (/[/\\]\.yarn[/\\]|yarn[/\\]global/.test(normalizedPath)) return "yarn";
+
+	return undefined;
+}
+
 export function detectPackageManager(
 	env: NodeJS.ProcessEnv,
 	runtime: RuntimeName,
 ): PackageManagerName {
 	if (runtime === "bun") return "bun";
 
+	// Check npm_config_user_agent first (set when running via package manager scripts)
 	const userAgent = env.npm_config_user_agent;
 	if (userAgent) {
 		const firstToken = userAgent.split(" ")[0] ?? "";
@@ -22,6 +45,14 @@ export function detectPackageManager(
 		if (name === "yarn") return "yarn";
 		if (name === "npm") return "npm";
 		if (name === "bun") return "bun";
+	}
+
+	// For global CLI execution, detect from the executable path
+	// process.argv[1] contains the path to the executed script
+	const scriptPath = process.argv[1];
+	if (scriptPath) {
+		const fromPath = detectPackageManagerFromPath(scriptPath);
+		if (fromPath) return fromPath;
 	}
 
 	// Fallback for direct execution without a package manager wrapper.

--- a/cli/src/core/update-check.ts
+++ b/cli/src/core/update-check.ts
@@ -206,18 +206,6 @@ export async function checkForUpdates(
 		if (isTruthyEnv(env.PHALA_DISABLE_UPDATE_CHECK)) return null;
 		if (configStore.get("disableUpdateNotice") === true) return null;
 
-		const cached = getCachedUpdateNotice({
-			executableName,
-			packageName,
-			currentVersion,
-			runtime,
-			env,
-			isJson,
-			stderrIsTTY,
-			configStore,
-		});
-		if (cached) return cached;
-
 		const channel = resolveChannel(currentVersion, env, configStore);
 		const lastAtKey = getChannelConfigKey("updateCheckLastAt", channel);
 		const lastAt =
@@ -225,8 +213,19 @@ export async function checkForUpdates(
 			(channel === "latest"
 				? getNumberConfig(configStore, "updateCheckLastAt")
 				: undefined);
+
+		// If within TTL, return cached notice (if any) without fetching
 		if (lastAt && now - lastAt < ttlMs) {
-			return null;
+			return getCachedUpdateNotice({
+				executableName,
+				packageName,
+				currentVersion,
+				runtime,
+				env,
+				isJson,
+				stderrIsTTY,
+				configStore,
+			});
 		}
 
 		const encodedName = encodeNpmPackageName(packageName);


### PR DESCRIPTION
## Summary
- Fix package manager detection for globally installed CLI (e.g., `bun install -g phala` now correctly suggests `bun add -g` for updates)
- Fix update check to refresh from npmjs when TTL (24h) expires
- Enhance `phala self update` to show current vs latest version before prompting

## Changes
1. **Package manager detection** (`package-manager.ts`)
   - Add `detectPackageManagerFromPath()` to detect from executable path
   - `~/.bun/bin/` → bun, `pnpm` in path → pnpm, `~/.yarn/` → yarn

2. **Update check logic** (`update-check.ts`)
   - Previously: if cached notice exists, return it without querying npmjs
   - Now: check TTL first, return cached if within TTL, query npmjs if expired

3. **Self update command** (`commands/self/update/index.ts`)
   - Fetch latest version from npmjs before prompting
   - Display current version, latest version, and update status
   - Update local cache with fresh data
   - If already up to date, ask if user still wants to reinstall

## Test plan
- [x] Unit tests added for `detectPackageManagerFromPath()`
- [x] All existing tests pass
- [ ] Manual test: `phala self update --dry-run` shows version info