### PR TITLE
ci: use vars.CI_RUNNER for configurable runner selection

### DIFF
--- a/.github/workflows/cli-checks.yml
+++ b/.github/workflows/cli-checks.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   cli-checks:
     name: CLI Checks
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     defaults:
       run:
         working-directory: cli

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   js-sdk-checks:
     name: JavaScript SDK Checks
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -141,7 +141,7 @@ jobs:
 
   python-sdk-checks:
     name: Python SDK Checks (non-e2e)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -170,7 +170,7 @@ jobs:
 
   compatibility-checks:
     name: Compatibility Checks
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     strategy:
       matrix:
         node-version: ['18', '20', '22']
@@ -244,7 +244,7 @@ jobs:
 
   browser-compatibility:
     name: Browser Compatibility
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   comment:
     name: Post Check Results
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     if: >
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion != 'cancelled'

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   commitlint:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -41,7 +41,7 @@ jobs:
        contains(github.event.comment.body, '!Release') ||
        contains(github.event.comment.body, '!RELEASE')) &&
       github.event.comment.user.type != 'Bot'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     outputs:
       should_release: ${{ steps.parse.outputs.should_release }}
       release_type: ${{ steps.parse.outputs.release_type }}
@@ -202,7 +202,7 @@ jobs:
     concurrency:
       group: release-go-${{ github.event_name == 'workflow_dispatch' && inputs.ref || needs.parse.outputs.ref }}
       cancel-in-progress: false
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     env:
       RELEASE_TYPE: ${{ github.event_name == 'workflow_dispatch' && inputs.release_type || needs.parse.outputs.release_type }}
       PRERELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || needs.parse.outputs.prerelease }}

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -52,7 +52,7 @@ jobs:
        contains(github.event.comment.body, '!Release') ||
        contains(github.event.comment.body, '!RELEASE')) &&
       github.event.comment.user.type != 'Bot'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     outputs:
       should_release: ${{ steps.parse.outputs.should_release }}
       package: ${{ steps.parse.outputs.package }}
@@ -230,7 +230,7 @@ jobs:
     concurrency:
       group: release-${{ github.event_name == 'workflow_dispatch' && inputs.package || needs.parse.outputs.package }}-${{ github.event_name == 'workflow_dispatch' && inputs.ref || needs.parse.outputs.ref }}
       cancel-in-progress: false
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     env:
       PACKAGE: ${{ github.event_name == 'workflow_dispatch' && inputs.package || needs.parse.outputs.package }}
       RELEASE_TYPE: ${{ github.event_name == 'workflow_dispatch' && inputs.release_type || needs.parse.outputs.release_type }}

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -42,7 +42,7 @@ jobs:
        contains(github.event.comment.body, '!Release') ||
        contains(github.event.comment.body, '!RELEASE')) &&
       github.event.comment.user.type != 'Bot'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     outputs:
       should_release: ${{ steps.parse.outputs.should_release }}
       release_type: ${{ steps.parse.outputs.release_type }}
@@ -203,7 +203,7 @@ jobs:
     concurrency:
       group: release-python-${{ github.event_name == 'workflow_dispatch' && inputs.ref || needs.parse.outputs.ref }}
       cancel-in-progress: false
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     environment: pypi
     env:
       RELEASE_TYPE: ${{ github.event_name == 'workflow_dispatch' && inputs.release_type || needs.parse.outputs.release_type }}

--- a/.github/workflows/validate-config.yml
+++ b/.github/workflows/validate-config.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Summary
- Replace hardcoded `ubuntu-latest` with `${{ vars.CI_RUNNER || 'ubuntu-latest' }}` across all 8 workflow files
- Matches the pattern already used in the teehouse repo's pr-checks.yml
- Set the `CI_RUNNER` repo variable to switch runners (e.g. self-hosted/blacksmith); defaults to `ubuntu-latest` when unset

## Files changed
- `.github/workflows/pr-checks.yml` (4 jobs)
- `.github/workflows/cli-checks.yml`
- `.github/workflows/pr-comment.yml`
- `.github/workflows/pr-lint.yml`
- `.github/workflows/validate-config.yml`
- `.github/workflows/release-npm.yml` (2 jobs)
- `.github/workflows/release-go.yml` (2 jobs)
- `.github/workflows/release-python.yml` (2 jobs)

## Test plan
- [ ] Verify CI runs pass on this PR (using default ubuntu-latest)
- [ ] Set `CI_RUNNER` repo variable and confirm subsequent runs use the configured runner