### PR TITLE
fix(cli): --wait poller accepts names and app_ids, not just UUIDs

### DIFF
--- a/cli/src/utils/cvms.ts
+++ b/cli/src/utils/cvms.ts
@@ -6,12 +6,12 @@ import { logger } from "./logger";
  * Wait for CVM to complete any in-progress operations and reach running state
  * Progress messages are automatically suppressed in JSON mode.
  *
- * @param uuid CVM UUID to monitor
+ * @param cvmId CVM identifier (UUID, app_id, name, or any format accepted by CvmIdSchema)
  * @param timeoutMs Maximum time to wait in milliseconds (default: 5 minutes)
  * @returns Promise that resolves when CVM is running and not in_progress, or rejects on timeout
  */
 export async function waitForCvmReady(
-	uuid: string,
+	cvmId: string,
 	timeoutMs = 300000, // 5 minutes default
 ): Promise<void> {
 	const client = await getClient();
@@ -22,7 +22,7 @@ export async function waitForCvmReady(
 
 	while (Date.now() - startTime < timeoutMs) {
 		try {
-			const result = await safeGetCvmInfo(client, { uuid });
+			const result = await safeGetCvmInfo(client, { id: cvmId });
 
 			if (!result.success) {
 				logger.warn(`Failed to get CVM info: ${result.error.message}`);


### PR DESCRIPTION
## Summary

- `waitForCvmReady` passed the CVM identifier as `{ uuid }` to `safeGetCvmInfo`, which applies strict UUID regex validation
- This caused `--wait` to loop for 300s with "Invalid UUID format" when `--cvm-id` was a name or hex app_id
- Switch to `{ id: cvmId }` which accepts any identifier format (names, app_ids, UUIDs)

## Repro (before fix)

```bash
# These deploy fine but --wait loops with "Invalid UUID format":
phala deploy --cvm-id my-app-name -c compose.yml --wait
phala deploy --cvm-id 43069de20638d656a2d0e49fb074bee1049bc90e -c compose.yml --wait
```

## Test plan

- [x] Deployed a CVM, then updated by **app_id** with `--wait` — poller worked correctly, waited 46s until running
- [x] Updated by **name** with `--wait` — completed successfully
- [x] `bun test cli/src/commands/deploy/handler.test.ts` — 34 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)