### PR TITLE
fix: make PR255 templates deployable

### DIFF
--- a/templates/prebuilt/hermes-agent/README.md
+++ b/templates/prebuilt/hermes-agent/README.md
@@ -6,8 +6,7 @@ This template deploys Hermes Agent in a confidential VM on Phala Cloud with a sh
 
 ## Services
 
-- `gateway`: Hermes gateway and OpenAI-compatible API server.
-- `dashboard`: Hermes web dashboard.
+- `hermes`: Hermes gateway, OpenAI-compatible API server, and dashboard in one container.
 
 ## Ports
 
@@ -51,11 +50,12 @@ The `hermes_data` volume is mounted to `/opt/data` and stores Hermes state:
 - `hooks/`
 - `logs/`
 
-Do not run two Hermes gateway containers against the same data directory. The dashboard service can share the volume with the gateway.
+Do not run two Hermes gateway containers against the same data directory.
 
 ## Deploy
 
 ```bash
+docker compose config
 docker compose up -d
 ```
 
@@ -67,4 +67,5 @@ After deployment:
 ## Notes
 
 - The upstream compose file uses `network_mode: host` and binds the dashboard to `127.0.0.1`. This Phala template uses normal Compose port mappings and binds the dashboard to `0.0.0.0` so it can be reached through the CVM gateway.
+- The dashboard is enabled via gateway-managed mode (`HERMES_DASHBOARD=1`) instead of running a second standalone dashboard container. This matches upstream Docker guidance and avoids dashboard restart loops when binding on `0.0.0.0`.
 - Keep `API_SERVER_KEY` secret and rotate it if it is exposed.

--- a/templates/prebuilt/hermes-agent/docker-compose.yml
+++ b/templates/prebuilt/hermes-agent/docker-compose.yml
@@ -1,10 +1,11 @@
 services:
-  gateway:
+  hermes:
     image: nousresearch/hermes-agent:latest
     container_name: hermes
     restart: unless-stopped
     ports:
       - "8642:8642"
+      - "9119:9119"
     volumes:
       - hermes_data:/opt/data
     environment:
@@ -12,27 +13,15 @@ services:
       HERMES_GID: ${HERMES_GID:-10000}
       API_SERVER_HOST: ${API_SERVER_HOST:-0.0.0.0}
       API_SERVER_KEY: ${API_SERVER_KEY}
+      HERMES_DASHBOARD: ${HERMES_DASHBOARD:-1}
+      HERMES_DASHBOARD_HOST: ${HERMES_DASHBOARD_HOST:-0.0.0.0}
+      HERMES_DASHBOARD_PORT: ${HERMES_DASHBOARD_PORT:-9119}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:-}
       DISCORD_TOKEN: ${DISCORD_TOKEN:-}
       SLACK_BOT_TOKEN: ${SLACK_BOT_TOKEN:-}
     command: ["gateway", "run"]
-
-  dashboard:
-    image: nousresearch/hermes-agent:latest
-    container_name: hermes-dashboard
-    restart: unless-stopped
-    depends_on:
-      - gateway
-    ports:
-      - "9119:9119"
-    volumes:
-      - hermes_data:/opt/data
-    environment:
-      HERMES_UID: ${HERMES_UID:-10000}
-      HERMES_GID: ${HERMES_GID:-10000}
-    command: ["dashboard", "--host", "0.0.0.0", "--no-open"]
 
 volumes:
   hermes_data:

--- a/templates/prebuilt/llm-wiki/README.md
+++ b/templates/prebuilt/llm-wiki/README.md
@@ -6,7 +6,7 @@ The upstream project is primarily a Tauri desktop app, not a server app. This Ph
 
 ## Service
 
-- `llm-wiki`: clones `nashsu/llm_wiki`, installs dependencies, and starts the Vite dev server.
+- `llm-wiki`: clones `nashsu/llm_wiki`, applies a Vite `allowedHosts` compatibility patch, installs dependencies, and starts the Vite dev server.
 
 ## Port
 
@@ -35,10 +35,13 @@ The template creates these volumes:
 ## Deploy
 
 ```bash
+docker compose config
 docker compose up -d
 ```
 
 Open port `1420` to view the frontend preview.
+
+The startup patch sets `server.allowedHosts = true` in `vite.config.ts` if the setting is missing. This prevents Vite host-block errors when accessing the app through dynamic Phala public URLs.
 
 ## Important limitation
 

--- a/templates/prebuilt/llm-wiki/docker-compose.yml
+++ b/templates/prebuilt/llm-wiki/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       [
         "sh",
         "-lc",
-        "if [ ! -f package.json ]; then git clone --depth=1 https://github.com/nashsu/llm_wiki.git .; fi && npm ci && npm run dev -- --host 0.0.0.0 --port 1420",
+        "set -eu; if [ ! -f package.json ]; then git clone --depth=1 https://github.com/nashsu/llm_wiki.git .; fi; if [ -f vite.config.ts ] && ! grep -q 'allowedHosts' vite.config.ts; then perl -0pi -e 's/server:\\s*\\{/server: { allowedHosts: true, /' vite.config.ts; fi; npm ci; npm run dev -- --host 0.0.0.0 --port 1420 --strictPort",
       ]
 
 volumes:

--- a/templates/prebuilt/openclaw/README.md
+++ b/templates/prebuilt/openclaw/README.md
@@ -46,6 +46,7 @@ The template creates these volumes:
 ## Deploy
 
 ```bash
+docker compose config
 docker compose up -d
 ```
 
@@ -53,5 +54,6 @@ After the gateway starts, connect OpenClaw clients or companion nodes to the pub
 
 ## Notes
 
+- On startup, this template writes `gateway.mode=local` and `gateway.bind=${OPENCLAW_GATEWAY_BIND}` before launching the gateway. This avoids bootstrap failures on fresh volumes and keeps redeploys deterministic.
 - Bonjour/mDNS is disabled because container bridge networking and remote CVM environments do not reliably support local network discovery.
 - The upstream Docker setup also provides an interactive CLI sidecar. This Phala template keeps the deployment focused on the long-running gateway service so it can run reliably as a hosted CVM.

--- a/templates/prebuilt/openclaw/docker-compose.yml
+++ b/templates/prebuilt/openclaw/docker-compose.yml
@@ -35,13 +35,9 @@ services:
       - no-new-privileges:true
     command:
       [
-        "node",
-        "dist/index.js",
-        "gateway",
-        "--bind",
-        "${OPENCLAW_GATEWAY_BIND:-lan}",
-        "--port",
-        "18789",
+        "sh",
+        "-lc",
+        "set -eu; BIND=\"${OPENCLAW_GATEWAY_BIND:-lan}\"; node dist/index.js config set --batch-json \"[{\\\"path\\\":\\\"gateway.mode\\\",\\\"value\\\":\\\"local\\\"},{\\\"path\\\":\\\"gateway.bind\\\",\\\"value\\\":\\\"$${BIND}\\\"}]\"; exec node dist/index.js gateway --allow-unconfigured --bind \"$${BIND}\" --port 18789"
       ]
     healthcheck:
       test:


### PR DESCRIPTION
## Summary
- bootstraps OpenClaw gateway config before launching so first-run CVMs stop restart-looping
- switches Hermes Agent to a single gateway-managed dashboard container and exposes 9119 from that container
- patches LLM Wiki Vite config at startup to allow dynamic Phala gateway hosts

## Live Phala CLI validation
Tested in `h4x's projects` with fresh CVMs from this branch:

- OpenClaw: `a70585b7d8a9c76c61fc384473938985ea4a07a1`
  - container: `/openclaw-gateway` running, healthy
  - `https://a70585b7d8a9c76c61fc384473938985ea4a07a1-18789.dstack-pha-prod7.phala.network/healthz` -> HTTP 200
- Hermes Agent: `fda0b698829e663dce98367f5bae80ae1d0f61a1`
  - container: `/hermes` running
  - API health: `...-8642.../health` -> HTTP 200
  - dashboard: `...-9119.../` -> HTTP 200
- LLM Wiki: `e577b65381860337ea7565cd9796769b5e9fa077`
  - container: `/llm-wiki` running
  - public URL `...-1420.../` -> HTTP 200

## Local validation
- `docker compose -f templates/prebuilt/openclaw/docker-compose.yml config`
- `docker compose -f templates/prebuilt/hermes-agent/docker-compose.yml config`
- `docker compose -f templates/prebuilt/llm-wiki/docker-compose.yml config`
- `cd templates && python3 validate.py`

All passed. Existing unused-icon warnings unchanged.

## Note
I could not push directly to `Phala-Network:add-openclaw-hermes-templates` as `phala-agent` (403), so this PR targets the PR #255 branch with the fix branch from the `phala-agent` fork.
