### PR TITLE
fix(cli): percent-encode query parameter values in `phala api`

### DIFF
--- a/cli/src/commands/api/index.ts
+++ b/cli/src/commands/api/index.ts
@@ -254,10 +254,17 @@ export async function runApiCommand(
 
 	const customHeaders = parseHeaders(input.header);
 
-	// Normalize endpoint (ensure it starts with /)
-	const endpoint = input.endpoint.startsWith("/")
+	// Normalize endpoint (ensure it starts with / and query params are encoded)
+	const rawEndpoint = input.endpoint.startsWith("/")
 		? input.endpoint
 		: `/${input.endpoint}`;
+
+	// Percent-encode query parameter values (e.g. @ → %40)
+	const qIdx = rawEndpoint.indexOf("?");
+	const endpoint =
+		qIdx >= 0
+			? `${rawEndpoint.slice(0, qIdx)}?${new URLSearchParams(rawEndpoint.slice(qIdx + 1)).toString()}`
+			: rawEndpoint;
 
 	try {
 		// Build request


### PR DESCRIPTION
## Summary

- Percent-encode special characters in query parameter values passed to `phala api`
- Fixes `@` in email addresses causing nginx 403 (e.g. `?identifier=user@example.com`)
- Uses `URLSearchParams` to normalize encoding, which also handles already-encoded values correctly

## Test plan

- [x] `bun run fmt && bun run lint && bun run type-check`
- [x] 305 tests passing