### PR TITLE
fix(cli): restore -i/--interactive flag for switch command

### DIFF
--- a/cli/src/commands/switch/command.ts
+++ b/cli/src/commands/switch/command.ts
@@ -14,7 +14,15 @@ export const switchCommandMeta: CommandMeta = {
 			target: "profileName",
 		},
 	],
-	options: [],
+	options: [
+		{
+			name: "interactive",
+			shorthand: "i",
+			description: "Select profile interactively",
+			type: "boolean",
+			target: "interactive",
+		},
+	],
 };
 
 export const switchCommandSchema = z.object({


### PR DESCRIPTION
## Summary

- The `-i`/`--interactive` option for `phala switch` was never registered in the command meta `options` array, despite having full schema and handler support since the initial commit (`907f1fe`). This made interactive profile selection unreachable from the CLI.
- Adds the option declaration back so `phala switch -i` works as intended.

## Test plan

- [x] `bun run type-check` passes
- [x] All 7 existing switch tests pass
- [x] `phala switch -i` triggers interactive profile selection
- [x] `phala switch <name>` still does direct switch
- [x] `phala switch` (no args) still shows usage error