### PR TITLE
feat(sdk): add compose_hash_registered to provision response schema

### DIFF
--- a/js/src/actions/cvms/provision_cvm_compose_file_update.test.ts
+++ b/js/src/actions/cvms/provision_cvm_compose_file_update.test.ts
@@ -35,6 +35,7 @@ describe("provisionCvmComposeFileUpdate", () => {
     app_id: "app-123",
     device_id: "device-456",
     compose_hash: "abc123def456",
+    compose_hash_registered: false,
     kms_info: {
       id: "kms-123",
       slug: "test-kms",

--- a/js/src/actions/cvms/provision_cvm_compose_file_update.ts
+++ b/js/src/actions/cvms/provision_cvm_compose_file_update.ts
@@ -126,6 +126,7 @@ export const ProvisionCvmComposeFileUpdateResultSchema = z
     device_id: z.string().nullable(),
     compose_hash: z.string(),
     kms_info: KmsInfoSchema.nullable().optional(),
+    compose_hash_registered: z.boolean().optional().default(false),
   })
   .passthrough();
 


### PR DESCRIPTION
## Summary
- Add `compose_hash_registered` boolean field to `ProvisionCvmComposeFileUpdateResultSchema`
- Update test fixture to include the new field

## Context
Supports compose update flow for on-chain KMS CVMs, where the frontend needs to know whether the compose hash has been registered on-chain.