### PR TITLE
fix(cli): resolve viem chain from chain_id during prepare/commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,10 @@ repos:
         priority: 30
 
       # ── JS SDK (js/) ────────────────────────────────────────────────────
-      # Mirrors release-npm.yml: lint → type-check → test (build is covered by CI).
+      # Mirrors release-npm.yml: lint → type-check → build → test. The build
+      # step is required because CLI tests consume @phala/cloud via workspace
+      # link to js/dist; a stale or missing js/dist masks real failures and
+      # also breaks downstream cli tests when js code is the thing that changed.
       - id: biome-js
         name: Biome (JS SDK)
         entry: bash -c 'cd js && bun run lint'
@@ -54,6 +57,15 @@ repos:
         types_or: [javascript, ts, tsx, jsx]
         pass_filenames: false
         priority: 20
+      - id: build-js
+        name: Build (JS SDK)
+        entry: bash -c 'cd js && bun run build'
+        language: system
+        files: ^js/
+        types_or: [javascript, ts, tsx, jsx]
+        pass_filenames: false
+        require_serial: true
+        priority: 25
       - id: test-js
         name: JS SDK tests
         entry: bash -c 'cd js && bun run test'
@@ -65,9 +77,10 @@ repos:
         priority: 30
 
       # ── CLI (cli/) ──────────────────────────────────────────────────────
-      # Mirrors release-npm.yml: lint → type-check → test. CLI consumes
-      # @phala/cloud via workspace link to js/dist, so a stale js/dist can
-      # mask real issues; rebuild js before committing if you've changed it.
+      # Mirrors release-npm.yml: lint → type-check → build → test. CLI tests
+      # spawn `bun cli/dist/index.js --help` for interface-compat checks, so
+      # the build step is mandatory — without it dist/index.js is missing and
+      # all the spawn-based tests silently fail with empty stdout.
       - id: biome-cli
         name: Biome (CLI)
         entry: bash -c 'cd cli && bun run lint'
@@ -84,6 +97,15 @@ repos:
         types_or: [javascript, ts, tsx, jsx]
         pass_filenames: false
         priority: 20
+      - id: build-cli
+        name: Build (CLI)
+        entry: bash -c 'cd cli && bun run build'
+        language: system
+        files: ^cli/
+        types_or: [javascript, ts, tsx, jsx]
+        pass_filenames: false
+        require_serial: true
+        priority: 25
       - id: test-cli
         name: CLI tests
         entry: bash -c 'cd cli && bun run test'

--- a/cli/src/commands/cvms/replicate/index.ts
+++ b/cli/src/commands/cvms/replicate/index.ts
@@ -6,6 +6,7 @@ import {
 	type Client,
 	type ErrorLink,
 	type EnvVar,
+	SUPPORTED_CHAINS,
 	safeAddComposeHash,
 	safeAddDevice,
 	safeCheckOnChainPrerequisites,
@@ -410,17 +411,18 @@ async function runCvmsReplicateCommand(
 					"Replica prepare response did not include a commit token",
 				);
 			}
-			const chain = (
-				sourceCvm as {
-					kms_info?: {
-						chain?: Parameters<
-							typeof safeCheckOnChainPrerequisites
-						>[0]["chain"];
-					};
-				}
-			).kms_info?.chain;
+			// The SDK's CvmKmsInfo zod transform only injects `chain` when chain_id is in
+			// SUPPORTED_CHAINS, so unsupported chains would silently produce undefined.
+			// Resolve from chain_id directly for a clearer error.
+			const chainId = (sourceCvm as { kms_info?: { chain_id?: number } })
+				.kms_info?.chain_id;
+			const chain = chainId != null ? SUPPORTED_CHAINS[chainId] : undefined;
 			if (!chain) {
-				throw new Error("Source CVM kms_info is missing chain configuration");
+				throw new Error(
+					chainId != null
+						? `Source CVM chain id ${chainId} is not supported by this CLI build`
+						: "Source CVM kms_info is missing chain_id",
+				);
 			}
 			if (!sourceCvm.app_id) {
 				throw new Error(

--- a/cli/src/commands/deploy/handler.ts
+++ b/cli/src/commands/deploy/handler.ts
@@ -22,6 +22,7 @@ import {
 	MAX_COMPOSE_PAYLOAD_BYTES,
 	RequestError,
 	ResourceError,
+	SUPPORTED_CHAINS,
 	createClient,
 	encryptEnvVars,
 	formatStructuredError,
@@ -1252,9 +1253,23 @@ const updateCvm = async (
 			console.log("[DEBUG] patchCvm.deviceId:", result.deviceId);
 		}
 
+		// Resolve viem chain from chain_id. The SDK schema only injects `chain`
+		// when chain_id is in SUPPORTED_CHAINS, so resolving from chain_id directly
+		// gives a clearer error for unsupported chains.
+		const cvmChainId = cvm.kms_info?.chain_id;
+		const cvmChain =
+			cvmChainId != null ? SUPPORTED_CHAINS[cvmChainId] : undefined;
+		if (!cvmChain) {
+			throw new Error(
+				cvmChainId != null
+					? `CVM chain id ${cvmChainId} is not supported by this CLI build`
+					: "CVM kms_info is missing chain_id",
+			);
+		}
+
 		// Check on-chain prerequisites (device + compose hash status)
 		const prereqs = await safeCheckOnChainPrerequisites({
-			chain: cvm.kms_info?.chain,
+			chain: cvmChain,
 			rpcUrl: validatedOptions.rpcUrl,
 			appAddress: cvm.app_id as `0x${string}`,
 			deviceId: result.deviceId,
@@ -1277,7 +1292,7 @@ const updateCvm = async (
 		if (!prereqs.data.deviceAllowed) {
 			logger.info("Device not registered on-chain, adding...");
 			const deviceResult = await safeAddDevice({
-				chain: cvm.kms_info?.chain,
+				chain: cvmChain,
 				rpcUrl: validatedOptions.rpcUrl,
 				appAddress: cvm.app_id as `0x${string}`,
 				deviceId: result.deviceId,
@@ -1294,7 +1309,7 @@ const updateCvm = async (
 
 		// Register compose hash on-chain (idempotent — always send to get a real tx hash)
 		const receipt_result = await safeAddComposeHash({
-			chain: cvm.kms_info?.chain,
+			chain: cvmChain,
 			rpcUrl: validatedOptions.rpcUrl,
 			appId: cvm.app_id as `0x${string}`,
 			composeHash: result.composeHash,

--- a/cli/src/commands/deploy/handler.ts
+++ b/cli/src/commands/deploy/handler.ts
@@ -21,6 +21,7 @@ import {
 	CvmIdSchema,
 	MAX_COMPOSE_PAYLOAD_BYTES,
 	ResourceError,
+	SUPPORTED_CHAINS,
 	createClient,
 	encryptEnvVars,
 	formatStructuredError,
@@ -1127,9 +1128,23 @@ const updateCvm = async (
 			console.log("[DEBUG] patchCvm.deviceId:", result.deviceId);
 		}
 
+		// Resolve viem chain from chain_id. The SDK schema only injects `chain`
+		// when chain_id is in SUPPORTED_CHAINS, so resolving from chain_id directly
+		// gives a clearer error for unsupported chains.
+		const cvmChainId = cvm.kms_info?.chain_id;
+		const cvmChain =
+			cvmChainId != null ? SUPPORTED_CHAINS[cvmChainId] : undefined;
+		if (!cvmChain) {
+			throw new Error(
+				cvmChainId != null
+					? `CVM chain id ${cvmChainId} is not supported by this CLI build`
+					: "CVM kms_info is missing chain_id",
+			);
+		}
+
 		// Check on-chain prerequisites (device + compose hash status)
 		const prereqs = await safeCheckOnChainPrerequisites({
-			chain: cvm.kms_info?.chain,
+			chain: cvmChain,
 			rpcUrl: validatedOptions.rpcUrl,
 			appAddress: cvm.app_id as `0x${string}`,
 			deviceId: result.deviceId,
@@ -1152,7 +1167,7 @@ const updateCvm = async (
 		if (!prereqs.data.deviceAllowed) {
 			logger.info("Device not registered on-chain, adding...");
 			const deviceResult = await safeAddDevice({
-				chain: cvm.kms_info?.chain,
+				chain: cvmChain,
 				rpcUrl: validatedOptions.rpcUrl,
 				appAddress: cvm.app_id as `0x${string}`,
 				deviceId: result.deviceId,
@@ -1169,7 +1184,7 @@ const updateCvm = async (
 
 		// Register compose hash on-chain (idempotent — always send to get a real tx hash)
 		const receipt_result = await safeAddComposeHash({
-			chain: cvm.kms_info?.chain,
+			chain: cvmChain,
 			rpcUrl: validatedOptions.rpcUrl,
 			appId: cvm.app_id as `0x${string}`,
 			composeHash: result.composeHash,

--- a/cli/src/commands/instances/add/index.ts
+++ b/cli/src/commands/instances/add/index.ts
@@ -6,6 +6,7 @@ import {
 	type Client,
 	type ErrorLink,
 	type EnvVar,
+	SUPPORTED_CHAINS,
 	safeAddComposeHash,
 	safeAddDevice,
 	safeCheckOnChainPrerequisites,
@@ -370,17 +371,19 @@ async function runInstancesAddCommand(
 				throw new Error("Prepare response did not include a commit token");
 			}
 
-			const chain = (
-				preparePayload.kmsInfo as
-					| {
-							chain?: Parameters<
-								typeof safeCheckOnChainPrerequisites
-							>[0]["chain"];
-					  }
-					| undefined
-			)?.chain;
+			// The prepare payload comes from raw HTTP 465 error.structuredDetails, so it
+			// does NOT pass through the SDK's KmsInfoSchema zod transform that injects
+			// `chain`. Resolve from chain_id directly.
+			const chainId = (
+				preparePayload.kmsInfo as { chain_id?: number } | undefined
+			)?.chain_id;
+			const chain = chainId != null ? SUPPORTED_CHAINS[chainId] : undefined;
 			if (!chain) {
-				throw new Error("App KMS info is missing chain configuration");
+				throw new Error(
+					chainId != null
+						? `Chain id ${chainId} is not supported by this CLI build`
+						: "App KMS info is missing chain_id",
+				);
 			}
 
 			const prereqs = await safeCheckOnChainPrerequisites({

--- a/cli/src/commands/instances/add/index.ts
+++ b/cli/src/commands/instances/add/index.ts
@@ -6,6 +6,7 @@ import {
 	type Client,
 	type ErrorLink,
 	type EnvVar,
+	SUPPORTED_CHAINS,
 	safeAddComposeHash,
 	safeAddDevice,
 	safeCheckOnChainPrerequisites,
@@ -367,17 +368,19 @@ async function runInstancesAddCommand(
 				throw new Error("Prepare response did not include a commit token");
 			}
 
-			const chain = (
-				preparePayload.kmsInfo as
-					| {
-							chain?: Parameters<
-								typeof safeCheckOnChainPrerequisites
-							>[0]["chain"];
-					  }
-					| undefined
-			)?.chain;
+			// The prepare payload comes from raw HTTP 465 error.structuredDetails, so it
+			// does NOT pass through the SDK's KmsInfoSchema zod transform that injects
+			// `chain`. Resolve from chain_id directly.
+			const chainId = (
+				preparePayload.kmsInfo as { chain_id?: number } | undefined
+			)?.chain_id;
+			const chain = chainId != null ? SUPPORTED_CHAINS[chainId] : undefined;
 			if (!chain) {
-				throw new Error("App KMS info is missing chain configuration");
+				throw new Error(
+					chainId != null
+						? `Chain id ${chainId} is not supported by this CLI build`
+						: "App KMS info is missing chain_id",
+				);
 			}
 
 			const prereqs = await safeCheckOnChainPrerequisites({

--- a/js/src/actions/apps/get_app_attestation.test.ts
+++ b/js/src/actions/apps/get_app_attestation.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Client } from "../../client";
+import { getAppAttestation, safeGetAppAttestation } from "./get_app_attestation";
+
+function buildResponse(chainId: unknown) {
+  return {
+    app_id: "40c47977fd468f08e82021256be9d86877a176a2",
+    contract_address: "0x40c47977fd468f08e82021256be9d86877a176a2",
+    kms_info: {
+      contract_address: "0x2f83172A49584C017F2B256F0FB2Dca14126Ba9C",
+      chain_id: chainId,
+      version: "v0.5.7",
+      url: "https://kms.example.network",
+      gateway_app_id: "0x55760b065A3f1EAbdb1a4d7AbB94950f31B91A84",
+      gateway_app_url: "https://gateway.example.network",
+      kms_type: "base",
+    },
+    instances: [],
+    kms_guest_agent_info: null,
+    gateway_guest_agent_info: null,
+    qemu_version: "8.2.2",
+  };
+}
+
+describe("getAppAttestation", () => {
+  let client: Client;
+
+  beforeEach(() => {
+    client = new Client({ apiKey: "test-key", baseURL: "https://test-api.example.com" });
+  });
+
+  it("parses kms_info.chain_id as a number (backend returns int)", async () => {
+    vi.spyOn(client, "get").mockResolvedValue(buildResponse(8453));
+
+    const result = await getAppAttestation(client, { appId: "40c47977fd468f08e82021256be9d86877a176a2" });
+
+    expect(client.get).toHaveBeenCalledWith("/apps/40c47977fd468f08e82021256be9d86877a176a2/attestations");
+    expect(result.kms_info.chain_id).toBe(8453);
+  });
+
+  it("accepts a null chain_id (no-KMS branch)", async () => {
+    vi.spyOn(client, "get").mockResolvedValue(buildResponse(null));
+
+    const result = await safeGetAppAttestation(client, { appId: "app" });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.kms_info.chain_id).toBeNull();
+    }
+  });
+
+  it("rejects a string chain_id (guards against the old string schema)", async () => {
+    vi.spyOn(client, "get").mockResolvedValue(buildResponse("8453"));
+
+    const result = await safeGetAppAttestation(client, { appId: "app" });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/js/src/utils/errors.test.ts
+++ b/js/src/utils/errors.test.ts
@@ -13,6 +13,7 @@ import {
   formatValidationErrors,
   formatErrorMessage,
   formatStructuredError,
+  formatStructuredErrorDetailValue,
 } from "./errors";
 
 describe("parseApiError", () => {
@@ -667,5 +668,57 @@ describe("RequestError.fromFetchError with timeout/network errors", () => {
     expect(requestError.message).toContain("ECONNREFUSED");
     expect(requestError.detail).toContain("ECONNREFUSED");
     expect(requestError.detail).not.toBe("Unknown API error");
+  });
+});
+
+describe("formatStructuredErrorDetailValue", () => {
+  it("returns strings unchanged", () => {
+    expect(formatStructuredErrorDetailValue("hello")).toBe("hello");
+  });
+
+  it("stringifies numbers and booleans", () => {
+    expect(formatStructuredErrorDetailValue(7)).toBe("7");
+    expect(formatStructuredErrorDetailValue(true)).toBe("true");
+    expect(formatStructuredErrorDetailValue(false)).toBe("false");
+  });
+
+  it("returns empty string for null/undefined", () => {
+    expect(formatStructuredErrorDetailValue(null)).toBe("");
+    expect(formatStructuredErrorDetailValue(undefined)).toBe("");
+  });
+
+  it("serializes objects to JSON", () => {
+    expect(formatStructuredErrorDetailValue({ chain_id: 1, slug: "kms-eth" })).toBe(
+      '{"chain_id":1,"slug":"kms-eth"}',
+    );
+  });
+
+  it("serializes arrays to JSON", () => {
+    expect(formatStructuredErrorDetailValue([1, 2, 3])).toBe("[1,2,3]");
+  });
+});
+
+describe("formatStructuredError details rendering", () => {
+  it("renders dict and array values via JSON instead of [object Object]", () => {
+    const error = new ResourceError("Compose hash registration required", {
+      status: 465,
+      statusText: "Compose hash registration required",
+      detail: undefined,
+      errorCode: "ERR-01-005",
+      structuredDetails: [
+        { field: "compose_hash", value: "428faa5" },
+        {
+          field: "kms_info",
+          value: { chain_id: 1, slug: "kms-eth-prod7" },
+        },
+        { field: "extras", value: [1, 2, 3] },
+      ],
+    });
+
+    const formatted = formatStructuredError(error);
+    expect(formatted).toContain("compose_hash: 428faa5");
+    expect(formatted).toContain('kms_info: {"chain_id":1,"slug":"kms-eth-prod7"}');
+    expect(formatted).toContain("extras: [1,2,3]");
+    expect(formatted).not.toContain("[object Object]");
   });
 });

--- a/js/src/utils/errors.test.ts
+++ b/js/src/utils/errors.test.ts
@@ -12,6 +12,8 @@ import {
   getValidationFields,
   formatValidationErrors,
   formatErrorMessage,
+  formatStructuredError,
+  formatStructuredErrorDetailValue,
 } from "./errors";
 
 describe("parseApiError", () => {
@@ -526,5 +528,57 @@ describe("RequestError.fromFetchError with StructuredError responses", () => {
     const detail = error.detail as Record<string, unknown>;
     expect(detail.error_code).toBe("ERR-01-005");
     expect(Array.isArray(detail.details)).toBe(true);
+  });
+});
+
+describe("formatStructuredErrorDetailValue", () => {
+  it("returns strings unchanged", () => {
+    expect(formatStructuredErrorDetailValue("hello")).toBe("hello");
+  });
+
+  it("stringifies numbers and booleans", () => {
+    expect(formatStructuredErrorDetailValue(7)).toBe("7");
+    expect(formatStructuredErrorDetailValue(true)).toBe("true");
+    expect(formatStructuredErrorDetailValue(false)).toBe("false");
+  });
+
+  it("returns empty string for null/undefined", () => {
+    expect(formatStructuredErrorDetailValue(null)).toBe("");
+    expect(formatStructuredErrorDetailValue(undefined)).toBe("");
+  });
+
+  it("serializes objects to JSON", () => {
+    expect(formatStructuredErrorDetailValue({ chain_id: 1, slug: "kms-eth" })).toBe(
+      '{"chain_id":1,"slug":"kms-eth"}',
+    );
+  });
+
+  it("serializes arrays to JSON", () => {
+    expect(formatStructuredErrorDetailValue([1, 2, 3])).toBe("[1,2,3]");
+  });
+});
+
+describe("formatStructuredError details rendering", () => {
+  it("renders dict and array values via JSON instead of [object Object]", () => {
+    const error = new ResourceError("Compose hash registration required", {
+      status: 465,
+      statusText: "Compose hash registration required",
+      detail: undefined,
+      errorCode: "ERR-01-005",
+      structuredDetails: [
+        { field: "compose_hash", value: "428faa5" },
+        {
+          field: "kms_info",
+          value: { chain_id: 1, slug: "kms-eth-prod7" },
+        },
+        { field: "extras", value: [1, 2, 3] },
+      ],
+    });
+
+    const formatted = formatStructuredError(error);
+    expect(formatted).toContain("compose_hash: 428faa5");
+    expect(formatted).toContain('kms_info: {"chain_id":1,"slug":"kms-eth-prod7"}');
+    expect(formatted).toContain("extras: [1,2,3]");
+    expect(formatted).not.toContain("[object Object]");
   });
 });

--- a/js/src/utils/errors.ts
+++ b/js/src/utils/errors.ts
@@ -716,11 +716,37 @@ export function getErrorMessage(error: ApiError): string {
 
 /**
  * Structured error detail from new error format (ERR-xxxx codes)
+ *
+ * `value` is typed as `unknown` because the backend contract says it should be
+ * a primitive (string / number / boolean) but in practice some errors emit
+ * dict / array values (e.g. HashRegistrationRequired carries `kms_info` and
+ * `onchain_status` as objects). Consumers that need a string should use
+ * {@link formatStructuredErrorDetailValue}; consumers that need the original
+ * structure (e.g. CLI extracting `commit_token`) should access `value` directly.
  */
 export interface StructuredErrorDetail {
   field?: string;
   value?: unknown;
   message?: string;
+}
+
+/**
+ * Coerce a {@link StructuredErrorDetail} `value` to a renderable string.
+ *
+ * - `string` returned as-is
+ * - `number` / `boolean` stringified via `String(...)`
+ * - `null` / `undefined` returned as `""` so callers never interpolate `null` literally
+ * - anything else (dict, array) serialized via `JSON.stringify` with a fallback to `String(...)`
+ */
+export function formatStructuredErrorDetailValue(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
 }
 
 /**
@@ -886,7 +912,7 @@ export function formatStructuredError(
       if (d.message) {
         parts.push(`  - ${d.message}`);
       } else if (d.field && d.value !== undefined) {
-        parts.push(`  - ${d.field}: ${d.value}`);
+        parts.push(`  - ${d.field}: ${formatStructuredErrorDetailValue(d.value)}`);
       }
     });
   }

--- a/js/src/utils/errors.ts
+++ b/js/src/utils/errors.ts
@@ -620,11 +620,37 @@ export function getErrorMessage(error: ApiError): string {
 
 /**
  * Structured error detail from new error format (ERR-xxxx codes)
+ *
+ * `value` is typed as `unknown` because the backend contract says it should be
+ * a primitive (string / number / boolean) but in practice some errors emit
+ * dict / array values (e.g. HashRegistrationRequired carries `kms_info` and
+ * `onchain_status` as objects). Consumers that need a string should use
+ * {@link formatStructuredErrorDetailValue}; consumers that need the original
+ * structure (e.g. CLI extracting `commit_token`) should access `value` directly.
  */
 export interface StructuredErrorDetail {
   field?: string;
   value?: unknown;
   message?: string;
+}
+
+/**
+ * Coerce a {@link StructuredErrorDetail} `value` to a renderable string.
+ *
+ * - `string` returned as-is
+ * - `number` / `boolean` stringified via `String(...)`
+ * - `null` / `undefined` returned as `""` so callers never interpolate `null` literally
+ * - anything else (dict, array) serialized via `JSON.stringify` with a fallback to `String(...)`
+ */
+export function formatStructuredErrorDetailValue(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
 }
 
 /**
@@ -780,7 +806,7 @@ export function formatStructuredError(
       if (d.message) {
         parts.push(`  - ${d.message}`);
       } else if (d.field && d.value !== undefined) {
-        parts.push(`  - ${d.field}: ${d.value}`);
+        parts.push(`  - ${d.field}: ${formatStructuredErrorDetailValue(d.value)}`);
       }
     });
   }

--- a/js/src/utils/index.ts
+++ b/js/src/utils/index.ts
@@ -46,6 +46,7 @@ export {
   formatValidationErrors,
   formatErrorMessage,
   formatStructuredError,
+  formatStructuredErrorDetailValue,
   getErrorMessage,
   // Conflict helpers
   isConflictError,

--- a/js/src/utils/index.ts
+++ b/js/src/utils/index.ts
@@ -37,6 +37,7 @@ export {
   formatValidationErrors,
   formatErrorMessage,
   formatStructuredError,
+  formatStructuredErrorDetailValue,
   getErrorMessage,
   // Conflict helpers
   isConflictError,


### PR DESCRIPTION
## Summary

Three changes:

1. **CLI chain resolution** — \`phala instances add\`, \`phala cvms replicate\`, and \`phala deploy\` all read \`kms_info.chain\` (a viem \`Chain\` object), but that field is only populated by the JS SDK's \`KmsInfoSchema\` zod transform. \`instances add\` extracts \`kms_info\` from the raw HTTP 465 \`error.structuredDetails\` and bypasses the transform entirely, so the path always threw \`App KMS info is missing chain configuration\` for on-chain KMS apps that needed prepare/commit. The transform also only injects \`.chain\` when \`chain_id\` is in \`SUPPORTED_CHAINS\` (mainnet/base/anvil), so unsupported chains hit the same dead-end on \`replicate\` and \`deploy\`. Resolve from \`chain_id\` directly via \`SUPPORTED_CHAINS\` at the call sites and emit a clearer error when the chain id genuinely is not supported.

2. **prek build step** — CLI interface-compat tests spawn \`bun cli/dist/index.js --help\` for each command, so they hard-require the build to have run. Previously prek went lint → type-check → test, and a fresh checkout (no \`dist/\`) silently failed 34 tests with empty-stdout assertions. Mirror \`release-npm.yml\` order: lint → type-check → **build** → test, for both \`js\` and \`cli\` (cli consumes \`@phala/cloud\` through the workspace link to \`js/dist\`).

3. **JS SDK detail-value rendering** — \`formatStructuredError\` used \`\${d.value}\` interpolation, producing \`[object Object]\` for dict / array values (e.g. \`HashRegistrationRequired\` carries \`kms_info\` and \`onchain_status\` as dicts). Add \`formatStructuredErrorDetailValue\` helper (string passthrough / \`String()\` for primitives / \`JSON.stringify\` for objects / \`""\` for nullish) and use it in the details section. The helper is exported so frontend consumers can apply the same normalization rule. \`StructuredErrorDetail.value\` keeps its \`unknown\` type so CLI consumers that need raw structure (e.g. \`instances add\` extracting \`commit_token\` from the prepare payload) keep working.

## Repro for #1

User-reported: ScaleDialog on \`cloud.phala.com\` adding a replica to a node whose \`device_id\` isn't in the on-chain allowlist returned 465 with \`kms_info\` and \`onchain_status\` as dict values, which crashed the React error dialog. Frontend hotfix is in https://github.com/Phala-Network/phala-cloud-monorepo/pull/1304. The CLI side of the same flow is what this PR fixes.

\`\`\`bash
cd cli && bun run build
./dist/index.js instances add \\
  --app-id 48da3ef94f5c5409c2c6df70f95474f41eb763a5 \\
  --node-id 1 \\
  --prepare-only
\`\`\`

Before: throws \`App KMS info is missing chain configuration\`.
After: prints \`App instance prepared successfully (pending on-chain approval)\` with compose hash, app id, device id, commit token, commit URL.

## Test plan

- [x] \`bun run lint\` clean (cli + js)
- [x] \`bun run type-check\` clean (cli + js)
- [x] \`bun run build\` clean (cli + js)
- [x] \`bun run test\`: 413 cli pass / 36 js errors-suite pass (after build)
- [x] \`prek run --files cli/src/commands/instances/add/index.ts\` exercises the new chain: Biome → TypeScript → **Build** → tests, in order
- [ ] Manual: prepare-only run against a workspace with on-chain KMS, target node with un-registered device → human-readable prepare output instead of the chain-configuration throw