### PR TITLE
fix(ci): propagate npm publish exit code through tee pipeline

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -474,6 +474,7 @@ jobs:
       - name: Publish to npm
         working-directory: ${{ env.PACKAGE }}
         run: |
+          set -o pipefail
           echo "🚀 Publishing @phala/cloud..."
           echo ""
           echo "Package info:"

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,4 @@
+## [1.1.17](https://github.com/Phala-Network/phala-cloud/compare/cli-v1.1.16...cli-v1.1.17) (2026-04-10)
 ## [1.1.16](https://github.com/Phala-Network/phala-cloud/compare/cli-v1.1.15...cli-v1.1.16) (2026-04-10)
 
 ### fix

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "phala",
-	"version": "1.1.16",
+	"version": "1.1.17",
 	"description": "CLI for Managing Phala Cloud Services",
 	"author": {
 		"name": "Phala Network",

--- a/js/CHANGELOG.md
+++ b/js/CHANGELOG.md
@@ -1,3 +1,4 @@
+## [0.2.8](https://github.com/Phala-Network/phala-cloud/compare/js-v0.2.7...js-v0.2.8) (2026-04-10)
 ## [0.2.7](https://github.com/Phala-Network/phala-cloud/compare/js-v0.2.6...js-v0.2.7) (2026-04-10)
 
 ### feat

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phala/cloud",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "TypeScript SDK for Phala Cloud API",
   "main": "dist/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
## Problem

In the `Publish to npm` step of `release-npm.yml`, the publish command pipes output through `tee`:

```bash
npm publish --access public --tag "$NPM_TAG" --verbose 2>&1 | tee publish.log || {
  echo "Publish failed!"
  exit 1
}
```

In bash, the exit code of a pipeline is taken from the **last** command (`tee`), not from `npm publish`. Since `tee` always exits 0, the `|| { exit 1 }` handler never fires even when `npm publish` fails. The step reports success and the workflow continues normally — creating tags, GitHub releases, and success comments — while the package was never actually published to npm.

This is what happened in PR #231: all three release runs (`@phala/cloud@0.2.7`, `phala@1.1.15`, `phala@1.1.16`) silently failed at publish but the workflow reported `completed: success`.

## Fix

Add `set -o pipefail` at the top of the step. This makes bash treat a pipeline as failed if any command in it fails, so `npm publish` failures will now correctly propagate and fail the step.

## Note

The publish failures in PR #231 were also caused by OIDC Trusted Publishers not being configured on npmjs.com for `phala` and `@phala/cloud`. That requires a separate fix in the npmjs package settings. Once Trusted Publishers are configured, those releases will need to be re-triggered.