### PR TITLE
Fix n8n Phala Cloud template

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -326,18 +326,27 @@
   {
     "id": "n8n-automation",
     "name": "n8n Workflow Automation",
-    "description": "Deploy n8n workflow automation platform on Phala Cloud's secure TEE infrastructure. Connect 400+ services, automate business processes, and create complex workflows with a visual interface. Features secure OAuth integration, encrypted credential storage, and confidential workflow execution.",
-    "repo": "https://github.com/Marvin-Cypher/phala-n8n-template",
-    "author": "Marvin-Cypher",
+    "description": "Deploy n8n workflow automation platform on Phala Cloud's secure TEE infrastructure. Connect 400+ services, automate business processes, and create workflows with a visual interface. Uses Phala's HTTPS app domain for webhooks and OAuth callbacks, with n8n user management and encrypted credential storage.",
+    "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/n8n",
+    "author": "Phala-Network",
     "icon": "n8n.png",
     "envs": [
-      { "key": "N8N_USER", "required": true },
-      { "key": "N8N_PASSWORD", "required": true },
-      { "key": "N8N_ENCRYPTION_KEY", "required": false },
+      {
+        "key": "N8N_ENCRYPTION_KEY",
+        "required": true,
+        "description": "Stable encryption key for n8n credentials. Generate with: openssl rand -hex 32"
+      },
+      {
+        "key": "GENERIC_TIMEZONE",
+        "required": false,
+        "default": "UTC",
+        "description": "Timezone for schedule-oriented n8n nodes"
+      },
       { "key": "OPENAI_API_KEY", "required": false },
       { "key": "GOOGLE_OAUTH_CLIENT_ID", "required": false },
       { "key": "GOOGLE_OAUTH_CLIENT_SECRET", "required": false }
     ],
+    "defaultResource": { "vCPU": 2, "memory": 4096, "diskSize": 40 },
     "tags": ["Automation", "Workflow", "Integration"]
   },
   {

--- a/templates/prebuilt/n8n/README.md
+++ b/templates/prebuilt/n8n/README.md
@@ -1,0 +1,33 @@
+# n8n Workflow Automation
+
+Deploy n8n on Phala Cloud with a compose file that works with Phala's built-in HTTPS app domain.
+
+## Configuration
+
+Set these encrypted secrets when deploying:
+
+- `N8N_ENCRYPTION_KEY` - Required. Generate with `openssl rand -hex 32` and keep the same value for this instance.
+- `GENERIC_TIMEZONE` - Optional. Defaults to `UTC`.
+- `OPENAI_API_KEY` - Optional, for AI workflows.
+- `GOOGLE_OAUTH_CLIENT_ID` - Optional, for Google integrations.
+- `GOOGLE_OAUTH_CLIENT_SECRET` - Optional, for Google integrations.
+
+Phala Cloud injects `DSTACK_APP_DOMAIN` automatically. The compose file uses it for `WEBHOOK_URL` and `N8N_EDITOR_BASE_URL`, so OAuth callbacks and webhooks use the public HTTPS app URL.
+
+## First Run
+
+After deployment, open the app URL shown by Phala Cloud. n8n displays its owner-account setup screen on first launch. n8n basic auth environment variables were removed upstream in n8n 1.0, so this template uses n8n's built-in user management flow.
+
+## OAuth Callback URL
+
+For OAuth providers such as Google, use:
+
+```text
+https://<your-phala-app-domain>/rest/oauth2-credential/callback
+```
+
+## Notes
+
+- The service is exposed as `80:5678` so Phala's default app domain routes directly to n8n.
+- n8n data persists in the `n8n_data` Docker volume.
+- Keep `N8N_ENCRYPTION_KEY` stable. Changing it can prevent n8n from decrypting stored credentials.

--- a/templates/prebuilt/n8n/docker-compose.yml
+++ b/templates/prebuilt/n8n/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  n8n:
+    image: docker.n8n.io/n8nio/n8n
+    restart: unless-stopped
+    ports:
+      - "80:5678"
+    volumes:
+      - /var/run/dstack.sock:/var/run/dstack.sock
+      - n8n_data:/home/node/.n8n
+    environment:
+      - NODE_ENV=production
+      - N8N_HOST=${DSTACK_APP_DOMAIN:-localhost}
+      - N8N_PORT=5678
+      - N8N_PROTOCOL=${N8N_PROTOCOL:-https}
+      - N8N_EDITOR_BASE_URL=${N8N_PROTOCOL:-https}://${DSTACK_APP_DOMAIN:-localhost}/
+      - WEBHOOK_URL=${N8N_PROTOCOL:-https}://${DSTACK_APP_DOMAIN:-localhost}/
+      - N8N_ENCRYPTION_KEY=${N8N_ENCRYPTION_KEY}
+      - N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS=true
+      - GENERIC_TIMEZONE=${GENERIC_TIMEZONE:-UTC}
+      - TZ=${GENERIC_TIMEZONE:-UTC}
+      - N8N_SECURE_COOKIE=${N8N_SECURE_COOKIE:-true}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - GOOGLE_OAUTH_CLIENT_ID=${GOOGLE_OAUTH_CLIENT_ID}
+      - GOOGLE_OAUTH_CLIENT_SECRET=${GOOGLE_OAUTH_CLIENT_SECRET}
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:5678/healthz || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+volumes:
+  n8n_data:
+    driver: local


### PR DESCRIPTION
## Summary
- add an official in-repo n8n prebuilt template under templates/prebuilt/n8n
- update the template catalog entry to point at the official Phala Cloud repo path
- remove obsolete n8n basic-auth env prompts and use DSTACK_APP_DOMAIN for webhooks/OAuth URLs

## Validation
- python3 templates/validate.py
- docker compose -f templates/prebuilt/n8n/docker-compose.yml config