### PR TITLE
fix: repair ElevenLabs MCP template deployment

### DIFF
--- a/templates/prebuilt/elevenlabs-mcp-server/docker-compose.yaml
+++ b/templates/prebuilt/elevenlabs-mcp-server/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     # ports: # Using caddy to proxy the server to enhance security, so no need to expose the port
     #   - "8000:8000"
     volumes:
-      - /root/data:/root/Desktop
+      - elevenlabs_data:/root/Desktop
     environment:
       - ELEVENLABS_API_KEY=${ELEVENLABS_API_KEY}
       - ELEVENLABS_MCP_BASE_PATH=${ELEVENLABS_MCP_BASE_PATH}
@@ -16,7 +16,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - /root/data:/root/data
+      - elevenlabs_data:/root/data
     working_dir: /root/data
     command: python -m http.server 8080
     networks:
@@ -45,7 +45,7 @@ configs:
               header Authorization "Bearer $BEARER_TOKEN"
           }
           route @valid_auth {
-              reverse_proxy app:8080
+              reverse_proxy app:8000
           }
           route {
               respond 401 {
@@ -54,6 +54,9 @@ configs:
               }
           }
       }
+
+volumes:
+  elevenlabs_data:
 
 networks:
   internal:


### PR DESCRIPTION
## Summary
- Replace absolute `/root/data` bind mounts with a named Docker volume for the ElevenLabs MCP template.
- Proxy the authenticated Caddy route to the MCP app port (`app:8000`) instead of the fileserver port.

## Test Plan
- `docker compose -f templates/prebuilt/elevenlabs-mcp-server/docker-compose.yaml config`
- Deployed the template to Phala Cloud with generated dummy/test environment values.
- Verified the original template failed with `failed to start containers` due to `mkdir /root: read-only file system` for `/root/data`.
- Redeployed the fixed compose; CVM reached `running` with sysinfo present.
- Verified endpoints: fileserver `8080` returned HTTP 200, proxy `18080` returned HTTP 401 without auth and app-level HTTP 404 with dummy bearer token.
- Stopped the fixed test CVM after verification.

Notes: real ElevenLabs API behavior was not exercised; this was a deployment/runtime smoke test with safe dummy credentials.