### PR TITLE
fix(js): pass through unknown keys on provision compose_file

### DIFF
--- a/js/src/actions/cvms/provision_cvm.test.ts
+++ b/js/src/actions/cvms/provision_cvm.test.ts
@@ -210,4 +210,36 @@ describe("ProvisionCvmRequestSchema", () => {
       }
     });
   });
+
+  describe("compose_file passthrough", () => {
+    // compose_file must forward unknown keys so newer backend fields
+    // (local_key_provider_enabled, port_policy, ...) reach the server
+    // without requiring a schema bump on every client.
+    it("preserves unknown keys on compose_file", () => {
+      const input = {
+        name: "test-app",
+        instance_type: "tdx.small",
+        compose_file: {
+          docker_compose_file: "version: '3'\nservices:\n  app:\n    image: nginx",
+          local_key_provider_enabled: true,
+          port_policy: {
+            ports: [{ port: 8080, pp: true }],
+            restrict_mode: true,
+          },
+        },
+      };
+
+      const result = ProvisionCvmRequestSchema.safeParse(input);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        const composeFile = result.data.compose_file as Record<string, unknown>;
+        expect(composeFile.local_key_provider_enabled).toBe(true);
+        expect(composeFile.port_policy).toEqual({
+          ports: [{ port: 8080, pp: true }],
+          restrict_mode: true,
+        });
+      }
+    });
+  });
 });

--- a/js/src/actions/cvms/provision_cvm.ts
+++ b/js/src/actions/cvms/provision_cvm.ts
@@ -217,6 +217,11 @@ export const ProvisionCvmRequestSchema = z
         tproxy_enabled: z.boolean().optional(), // deprecated, for compatibility
         storage_fs: z.enum(["ext4", "zfs"]).optional(),
       })
+      // Keep compose_file open to newer backend fields (e.g.
+      // local_key_provider_enabled, port_policy). Without passthrough, zod's
+      // default strip mode drops every unknown key at parse time and the
+      // backend never sees fields that the UI / SDK consumer set.
+      .passthrough()
       .superRefine((data, ctx) => {
         validateComposePayloadSize(data.docker_compose_file, data.pre_launch_script, ctx);
       }),


### PR DESCRIPTION
Allow compose_file to pass through newer backend fields (local_key_provider_enabled, port_policy) without being stripped by zod.