### PR TITLE
sdk(js): use revisionId for app revision detail

### DIFF
--- a/js/src/actions/apps/get_app_revision_detail.ts
+++ b/js/src/actions/apps/get_app_revision_detail.ts
@@ -7,7 +7,7 @@ import type { ApiVersion } from "../../types/client";
 export const GetAppRevisionDetailRequestSchema = z
   .object({
     appId: z.string().min(1),
-    composeHash: z.string().min(1),
+    revisionId: z.string().min(1),
     rawComposeFile: z.boolean().optional(),
   })
   .strict();
@@ -20,7 +20,7 @@ export type GetAppRevisionDetailRequest = z.infer<typeof GetAppRevisionDetailReq
  * @param client - The API client
  * @param request - Request parameters
  * @param request.appId - The app ID
- * @param request.composeHash - The compose hash of the revision
+ * @param request.revisionId - The revision record id (rev_...) of the revision
  * @param request.rawComposeFile - If true, returns compose_file as raw string instead of parsed object
  * @returns Detailed revision information including compose file and encrypted env
  *
@@ -28,13 +28,13 @@ export type GetAppRevisionDetailRequest = z.infer<typeof GetAppRevisionDetailReq
  * ```typescript
  * const detail = await getAppRevisionDetail(client, {
  *   appId: "my-app-id",
- *   composeHash: "abc123"
+ *   revisionId: "rev_abc123"
  * })
  *
  * // Get with raw compose file
  * const detail = await getAppRevisionDetail(client, {
  *   appId: "my-app-id",
- *   composeHash: "abc123",
+ *   revisionId: "rev_abc123",
  *   rawComposeFile: true
  * })
  * ```
@@ -43,9 +43,9 @@ export async function getAppRevisionDetail<V extends ApiVersion>(
   client: Client<V>,
   request: GetAppRevisionDetailRequest,
 ): Promise<AppRevisionDetailResponse> {
-  const { appId, composeHash, rawComposeFile } = GetAppRevisionDetailRequestSchema.parse(request);
+  const { appId, revisionId, rawComposeFile } = GetAppRevisionDetailRequestSchema.parse(request);
   const params = rawComposeFile !== undefined ? { raw_compose_file: rawComposeFile } : undefined;
-  const response = await client.get(`/apps/${appId}/revisions/${composeHash}`, { params });
+  const response = await client.get(`/apps/${appId}/revisions/${revisionId}`, { params });
   return AppRevisionDetailResponseSchema.parse(response);
 }
 

--- a/js/src/types/app_revision.ts
+++ b/js/src/types/app_revision.ts
@@ -11,6 +11,7 @@ export const CvmRefSchema = z.object({
 export type CvmRef = z.infer<typeof CvmRefSchema>;
 
 export const AppRevisionResponseSchema = z.object({
+  revision_id: z.string(),
   app_id: z.string(),
   vm_uuid: z.string(),
   compose_hash: z.string(),
@@ -24,6 +25,7 @@ export const AppRevisionResponseSchema = z.object({
 export type AppRevisionResponse = z.infer<typeof AppRevisionResponseSchema>;
 
 export const AppRevisionDetailResponseSchema = z.object({
+  revision_id: z.string(),
   app_id: z.string(),
   vm_uuid: z.string(),
   compose_hash: z.string(),


### PR DESCRIPTION
## Summary

- Add `revision_id` field to `AppRevisionResponse` and `AppRevisionDetailResponse` schemas
- Change `getAppRevisionDetail` to accept `revisionId` instead of `composeHash` (matches backend path change from `/{compose_hash}` to `/{revision_id}`)

## Context

Backend PR: https://github.com/Phala-Network/phala-cloud-monorepo/pull/882

## Test plan

- [ ] Verify `getAppRevisionDetail` works with revision ID (e.g. `rev_abc123`)
- [ ] Verify `revision_id` is present in revision list responses