### PR TITLE
fix: add MOOF MCP prebuilt template

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -306,7 +306,7 @@
     "id": "moof-mcp",
     "name": "MOOF MCP",
     "description": "An MCP server enables LLMs to work with the MOOF platform, deployed on Phala Cloud. It can list flows, create new flows, and deploy other MCP servers on Phala Cloud. Additionally, it supports fetching public flow templates, forking flows from templates, retrieving authenticated user flows, publishing or unpublishing flows to/from the shared flow store, and deploying MCP servers directly from GitHub with optional Phala hosting and environment variable support.",
-    "repo": "https://github.com/moofdotfun/MOOF-MCP",
+    "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/moof-mcp",
     "author": "MOOF",
     "icon": "moof.png",
     "envs": [

--- a/templates/prebuilt/moof-mcp/README.md
+++ b/templates/prebuilt/moof-mcp/README.md
@@ -1,0 +1,57 @@
+# MOOF MCP
+
+MOOF MCP server prebuilt template for Phala Cloud.
+
+## Source
+
+- Upstream repository: https://github.com/moofdotfun/MOOF-MCP
+- Inspected upstream commit: `f3ff5b53d8e8d08f6bbb58024e8881489e4b3a34`
+- Pinned image: `mooflowai/moof-mcp:p4aacnr9zhke`
+- Pinned digest: `sha256:a11b0cf0643c9d6cb0e299b287f7be36302adb1bafd86107fb46ee5859d784b6`
+
+The compose file uses the tag plus digest reference:
+
+```text
+mooflowai/moof-mcp:p4aacnr9zhke@sha256:a11b0cf0643c9d6cb0e299b287f7be36302adb1bafd86107fb46ee5859d784b6
+```
+
+## Phala Patch
+
+The upstream `docker-compose.yml` declares `environment: {}`, so Phala-accepted template variables are not passed into the container. This template keeps the upstream image, port mapping, and `/var/run/tappd.sock` mount, then explicitly propagates the documented environment variables into the `app` service.
+
+## Environment Variables
+
+- `MOOF_API_KEY` (required): MOOF platform API key. The compose config fails if this is omitted.
+- `MCP_API_KEY` (required): MCP API key. The compose config fails if this is omitted.
+- `BASE_URL` (optional): MOOF app base URL. Defaults to `https://app.moof.fun`.
+- `MCP_BASE_URL` (optional): MOOF MCP API base URL. Defaults to `https://dev-mcp-api.mooflow.ai`, matching the inspected source default.
+
+Do not commit real API keys or secrets to this directory.
+
+## Smoke Test Probes
+
+After deployment, replace `APP_HOST` with the Phala CVM endpoint.
+
+```bash
+curl -i "https://APP_HOST/"
+# Expect an app-level 404 response.
+
+curl -iN "https://APP_HOST/sse"
+# Expect HTTP 200 with an SSE stream. The request may stay open.
+```
+
+`/` returning `404` is expected for this app. `/sse` returning `200` confirms the HTTP server is running and serving the MCP SSE transport.
+
+## Update Procedure
+
+1. Inspect the new upstream source commit and record it in this README.
+2. Verify the upstream image tag and public linux/amd64 digest.
+3. Update `docker-compose.yml` to the new tag plus digest reference.
+4. Re-check upstream environment variable names and defaults, then update the compose environment block and this README if needed.
+5. Run:
+
+```bash
+MOOF_API_KEY=dummy MCP_API_KEY=dummy docker compose -f templates/prebuilt/moof-mcp/docker-compose.yml config
+```
+
+6. Smoke test `/` and `/sse` after deploying on Phala Cloud.

--- a/templates/prebuilt/moof-mcp/docker-compose.yml
+++ b/templates/prebuilt/moof-mcp/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  app:
+    image: mooflowai/moof-mcp:p4aacnr9zhke@sha256:a11b0cf0643c9d6cb0e299b287f7be36302adb1bafd86107fb46ee5859d784b6
+    ports:
+      - "5555:3000"
+    volumes:
+      - /var/run/tappd.sock:/var/run/tappd.sock
+    environment:
+      MOOF_API_KEY: ${MOOF_API_KEY:?MOOF_API_KEY is required}
+      MCP_API_KEY: ${MCP_API_KEY:?MCP_API_KEY is required}
+      BASE_URL: ${BASE_URL:-https://app.moof.fun}
+      MCP_BASE_URL: ${MCP_BASE_URL:-https://dev-mcp-api.mooflow.ai}
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add a self-contained `templates/prebuilt/moof-mcp` template in Phala Cloud.
- Pin the known-good public MOOF MCP image by tag + digest and preserve upstream port/tappd settings.
- Fix env propagation so `MOOF_API_KEY`, `MCP_API_KEY`, `BASE_URL`, and `MCP_BASE_URL` reach the container instead of being accepted by Phala but missing at runtime.
- Point `templates/config.json` at the Phala-maintained prebuilt template path, avoiding dependency on an external upstream PR merge.

## Smoke test / validation
- Original external compose deployed and container ran, but logs showed `MOOF_API_KEY: MISSING` and `MCP_API_KEY: MISSING` because upstream compose had `environment: {}`.
- New local compose validated with `docker compose -f templates/prebuilt/moof-mcp/docker-compose.yml --env-file <safe dummy env> config`.
- Negative compose check without required keys fails at interpolation as expected.
- Live Phala redeploy of fixed compose in profile `hermes-admin-cvm-check` reached running/online; container logs showed required keys loaded from env; `/` returned HTTP 404 and `/sse` returned HTTP 200 stream as expected.
- Both original and fixed smoke CVMs were deleted and verified not found.

cc @Marvin-Cypher for review/check/merge.
