### PR TITLE
fix(cli): use bun update instead of bun add for self-update

### DIFF
--- a/cli/src/core/package-manager.test.ts
+++ b/cli/src/core/package-manager.test.ts
@@ -87,9 +87,9 @@ describe("detectPackageManager", () => {
 });
 
 describe("formatGlobalInstallCommand", () => {
-	test("includes --no-cache for bun", () => {
+	test("uses update for bun", () => {
 		expect(formatGlobalInstallCommand("bun", "phala@1.2.3")).toBe(
-			"bun add -g --no-cache phala@1.2.3",
+			"bun update -g phala@1.2.3",
 		);
 	});
 
@@ -113,10 +113,10 @@ describe("formatGlobalInstallCommand", () => {
 });
 
 describe("getGlobalInstallArgs", () => {
-	test("includes --no-cache for bun", () => {
+	test("uses update for bun", () => {
 		const result = getGlobalInstallArgs("bun", "phala@1.2.3");
 		expect(result.command).toBe("bun");
-		expect(result.args).toEqual(["add", "-g", "--no-cache", "phala@1.2.3"]);
+		expect(result.args).toEqual(["update", "-g", "phala@1.2.3"]);
 	});
 
 	test("returns correct args for npm", () => {

--- a/cli/src/core/package-manager.ts
+++ b/cli/src/core/package-manager.ts
@@ -65,7 +65,7 @@ export function formatGlobalInstallCommand(
 ): string {
 	switch (packageManager) {
 		case "bun":
-			return `bun add -g --no-cache ${packageName}`;
+			return `bun update -g ${packageName}`;
 		case "pnpm":
 			return `pnpm add -g ${packageName}`;
 		case "yarn":
@@ -83,7 +83,7 @@ export function getGlobalInstallArgs(
 		case "bun":
 			return {
 				command: "bun",
-				args: ["add", "-g", "--no-cache", packageNameOrSpec],
+				args: ["update", "-g", packageNameOrSpec],
 			};
 		case "pnpm":
 			return { command: "pnpm", args: ["add", "-g", packageNameOrSpec] };

--- a/cli/src/core/update-check.test.ts
+++ b/cli/src/core/update-check.test.ts
@@ -337,7 +337,7 @@ describe("checkForUpdates", () => {
 		expect(result).not.toBeNull();
 		expect(result?.message).toContain("phala@1.2.3");
 		expect(result?.message).not.toContain("phala@latest");
-		expect(result?.message).toContain("--no-cache");
+		expect(result?.message).toContain("bun update -g");
 	});
 
 	test("uses prerelease channel tag when current is prerelease", async () => {


### PR DESCRIPTION
## Summary

- `phala self update` was calling `bun add -g --no-cache phala@latest`, which reinstalls the already-cached version and leaves the CLI on the old version
- Fixed by switching to `bun update -g phala@latest`, which correctly fetches and installs the newer version
- Updated tests to match the new command

## Test plan

- [ ] Run `phala self update` with bun — verify it actually upgrades to the latest version
- [ ] `bun test src/core/package-manager.test.ts src/core/update-check.test.ts` passes (29/29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)