### PR TITLE
chore(cli): remove dead dependencies (jest, ts-jest, rimraf)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -38,10 +38,6 @@
 		"type-check": "tsc --noEmit",
 		"check": "bun run fmt && bun run lint && bun run type-check && bun run test"
 	},
-	"jest": {
-		"preset": "ts-jest",
-		"testEnvironment": "node"
-	},
 	"dependencies": {
 		"@iarna/toml": "^2.2.5",
 		"@michaelhomer/jqjs": "^1.5.0",
@@ -68,13 +64,9 @@
 		"@types/dedent": "^0.7.2",
 		"@types/fs-extra": "^11.0.1",
 		"@types/inquirer": "^9.0.7",
-		"@types/jest": "^29.5.14",
 		"@types/node": "^20.10.0",
 		"@types/prompts": "^2.4.2",
 		"dotenv": "^17.2.3",
-		"jest": "^29.7.0",
-		"rimraf": "^4.1.3",
-		"ts-jest": "^29.3.4",
 		"tsup": "^8.5.1",
 		"type-fest": "^3.8.0",
 		"typescript": "^5.9.2"

--- a/cli/test/utils/secrets.test.ts
+++ b/cli/test/utils/secrets.test.ts
@@ -2,8 +2,6 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { parseEnv } from "../../src/utils/secrets";
-// Assuming bun test provides Jest-like globals, otherwise, you might need:
-// import { describe, test, expect, afterEach } from '@jest/globals';
 
 // Helper to create a temporary file for testing
 const createTempFile = (content: string): string => {


### PR DESCRIPTION
## Summary

- Remove `jest`, `ts-jest`, `@types/jest` — tests migrated to `bun test`, these are unused
- Remove `rimraf` — no references in source code or scripts
- Remove dead jest config block from package.json
- Clean up commented-out jest import in test file

## Motivation

These dead dependencies pull in transitive vulnerabilities flagged by `bun audit` in the monorepo:
- `js-yaml <3.14.2` (moderate: prototype pollution via jest)
- `glob >=10.2.0 <10.5.0` (high: command injection via rimraf)

## Verification

- `bun run type-check` passes
- `bun run test` — 304 pass, 12 skip, 1 pre-existing failure (help text format, unrelated)

## Test plan
- [x] Type check passes
- [x] Tests unaffected (already use bun test, not jest)