### PR TITLE
feat(cli,sdk): add --fs option to deploy command for fs selection

### DIFF
--- a/cli/src/commands/deploy/command.ts
+++ b/cli/src/commands/deploy/command.ts
@@ -71,6 +71,13 @@ export const deployCommandMeta: CommandMeta = {
 			group: "advanced",
 		},
 		{
+			name: "fs",
+			description: "Filesystem type (ext4 or zfs, default: zfs)",
+			type: "string",
+			target: "fs",
+			group: "advanced",
+		},
+		{
 			name: "image",
 			description: "OS image version (auto-selected if omitted)",
 			type: "string",
@@ -274,6 +281,7 @@ export const deployCommandSchema = z.object({
 	vcpu: z.string().optional(),
 	memory: z.string().optional(),
 	diskSize: z.string().optional(),
+	fs: z.enum(["ext4", "zfs"]).optional(),
 	image: z.string().optional(),
 	region: z.string().optional(),
 	nodeId: z.string().optional(),

--- a/cli/src/commands/deploy/handler.test.ts
+++ b/cli/src/commands/deploy/handler.test.ts
@@ -575,6 +575,60 @@ describe("buildProvisionPayload", () => {
 		});
 	});
 
+	describe("storage_fs handling", () => {
+		test("should include storage_fs in compose_file when fs is 'ext4'", () => {
+			const options = {
+				fs: "ext4",
+			};
+
+			const payload = buildProvisionPayload(
+				options,
+				defaultName,
+				defaultDockerCompose,
+				defaultEnvs,
+				defaultPrivacySettings,
+			);
+
+			expect(
+				(payload.compose_file as Record<string, unknown>).storage_fs,
+			).toBe("ext4");
+		});
+
+		test("should include storage_fs in compose_file when fs is 'zfs'", () => {
+			const options = {
+				fs: "zfs",
+			};
+
+			const payload = buildProvisionPayload(
+				options,
+				defaultName,
+				defaultDockerCompose,
+				defaultEnvs,
+				defaultPrivacySettings,
+			);
+
+			expect(
+				(payload.compose_file as Record<string, unknown>).storage_fs,
+			).toBe("zfs");
+		});
+
+		test("should not include storage_fs in compose_file when fs is not specified", () => {
+			const options = {};
+
+			const payload = buildProvisionPayload(
+				options,
+				defaultName,
+				defaultDockerCompose,
+				defaultEnvs,
+				defaultPrivacySettings,
+			);
+
+			expect(
+				"storage_fs" in (payload.compose_file as Record<string, unknown>),
+			).toBe(false);
+		});
+	});
+
 	describe("pre-launch script handling", () => {
 		test("should include pre_launch_script in compose_file when provided", () => {
 			const options = {};

--- a/cli/src/commands/deploy/handler.ts
+++ b/cli/src/commands/deploy/handler.ts
@@ -60,6 +60,7 @@ interface Options {
 	vcpu?: string;
 	memory?: string;
 	diskSize?: string;
+	fs?: string;
 	image?: string;
 	region?: string;
 	nodeId?: string;
@@ -632,6 +633,10 @@ export const buildProvisionPayload = (
 
 	if (preLaunchScriptContent) {
 		composeFile.pre_launch_script = preLaunchScriptContent;
+	}
+
+	if (options.fs) {
+		composeFile.storage_fs = options.fs;
 	}
 
 	const payload: Record<string, unknown> = {

--- a/js/src/actions/cvms/provision_cvm.ts
+++ b/js/src/actions/cvms/provision_cvm.ts
@@ -215,6 +215,7 @@ export const ProvisionCvmRequestSchema = z
         public_sysinfo: z.boolean().optional(),
         gateway_enabled: z.boolean().optional(), // recommended
         tproxy_enabled: z.boolean().optional(), // deprecated, for compatibility
+        storage_fs: z.enum(["ext4", "zfs"]).optional(),
       })
       .superRefine((data, ctx) => {
         validateComposePayloadSize(data.docker_compose_file, data.pre_launch_script, ctx);

--- a/js/src/types/app_compose.ts
+++ b/js/src/types/app_compose.ts
@@ -37,6 +37,7 @@ export const LooseAppComposeSchema = z
     public_logs: z.boolean().optional(),
     public_sysinfo: z.boolean().optional(),
     tproxy_enabled: z.boolean().optional(),
+    storage_fs: z.enum(["ext4", "zfs"]).optional(),
     pre_launch_script: z.string().optional(),
     env_pubkey: z.string().optional(),
     salt: z.string().optional().nullable(),


### PR DESCRIPTION
Allow users to specify ext4 or zfs filesystem when provisioning a CVM via `phala deploy --fs ext4`. The storage_fs field is set in the app-compose (compose_file) payload, which is the source of truth for filesystem selection in dstack.