### PR TITLE
fix(js-sdk): add listed field to CvmInfoV20260121Schema

### DIFF
--- a/js/src/types/cvm_info_v20260121.ts
+++ b/js/src/types/cvm_info_v20260121.ts
@@ -104,6 +104,7 @@ export const CvmInfoV20260121Schema = z.object({
   public_tcbinfo: z.boolean().optional(),
   gateway_enabled: z.boolean().optional(),
   secure_time: z.boolean().optional(),
+  listed: z.boolean().optional().default(false),
   storage_fs: z.string().optional(),
   workspace: WorkspaceRefSchema.nullable().optional(),
   creator: UserRefSchema.nullable().optional(),


### PR DESCRIPTION
## Summary
- Add missing `listed` boolean field to `CvmInfoV20260121Schema`
- Backend returns `listed: bool = False` in v20260121 CVM response but the SDK schema was missing it, causing the field to be silently dropped during Zod parsing

## Test plan
- [ ] `cd js && bun run type-check && bun run test`