### PR TITLE
chore(sdk-js): add ppid to CvmNodeInfoV20260121

### DIFF
--- a/js/src/types/cvm_info_v20260121.ts
+++ b/js/src/types/cvm_info_v20260121.ts
@@ -70,6 +70,7 @@ export const CvmNodeInfoV20260121Schema = z.object({
   name: z.string().nullable().optional(),
   region: z.string().nullable().optional(),
   device_id: z.string().nullable().optional(),
+  ppid: z.string().nullable().optional(),
   status: z.string().nullable().optional(),
   version: z.string().nullable().optional(),
 });


### PR DESCRIPTION
Update v20260121 CVMNodeInfo schema to include `ppid` for node_info returned by API (2026-01-21).

Test:
- bun run fmt
- bun run lint
- bun run typecheck
- bun run test
