### PR TITLE
feat(js): expose workspace avatar URL

### DIFF
--- a/js/src/actions/workspaces/list_workspaces.ts
+++ b/js/src/actions/workspaces/list_workspaces.ts
@@ -69,6 +69,7 @@ export const WorkspaceResponseSchema = z
     id: z.string(),
     name: z.string(),
     slug: z.string().nullable(),
+    avatar_url: z.string().nullable().optional(),
     tier: z.string(),
     role: z.string(),
     is_default: z.boolean(),


### PR DESCRIPTION
## Summary
- Add optional `avatar_url` to the JS SDK workspace response schema.

## Testing
- `bun run build` from the SDK JS package was run from the parent worktree before this PR.
