### PR TITLE
feat(js): add confidential_models_enabled to workspace schema

### DIFF
--- a/js/src/actions/workspaces/list_workspaces.ts
+++ b/js/src/actions/workspaces/list_workspaces.ts
@@ -73,6 +73,7 @@ export const WorkspaceResponseSchema = z
     role: z.string(),
     is_default: z.boolean(),
     created_at: z.string(),
+    confidential_models_enabled: z.boolean().optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Summary
- Add `confidential_models_enabled: z.boolean().optional()` to `WorkspaceResponseSchema`
- Backend now returns this flag indicating whether Confidential Models (Redpill) is enabled for the workspace

## Test plan
- [x] `bun run fmt && bun run lint && bun run type-check` pass