### PR TITLE
feat: add profile field to app schemas and getAppFilterOptions action

### DIFF
--- a/js/src/actions/apps/get_app_filter_options.ts
+++ b/js/src/actions/apps/get_app_filter_options.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { type Client, type SafeResult } from "../../client";
+import type { ApiVersion } from "../../types/client";
+
+export const AppFilterOptionsSchema = z.object({
+  statuses: z.array(z.string()),
+  image_versions: z.array(z.string()),
+  instance_types: z.array(z.string()),
+  kms_slugs: z.array(z.string()),
+  kms_types: z.array(z.string()),
+  regions: z.array(z.string()),
+  nodes: z.array(z.string()),
+});
+export type AppFilterOptions = z.infer<typeof AppFilterOptionsSchema>;
+
+/**
+ * Get available filter options for apps
+ *
+ * Returns distinct values for each filterable field based on the current workspace's apps.
+ *
+ * @param client - The API client
+ * @returns Available filter option values
+ */
+export function getAppFilterOptions<V extends ApiVersion>(
+  client: Client<V>,
+): Promise<AppFilterOptions>;
+export async function getAppFilterOptions<V extends ApiVersion>(
+  client: Client<V>,
+): Promise<AppFilterOptions> {
+  const response = await client.get("/apps/filter-options");
+  return AppFilterOptionsSchema.parse(response);
+}
+
+/**
+ * Safe version of getAppFilterOptions that returns a SafeResult instead of throwing
+ */
+export function safeGetAppFilterOptions<V extends ApiVersion>(
+  client: Client<V>,
+): Promise<SafeResult<AppFilterOptions>>;
+export async function safeGetAppFilterOptions<V extends ApiVersion>(
+  client: Client<V>,
+): Promise<SafeResult<AppFilterOptions>> {
+  try {
+    const data = await getAppFilterOptions(client);
+    return { success: true, data };
+  } catch (error) {
+    if (error && typeof error === "object" && ("status" in error || "issues" in error)) {
+      return { success: false, error } as SafeResult<AppFilterOptions>;
+    }
+    return {
+      success: false,
+      error: {
+        name: "Error",
+        message: error instanceof Error ? error.message : String(error),
+      },
+    } as SafeResult<AppFilterOptions>;
+  }
+}

--- a/js/src/actions/index.ts
+++ b/js/src/actions/index.ts
@@ -406,3 +406,10 @@ export {
   GetAppRevisionDetailRequestSchema,
   type GetAppRevisionDetailRequest,
 } from "./apps/get_app_revision_detail";
+
+export {
+  getAppFilterOptions,
+  safeGetAppFilterOptions,
+  AppFilterOptionsSchema,
+  type AppFilterOptions,
+} from "./apps/get_app_filter_options";

--- a/js/src/types/app_info_v20251028.ts
+++ b/js/src/types/app_info_v20251028.ts
@@ -24,6 +24,14 @@ export const CvmBasicInfoV20251028Schema = z.object({
 });
 export type CvmBasicInfoV20251028 = z.infer<typeof CvmBasicInfoV20251028Schema>;
 
+export const AppProfileSchema = z.object({
+  display_name: z.string().nullable().optional(),
+  avatar_url: z.string().nullable().optional(),
+  description: z.string().nullable().optional(),
+  custom_domain: z.string().nullable().optional(),
+});
+export type AppProfile = z.infer<typeof AppProfileSchema>;
+
 export const DstackAppFullResponseV20251028Schema = z.object({
   id: z.string(),
   name: z.string(),
@@ -32,6 +40,7 @@ export const DstackAppFullResponseV20251028Schema = z.object({
   app_icon_url: z.string().nullable().optional(),
   created_at: z.string(),
   kms_type: z.string(),
+  profile: AppProfileSchema.nullable().optional(),
   current_cvm: CvmBasicInfoV20251028Schema.nullable().optional(),
   cvms: z.array(CvmBasicInfoV20251028Schema).default([]),
   cvm_count: z.number().int().default(0),

--- a/js/src/types/app_info_v20260121.ts
+++ b/js/src/types/app_info_v20260121.ts
@@ -9,6 +9,15 @@ export const DstackAppFullResponseV20260121Schema = z.object({
   app_icon_url: z.string().nullable().optional(),
   created_at: z.string(),
   kms_type: z.string(),
+  profile: z
+    .object({
+      display_name: z.string().nullable().optional(),
+      avatar_url: z.string().nullable().optional(),
+      description: z.string().nullable().optional(),
+      custom_domain: z.string().nullable().optional(),
+    })
+    .nullable()
+    .optional(),
   current_cvm: CvmInfoV20260121Schema.nullable().optional(),
   cvms: z.array(CvmInfoV20260121Schema).default([]),
   cvm_count: z.number().int().default(0),


### PR DESCRIPTION
## Summary
- Add `AppProfileSchema` and `profile` field to `DstackAppFullResponseV20251028Schema` and `DstackAppFullResponseV20260121Schema`
- Add `getAppFilterOptions` / `safeGetAppFilterOptions` action for `GET /apps/filter-options`
- Export new action and schema from `actions/index.ts`

## Context
Frontend `useDstackApps.ts` had duplicate Zod schemas. This PR adds the missing `profile` field and filter-options action to the SDK so the frontend can import from `@phala/cloud` instead of maintaining local copies.

## Test plan
- [x] `bun run fmt && bun run lint && bun run type-check && bun run test` — 620 tests passed