### PR TITLE
feat(go): sync JS SDK v0.2.8 updates

### DIFF
--- a/go/apps.go
+++ b/go/apps.go
@@ -33,6 +33,15 @@ func (c *Client) GetAppCVMs(ctx context.Context, appID string) ([]GenericObject,
 	return result, nil
 }
 
+// CreateAppInstance creates a new CVM instance under an existing app.
+func (c *Client) CreateAppInstance(ctx context.Context, appID string, req *CreateAppInstanceRequest) (*CVMInfo, error) {
+	var result CVMInfo
+	if err := c.doJSON(ctx, "POST", "/apps/"+appID+"/instances", req, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // ReplicateAppCVM creates a replica of a CVM within an application context.
 // This uses the app-scoped endpoint POST /apps/{appID}/cvms/{vmUUID}/replicas
 // to ensure the new replica is associated with the correct app.

--- a/go/apps_test.go
+++ b/go/apps_test.go
@@ -1,0 +1,62 @@
+package phala
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCreateAppInstance(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/apps/app-123/instances" {
+			t.Errorf("path = %q, want /apps/app-123/instances", r.URL.Path)
+		}
+
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["node_id"] != float64(5) {
+			t.Errorf("node_id = %v, want 5", body["node_id"])
+		}
+		if body["docker_compose_file"] != "services:\n  app:\n    image: nginx" {
+			t.Errorf("docker_compose_file = %v", body["docker_compose_file"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "cvm-456",
+			"name":     "instance-1",
+			"resource": map[string]any{"instance_type": "cpu-2"},
+			"status":   "running",
+		})
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(WithAPIKey("k"), WithBaseURL(srv.URL))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	dockerCompose := "services:\n  app:\n    image: nginx"
+	nodeID := 5
+	result, err := client.CreateAppInstance(context.Background(), "app-123", &CreateAppInstanceRequest{
+		NodeID:            &nodeID,
+		DockerComposeFile: &dockerCompose,
+	})
+	if err != nil {
+		t.Fatalf("CreateAppInstance: %v", err)
+	}
+	if result.ID != "cvm-456" {
+		t.Errorf("ID = %q, want cvm-456", result.ID)
+	}
+	if result.Status != "running" {
+		t.Errorf("Status = %q, want running", result.Status)
+	}
+}

--- a/go/errors.go
+++ b/go/errors.go
@@ -84,6 +84,38 @@ func (e *APIError) IsComposePrecondition() bool {
 	return e.StatusCode == 465
 }
 
+// ComposePrecondition extracts a structured compose-hash precondition response from a 465 error.
+// It returns the populated response and true when the error contains the required fields.
+func (e *APIError) ComposePrecondition() (*ComposeHashPreconditionResponse, bool) {
+	if !e.IsComposePrecondition() {
+		return nil, false
+	}
+	fieldMap := make(map[string]any)
+	for _, d := range e.Details {
+		if d.Field != "" {
+			fieldMap[d.Field] = d.Value
+		}
+	}
+	composeHash, _ := fieldMap["compose_hash"].(string)
+	appID, _ := fieldMap["app_id"].(string)
+	if composeHash == "" || appID == "" {
+		return nil, false
+	}
+	deviceID, _ := fieldMap["device_id"].(string)
+	var kmsInfo *KMSInfo
+	if v, ok := fieldMap["kms_info"]; ok {
+		b, _ := json.Marshal(v)
+		_ = json.Unmarshal(b, &kmsInfo)
+	}
+	return &ComposeHashPreconditionResponse{
+		Message:     e.Message,
+		ComposeHash: composeHash,
+		AppID:       appID,
+		DeviceID:    deviceID,
+		KMSInfo:     kmsInfo,
+	}, true
+}
+
 // RetryAfter returns the duration to wait before retrying, based on the Retry-After header.
 // Returns 0 if the header is not present or cannot be parsed.
 func (e *APIError) RetryAfter() time.Duration {

--- a/go/errors_test.go
+++ b/go/errors_test.go
@@ -131,3 +131,68 @@ func TestAPIError_RetryAfter(t *testing.T) {
 		}
 	})
 }
+
+func TestAPIError_ComposePrecondition(t *testing.T) {
+	t.Run("non-465 returns false", func(t *testing.T) {
+		e := &APIError{StatusCode: 400}
+		if _, ok := e.ComposePrecondition(); ok {
+			t.Fatal("expected false for non-465")
+		}
+	})
+
+	t.Run("465 without required fields returns false", func(t *testing.T) {
+		e := &APIError{StatusCode: 465, Message: "missing fields"}
+		if _, ok := e.ComposePrecondition(); ok {
+			t.Fatal("expected false when compose_hash/app_id missing")
+		}
+	})
+
+	t.Run("465 with structured details", func(t *testing.T) {
+		e := &APIError{
+			StatusCode: 465,
+			Message:    "Compose hash registration required",
+			Details: []ErrorDetail{
+				{Field: "compose_hash", Value: "0xhash123"},
+				{Field: "app_id", Value: "0xapp456"},
+				{Field: "device_id", Value: "0xdevice789"},
+				{Field: "kms_info", Value: map[string]any{
+					"id":                   "kms_test",
+					"slug":                 "kms-base-prod9",
+					"url":                  "https://kms.example.com",
+					"version":              "v0.5.7",
+					"chain_id":             8453,
+					"kms_contract_address": "0xkms123",
+					"gateway_app_id":       "0xgateway456",
+				}},
+			},
+		}
+		precond, ok := e.ComposePrecondition()
+		if !ok {
+			t.Fatal("expected true")
+		}
+		if precond.ComposeHash != "0xhash123" {
+			t.Errorf("ComposeHash = %q, want 0xhash123", precond.ComposeHash)
+		}
+		if precond.AppID != "0xapp456" {
+			t.Errorf("AppID = %q, want 0xapp456", precond.AppID)
+		}
+		if precond.DeviceID != "0xdevice789" {
+			t.Errorf("DeviceID = %q, want 0xdevice789", precond.DeviceID)
+		}
+		if precond.KMSInfo == nil {
+			t.Fatal("expected KMSInfo")
+		}
+		if precond.KMSInfo == nil {
+			t.Fatal("expected KMSInfo")
+		}
+		if precond.KMSInfo.ID != "kms_test" {
+			t.Errorf("KMSInfo.ID = %q, want kms_test", precond.KMSInfo.ID)
+		}
+		if precond.KMSInfo.KMSContractAddress == nil || *precond.KMSInfo.KMSContractAddress != "0xkms123" {
+			t.Errorf("KMSInfo.KMSContractAddress = %v, want 0xkms123", precond.KMSInfo.KMSContractAddress)
+		}
+		if precond.KMSInfo.ChainID == nil || *precond.KMSInfo.ChainID != 8453 {
+			t.Errorf("KMSInfo.ChainID = %v, want 8453", precond.KMSInfo.ChainID)
+		}
+	})
+}

--- a/go/request_compat_test.go
+++ b/go/request_compat_test.go
@@ -33,6 +33,36 @@ func TestCVMInfo_UnmarshalPreservesEndpointInstance(t *testing.T) {
 	}
 }
 
+func TestProvisionCVMResponse_UnmarshalComposeHashRegistered(t *testing.T) {
+	var resp ProvisionCVMResponse
+	err := json.Unmarshal([]byte(`{
+		"app_id":"app_1",
+		"compose_hash":"hash123",
+		"compose_hash_registered":true
+	}`), &resp)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !resp.ComposeHashRegistered {
+		t.Fatalf("ComposeHashRegistered = %v, want true", resp.ComposeHashRegistered)
+	}
+	if resp.ComposeHash != "hash123" {
+		t.Fatalf("ComposeHash = %q, want hash123", resp.ComposeHash)
+	}
+
+	var respFalse ProvisionCVMResponse
+	err = json.Unmarshal([]byte(`{
+		"app_id":"app_1",
+		"compose_hash":"hash456"
+	}`), &respFalse)
+	if err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if respFalse.ComposeHashRegistered {
+		t.Fatalf("ComposeHashRegistered = %v, want false", respFalse.ComposeHashRegistered)
+	}
+}
+
 func TestDo_PreservesStructuredErrorDetailValues(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/go/types_apps.go
+++ b/go/types_apps.go
@@ -1,5 +1,16 @@
 package phala
 
+// CreateAppInstanceRequest is the request body for creating an app instance.
+type CreateAppInstanceRequest struct {
+	NodeID            *int    `json:"node_id,omitempty"`
+	DockerComposeFile *string `json:"docker_compose_file,omitempty"`
+	PreLaunchScript   *string `json:"pre_launch_script,omitempty"`
+	EncryptedEnv      *string `json:"encrypted_env,omitempty"`
+	ComposeHash       *string `json:"compose_hash,omitempty"`
+	Token             *string `json:"token,omitempty"`
+	TransactionHash   *string `json:"transaction_hash,omitempty"`
+}
+
 // AppInfo represents application information.
 type AppInfo struct {
 	ID               string      `json:"id"`

--- a/go/types_common.go
+++ b/go/types_common.go
@@ -31,7 +31,7 @@ type UpdateResult struct {
 	Message     string `json:"message,omitempty"`
 
 	// KMS info for on-chain operations.
-	KMSInfo *CvmKmsInfo `json:"kms_info,omitempty"`
+	KMSInfo *KMSInfo `json:"kms_info,omitempty"`
 }
 
 // InProgressResponse is returned for operations that are in progress.
@@ -42,9 +42,9 @@ type InProgressResponse struct {
 
 // ComposeHashPreconditionResponse is returned when compose hash precondition fails (465).
 type ComposeHashPreconditionResponse struct {
-	Message     string      `json:"message"`
-	ComposeHash string      `json:"compose_hash"`
-	AppID       string      `json:"app_id"`
-	DeviceID    string      `json:"device_id"`
-	KMSInfo     *CvmKmsInfo `json:"kms_info,omitempty"`
+	Message     string   `json:"message"`
+	ComposeHash string   `json:"compose_hash"`
+	AppID       string   `json:"app_id"`
+	DeviceID    string   `json:"device_id"`
+	KMSInfo     *KMSInfo `json:"kms_info,omitempty"`
 }

--- a/go/types_cvms.go
+++ b/go/types_cvms.go
@@ -80,6 +80,23 @@ type CvmKmsInfo struct {
 	EncryptedEnvPubkey *string `json:"encrypted_env_pubkey,omitempty"`
 }
 
+// ChainName returns a human-readable chain name based on ChainID.
+func (k *CvmKmsInfo) ChainName() string {
+	if k == nil || k.ChainID == nil {
+		return ""
+	}
+	switch *k.ChainID {
+	case 1:
+		return "Ethereum"
+	case 8453:
+		return "Base"
+	case 31337:
+		return "Anvil"
+	default:
+		return ""
+	}
+}
+
 // CvmProgressInfo holds CVM progress information.
 type CvmProgressInfo struct {
 	Target        *string `json:"target,omitempty"`

--- a/go/types_cvms.go
+++ b/go/types_cvms.go
@@ -180,16 +180,17 @@ type ComposeFile struct {
 
 // ProvisionCVMResponse is the response from provisioning a CVM.
 type ProvisionCVMResponse struct {
-	AppID               string      `json:"app_id"`
-	ComposeHash         string      `json:"compose_hash"`
-	AppEnvEncryptPubkey string      `json:"app_env_encrypt_pubkey,omitempty"`
-	KMSInfo             *CvmKmsInfo `json:"kms_info,omitempty"`
-	FMSPC               string      `json:"fmspc,omitempty"`
-	DeviceID            string      `json:"device_id,omitempty"`
-	OSImageHash         string      `json:"os_image_hash,omitempty"`
-	InstanceType        string      `json:"instance_type,omitempty"`
-	NodeID              *int        `json:"node_id,omitempty"`
-	KMSID               string      `json:"kms_id,omitempty"`
+	AppID                 string      `json:"app_id"`
+	ComposeHash           string      `json:"compose_hash"`
+	AppEnvEncryptPubkey   string      `json:"app_env_encrypt_pubkey,omitempty"`
+	KMSInfo               *CvmKmsInfo `json:"kms_info,omitempty"`
+	FMSPC                 string      `json:"fmspc,omitempty"`
+	DeviceID              string      `json:"device_id,omitempty"`
+	OSImageHash           string      `json:"os_image_hash,omitempty"`
+	InstanceType          string      `json:"instance_type,omitempty"`
+	NodeID                *int        `json:"node_id,omitempty"`
+	KMSID                 string      `json:"kms_id,omitempty"`
+	ComposeHashRegistered bool        `json:"compose_hash_registered,omitempty"`
 }
 
 // CommitCVMProvisionRequest is the request for committing a CVM provision.

--- a/go/types_cvms_test.go
+++ b/go/types_cvms_test.go
@@ -1,0 +1,34 @@
+package phala
+
+import "testing"
+
+func TestCvmKmsInfo_ChainName(t *testing.T) {
+	tests := []struct {
+		name    string
+		chainID *int
+		want    string
+	}{
+		{"base", intPtr(8453), "Base"},
+		{"mainnet", intPtr(1), "Ethereum"},
+		{"anvil", intPtr(31337), "Anvil"},
+		{"unknown", intPtr(99999), ""},
+		{"nil", nil, ""},
+		{"nil receiver", nil, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var k *CvmKmsInfo
+			if tt.name != "nil receiver" {
+				k = &CvmKmsInfo{ChainID: tt.chainID}
+			}
+			if got := k.ChainName(); got != tt.want {
+				t.Errorf("ChainName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func intPtr(v int) *int {
+	return &v
+}


### PR DESCRIPTION
## Summary

Syncs Go SDK with JS SDK v0.2.8 changes (since 2026-03-27).

### Changes
- **feat**: add `ComposeHashRegistered` to `ProvisionCVMResponse`
- **feat**: add `APIError.ComposePrecondition()` helper to extract `compose_hash`/`app_id`/`device_id`/`kms_info` from the `StructuredError` `details` array on 465 responses
- **fix**: change `ComposeHashPreconditionResponse.KMSInfo` and `UpdateResult.KMSInfo` from `*CvmKmsInfo` to `*KMSInfo` to match actual API responses
- **feat**: add `CvmKmsInfo.ChainName()` helper mapping `ChainID` to human-readable names (Ethereum/Base/Anvil)

### Tests
- `request_compat_test.go`: unmarshal test for `ComposeHashRegistered`
- `errors_test.go`: 3 sub-tests for `ComposePrecondition()`
- `types_cvms_test.go`: 6 sub-tests for `ChainName()`
- All Go tests pass.