### PR TITLE
docs: remove broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ If you want to integrate the SDK into your existing apps, here are the SDKs we c
 - [**MOOF MCP**](https://github.com/moofdotfun/MOOF-MCP) - An MCP server enables LLMs to work with the MOOF platform, deployed on Phala Cloud. It can list flows, create new flows, and deploy other MCP servers on Phala Cloud. Additionally, it supports fetching public flow templates, forking flows from templates, retrieving authenticated user flows, publishing or unpublishing flows to/from the shared flow store, and deploying MCP servers directly from GitHub with optional Phala hosting and environment variable support. *by MOOF*
 - [**DeMCP Defillama**](https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/demap-defilama) - A DeFiLlama MCP server deployed on Phala Cloud that enables AI agents to fetch real-time DeFi data, including protocol TVL (Total Value Locked), chain metrics, and token prices. *by DeMCP*
 - [**Context7 MCP**](https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/context7-mcp) - A Context7 MCP server deployed on Phala Cloud that enables AI agents to fetch real-time Context7 data, including protocol TVL (Total Value Locked), chain metrics, and token prices. *by Phala-Network*
-- [**MCP Server Fetch**](https://github.com/Phala-Network/mcp-servers/tree/main/src/fetch) - A MCP server deployed on Phala Cloud that enables AI agents to fetch real-time data from a given URL. *by Leechael*
-- [**MCP Server Sequential Thinking**](https://github.com/Phala-Network/mcp-servers/tree/main/src/sequentialthinking) - A MCP server deployed on Phala Cloud that enables AI agents to think sequentially. *by Leechael*
+- [**MCP Server Fetch**](https://github.com/Leechael/mcp-servers/tree/main/src/fetch) - A MCP server deployed on Phala Cloud that enables AI agents to fetch real-time data from a given URL. *by Leechael*
+- [**MCP Server Sequential Thinking**](https://github.com/Leechael/mcp-servers/tree/main/src/sequentialthinking) - A MCP server deployed on Phala Cloud that enables AI agents to think sequentially. *by Leechael*
 - [**Swarms Agent in Phala TEE**](https://github.com/The-Swarm-Corporation/Phala-Deployment-Template) - A Swarms agent deployed on Phala Cloud that perform a comprehensive legal team swarm for contract creation and management. *by The-Swarm-Corporation*
 - [**Armor Crypto**](https://github.com/HashWarlock/armor-crypto-mcp/tree/phala-mcp) - A single source for integrating AI Agents with the Crypto ecosystem. This includes Wallet creation and management, swaps, transfers, event-based trades like DCA, stop loss and take profit, and much more. The Armor MCP supports Solana in Alpha and, when in beta, will support more than a dozen blockchains, including Ethereum. Base, Avalanche, Bitcoin, Sui, Berachain, megaETH, Optimism, Ton, BNB, and Arbitrum, among others. Using Armor's MCP you can bring all of crypto into your AI Agent with unified logic and a complete set of tools. *by Armor Crypto*
 - [**Moralis MCP**](https://github.com/HashWarlock/moralis-mcp-server) - The Moralis MCP Server is a local or cloud-deployable engine that connects natural language prompts to real blockchain insights — allowing AI models to query wallet activity, token metrics, dapp usage, and more without custom code or SQL. *by Moralis*
@@ -99,7 +99,7 @@ If you want to integrate the SDK into your existing apps, here are the SDKs we c
 
 ### Other Templates
 
-- [**n8n Workflow Automation**](https://github.com/Phala-Network/phala-cloud/tree/main/templates/n8n) - A powerful workflow automation tool deployed on Phala Cloud with OAuth2 authentication fixes for TEE environment. Build complex automations, integrate with 400+ services, and run workflows securely within the TEE. *by n8n*
+- [**n8n Workflow Automation**](https://github.com/Marvin-Cypher/phala-n8n-template) - A powerful workflow automation tool deployed on Phala Cloud with OAuth2 authentication fixes for TEE environment. Build complex automations, integrate with 400+ services, and run workflows securely within the TEE. *by n8n*
 - [**Maybe Finance**](https://github.com/Phala-Network/phala-cloud/tree/main/templates/maybe-ai) - A comprehensive open-source personal finance management app deployed on Phala Cloud. Track expenses, budgets, investments, and net worth with bank syncing, AI insights, and beautiful analytics - all secured within TEE infrastructure. *by Maybe Finance*
 - [**Anyone Anon Service**](https://github.com/rA3ka/dstack-examples/tree/main/anyone-anon-service) - Sets up a Anyone Anon (hidden) service and serves an nginx website from that. *by Anyone*
 - [**Anyone Network Relay**](https://github.com/rA3ka/anon-relay-docker/tree/main) - Set up a Anon relay and participate in expanding the Anyone Network by providing bandwidth to earn recognition rewards. *by Anyone*
@@ -116,7 +116,7 @@ If you want to integrate the SDK into your existing apps, here are the SDKs we c
 
 Phala Cloud API allows you to build your own applications programmatically. It offers all the features availabe on the Cloud Platform.
 
-- [Phala Cloud SDK](/js)
+- [Phala Cloud SDK](./js)
 - [Phala Cloud API](https://cloud-api.phala.network/docs)
 - [Cloud API Examples](https://github.com/Leechael/phala-cloud-api-example) (by @Leechael)
 - [Phala Cloud CLI](https://github.com/Phala-Network/tee-cloud-cli.git)

--- a/templates/prebuilt/bytebot/README.md
+++ b/templates/prebuilt/bytebot/README.md
@@ -188,7 +188,6 @@ For production deployments, consider:
 
 - Join the [ByteBot Discord Community](https://discord.gg/zcb5wA2t4u)
 - Report issues on [GitHub](https://github.com/bytebot-ai/bytebot)
-- Check the [ByteBot Blog](https://bytebot.ai/blog) for updates
 
 ---
 

--- a/templates/prebuilt/near-shade-agent/README.md
+++ b/templates/prebuilt/near-shade-agent/README.md
@@ -261,7 +261,7 @@ ls -la /var/run/tappd.sock
 ### Getting Help
 
 - Review the [NEAR Protocol documentation](https://docs.near.org/)
-- Check [Phala Cloud documentation](https://docs.phala.network/developers/dstack)
+- Check [Phala Cloud documentation](https://docs.phala.com/phala-cloud/getting-started/overview)
 - Submit issues to the [template repository](https://github.com/HashWarlock/shade-agent-template/issues)
 
 ## Security Considerations
@@ -295,7 +295,7 @@ ls -la /var/run/tappd.sock
 
 - [NEAR Shade Agent Template Repository](https://github.com/HashWarlock/shade-agent-template/tree/phala-cloud)
 - [NEAR Protocol Documentation](https://docs.near.org/)
-- [Phala Cloud TEE Documentation](https://docs.phala.network/developers/dstack)
+- [Phala Cloud TEE Documentation](https://docs.phala.com/phala-cloud/getting-started/overview)
 - [Phala Cloud Dashboard](https://cloud.phala.com/dashboard/)
 
 ## Contributing


### PR DESCRIPTION
## Summary
- replace broken README links with working destinations
- update the NEAR Shade Agent docs links to the current Phala Cloud docs URL
- remove the dead ByteBot blog link

## Verification
- prek
- checked the updated public links in README.md and templates/prebuilt/{near-shade-agent,bytebot}/README.md