### PR TITLE
Add ERC-8004 TEE Agent template

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -549,5 +549,21 @@
       "TEE",
       "PrimusLabs"
     ]
+  },
+  {
+    "id": "erc-8004-tee-agent",
+    "name": "ERC-8004 TEE Agent",
+    "description": "An ERC-8004 Compliant TEE Agent with a TEE Registry Extension for Secure & Verifiable Trustless Agents in a CVM on Phala Cloud. Combines on-chain identity verification, Intel TDX attestation, and AI chat interface for autonomous blockchain agents.",
+    "repo": "https://github.com/Phala-Network/erc-8004-tee-agent",
+    "author": "Phala-Network",
+    "envs": [
+      { "key": "AGENT_SALT", "required": true, "description": "Unique secret salt for key derivation" },
+      { "key": "REDPILL_API_KEY", "required": true, "description": "API key for confidential AI inference" },
+      { "key": "SUBGRAPH_API_KEY", "required": true, "description": "Access token for blockchain data queries" },
+      { "key": "CHAIN_NAME", "required": true, "description": "Target blockchain (e.g., eth-sepolia)" },
+      { "key": "RPC_URL", "required": true, "description": "Blockchain node endpoint" },
+      { "key": "ANTHROPIC_MODEL", "required": false, "description": "AI model selection", "default": "moonshotai/kimi-k2.5" }
+    ],
+    "tags": ["Agent", "TEE", "ERC-8004", "AI"]
   }
 ]


### PR DESCRIPTION
## Summary
- Adds new template for ERC-8004 Compliant TEE Agent
- Enables secure and verifiable trustless agents in CVMs on Phala Cloud
- Combines on-chain identity (ERC-8004), Intel TDX attestation, and AI chat interface

## Template Details
- **ID**: `erc-8004-tee-agent`
- **Repo**: https://github.com/Phala-Network/erc-8004-tee-agent
- **Tags**: Agent, TEE, ERC-8004, AI

## Test plan
- [x] Verify JSON syntax is valid
- [x] Confirm no duplicate template IDs
- [x] Test deployment from template

🤖 Generated with [Claude Code](https://claude.com/claude-code)