### PR TITLE
fix(cli): unify CVM ID handling across commands

### DIFF
--- a/cli/src/commands/cp/index.ts
+++ b/cli/src/commands/cp/index.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import chalk from "chalk";
+import { CvmIdSchema } from "@phala/cloud";
 import { defineCommand } from "@/src/core/define-command";
 import type { CommandContext } from "@/src/core/types";
 import { getClient } from "@/src/lib/client";
@@ -67,19 +68,14 @@ async function runCpCommand(
 		if (remotePath.cvmId) {
 			// If CVM ID is explicitly provided in path (e.g., app_123:path), parse it
 			cvmId = parse_cvm_id(remotePath.cvmId);
-		} else {
+		} else if (context.cvmId) {
 			// Otherwise use context.cvmId (already resolved with priority: interactive > --cvm-id > phala.toml)
-			cvmId =
-				context.cvmId?.id ||
-				context.cvmId?.uuid ||
-				context.cvmId?.app_id ||
-				context.cvmId?.instance_id;
+			cvmId = CvmIdSchema.parse(context.cvmId).cvmId;
 		}
 
 		if (!cvmId) {
-			logger.error(
-				"No CVM ID provided. Either use format cvm-id:path or configure it in phala.toml.\n" +
-					"Supported fields: id, uuid, app_id, or instance_id",
+			context.fail(
+				"No CVM ID provided. Either use format cvm-id:path or configure it in phala.toml.",
 			);
 			return 1;
 		}

--- a/cli/src/commands/cvms/replicate/command.ts
+++ b/cli/src/commands/cvms/replicate/command.ts
@@ -1,18 +1,12 @@
 import { z } from "zod";
 import type { CommandMeta } from "@/src/core/types";
+import { cvmIdArgument, interactiveOption } from "@/src/core/common-flags";
 
 export const cvmsReplicateCommandMeta: CommandMeta = {
 	name: "replicate",
 	description: "Create a replica of an existing CVM",
 	stability: "unstable",
-	arguments: [
-		{
-			name: "cvm-id",
-			description: "UUID of the CVM to replicate",
-			required: true,
-			target: "cvmId",
-		},
-	],
+	arguments: [cvmIdArgument],
 	options: [
 		{
 			name: "teepod-id",
@@ -27,6 +21,7 @@ export const cvmsReplicateCommandMeta: CommandMeta = {
 			type: "string",
 			target: "envFile",
 		},
+		interactiveOption,
 	],
 	examples: [
 		{
@@ -37,9 +32,10 @@ export const cvmsReplicateCommandMeta: CommandMeta = {
 };
 
 export const cvmsReplicateCommandSchema = z.object({
-	cvmId: z.string().min(1, "CVM ID is required"),
+	cvmId: z.string().optional(),
 	teepodId: z.string().optional(),
 	envFile: z.string().optional(),
+	interactive: z.boolean().default(false),
 });
 
 export type CvmsReplicateCommandInput = z.infer<

--- a/cli/src/commands/cvms/replicate/index.ts
+++ b/cli/src/commands/cvms/replicate/index.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { encryptEnvVars } from "@phala/cloud";
+import { CvmIdSchema, encryptEnvVars } from "@phala/cloud";
 import { getCvmComposeConfig, replicateCvm } from "@/src/api/cvms";
 import { defineCommand } from "@/src/core/define-command";
 import type { CommandContext } from "@/src/core/types";
@@ -28,10 +28,17 @@ function parseEnvFile(filePath: string): { key: string; value: string }[] {
 
 async function runCvmsReplicateCommand(
 	input: CvmsReplicateCommandInput,
-	_context: CommandContext,
+	context: CommandContext,
 ): Promise<number> {
 	try {
-		const normalizedCvmId = input.cvmId.replace(/-/g, "");
+		if (!context.cvmId) {
+			context.fail(
+				"No CVM ID provided. Use --interactive to select interactively.",
+			);
+			return 1;
+		}
+
+		const { cvmId: normalizedCvmId } = CvmIdSchema.parse(context.cvmId);
 		let encryptedEnv: string | undefined;
 
 		if (input.envFile) {

--- a/cli/src/commands/cvms/upgrade/index.ts
+++ b/cli/src/commands/cvms/upgrade/index.ts
@@ -48,7 +48,7 @@ async function runCvmsUpgradeCommand(
 		);
 
 		if (!context.cvmId) {
-			logger.error(
+			context.fail(
 				"No CVM ID provided. Use --interactive to select interactively.",
 			);
 			return 1;
@@ -58,13 +58,13 @@ async function runCvmsUpgradeCommand(
 		const infoResult = await safeGetCvmInfo(client, context.cvmId);
 
 		if (!infoResult.success) {
-			logger.error(infoResult.error.message);
+			context.fail(infoResult.error.message);
 			return 1;
 		}
 
 		const cvm = infoResult.data;
 		if (!cvm) {
-			logger.error("CVM not found");
+			context.fail("CVM not found");
 			return 1;
 		}
 

--- a/cli/src/commands/deploy/handler.ts
+++ b/cli/src/commands/deploy/handler.ts
@@ -19,6 +19,7 @@ import {
 	type EnvVar,
 	type ErrorLink,
 	type ProvisionCvmComposeFileUpdateRequest,
+	CvmIdSchema,
 	MAX_COMPOSE_PAYLOAD_BYTES,
 	ResourceError,
 	createClient,
@@ -1178,11 +1179,9 @@ export async function runDeploy(
 			console.log("[DEBUG] input.cvmId:", input.cvmId);
 		}
 
-		const uuid =
-			context.cvmId?.id ||
-			context.cvmId?.uuid ||
-			context.cvmId?.app_id ||
-			context.cvmId?.instance_id;
+		const uuid = context.cvmId
+			? CvmIdSchema.parse(context.cvmId).cvmId
+			: undefined;
 
 		if (input.debug) {
 			console.log("[DEBUG] resolved uuid:", uuid);

--- a/cli/src/commands/ssh/command.ts
+++ b/cli/src/commands/ssh/command.ts
@@ -1,19 +1,13 @@
 import { z } from "zod";
 import type { CommandMeta } from "@/src/core/types";
+import { cvmIdArgument } from "@/src/core/common-flags";
 
 export const sshCommandMeta: CommandMeta = {
 	name: "ssh",
 	category: "cvm-ops",
 	description: "Connect to a CVM via SSH",
 	stability: "unstable",
-	arguments: [
-		{
-			name: "cvm-name",
-			description: "CVM name (reads from phala.toml if omitted)",
-			required: false,
-			target: "cvmId",
-		},
-	],
+	arguments: [cvmIdArgument],
 	options: [
 		{
 			name: "port",

--- a/cli/src/commands/ssh/index.ts
+++ b/cli/src/commands/ssh/index.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import chalk from "chalk";
+import { CvmIdSchema } from "@phala/cloud";
 import { defineCommand } from "@/src/core/define-command";
 import type { CommandContext } from "@/src/core/types";
 import { getClient } from "@/src/lib/client";
@@ -51,19 +52,14 @@ async function runSshCommand(
 ): Promise<number> {
 	try {
 		// Get CVM ID from context (already resolved with priority: interactive > --cvm-id > phala.toml)
-		const cvmId =
-			context.cvmId?.id ||
-			context.cvmId?.uuid ||
-			context.cvmId?.app_id ||
-			context.cvmId?.instance_id;
-
-		if (!cvmId) {
-			logger.error(
-				"No CVM ID provided. Either pass a CVM ID as argument or configure it in phala.toml.\n" +
-					"Supported fields: id, uuid, app_id, or instance_id",
+		if (!context.cvmId) {
+			context.fail(
+				"No CVM ID provided. Either pass a CVM ID as argument or configure it in phala.toml.",
 			);
 			return 1;
 		}
+
+		const { cvmId } = CvmIdSchema.parse(context.cvmId);
 
 		// Check for blocked options in pass-through args
 		const passThroughArgs = input["--"] ?? [];

--- a/cli/src/core/input-builder.ts
+++ b/cli/src/core/input-builder.ts
@@ -47,7 +47,9 @@ export function buildCommandSchemaInput(
 			index = values.length;
 			break;
 		}
-		positionals[target] = values[index];
+		if (values[index] !== undefined) {
+			positionals[target] = values[index];
+		}
 		index += 1;
 	}
 


### PR DESCRIPTION
## Summary

- **Fix dispatcher positional merge bug** (`input-builder.ts`): skip `undefined` positional values so they don't overwrite option values via spread — this fixes `ps --cvm-id` not working
- **Standardize CVM ID normalization**: replace manual `context.cvmId?.id || ...` destructuring with `CvmIdSchema.parse()` in `ssh`, `cp`, `deploy`, `replicate`
- **Standardize error reporting**: replace `logger.error()` with `context.fail()` in `ssh`, `cp`, `replicate`, `upgrade` for structured `--json` error output
- **Align `replicate` with conventions**: use shared `cvmIdArgument` (optional) + `interactiveOption`, resolve via `context.cvmId`

## Test plan

- [ ] `phala ps --cvm-id <id>` should work (was broken by positional merge bug)
- [ ] `phala ps <id>` still works (positional override)
- [ ] `phala cvms replicate --cvm-id <id>` works (was not supported)
- [ ] `phala cvms replicate <id>` still works
- [ ] `phala ssh <various-id-formats>` normalizes correctly (UUID, app_xxx, 40-hex, name)
- [ ] `phala cp ./file :/path --cvm-id <id>` fallback works
- [ ] `phala deploy` in a dir with `phala.toml` correctly detects update vs new
- [ ] All error paths output structured JSON with `--json` flag