### PR TITLE
fix: add sequential thinking mcp prebuilt wrapper

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -435,8 +435,8 @@
     "id": "mcp-server-sequential-thinking",
     "name": "MCP Server Sequential Thinking",
     "description": "A MCP server deployed on Phala Cloud that enables AI agents to think sequentially.",
-    "repo": "https://github.com/Leechael/mcp-servers/tree/main/src/sequentialthinking",
-    "author": "Leechael",
+    "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/mcp-server-sequential-thinking",
+    "author": "Phala-Network",
     "tags": ["MCP"]
   },
   {

--- a/templates/prebuilt/mcp-server-sequential-thinking/README.md
+++ b/templates/prebuilt/mcp-server-sequential-thinking/README.md
@@ -1,0 +1,57 @@
+# MCP Server Sequential Thinking
+
+This Phala Cloud prebuilt template runs the Sequential Thinking MCP server from Leechael's `mcp-servers` repository as an HTTP SSE service.
+
+## Upstream
+
+- URL: https://github.com/Leechael/mcp-servers/tree/main/src/sequentialthinking
+- Pinned commit: `ded1d9211d0c713161cec146a96fe901e61e5fa7`
+- Upstream commit date: 2025-05-07
+- License: MIT, inherited from the upstream repository and the `src/sequentialthinking` package metadata.
+
+## Why this wrapper exists
+
+The upstream `src/sequentialthinking/docker-compose.yaml` references `leechael/mcp-server-sequentialthinking:latest`. That image is not publicly pullable, so Docker manifest inspection and Phala Cloud smoke deployment fail with pull access denied.
+
+This template keeps deployment self-contained in Phala Cloud by using Compose `dockerfile_inline` to build the server from the pinned upstream source instead of depending on the missing image or waiting for an upstream image fix. The inline Dockerfile fetches the pinned repository archive, copies only `src/sequentialthinking`, pins the direct npm dependencies to the versions recorded with that upstream commit, patches the POST endpoint to `/messages`, builds the TypeScript package, prunes development dependencies, and runs the compiled server on port `3001`.
+
+## Service
+
+- Service: `mcp-server-sequential-thinking`
+- Host port: `8000`
+- Container port: `3001`
+- Restart policy: `unless-stopped`
+
+## Smoke Probes
+
+After deployment, replace `APP_HOST` with the Phala CVM endpoint for port `8000`.
+
+```bash
+curl -i "https://APP_HOST/"
+```
+
+Expected: `404 Not Found`. The server does not define a root route, so this confirms the HTTP app is reachable.
+
+```bash
+curl -iN "https://APP_HOST/sse"
+```
+
+Expected: `200 OK` with `Content-Type: text/event-stream` and an `event: endpoint` line. The endpoint event should point clients at `/messages?sessionId=...`.
+
+```bash
+curl -i -X POST "https://APP_HOST/messages"
+```
+
+Expected: `400 Bad Request` with an invalid session response because no `session_id` or `sessionId` query parameter was supplied.
+
+## Update Path
+
+1. Review upstream changes in https://github.com/Leechael/mcp-servers/tree/main/src/sequentialthinking.
+2. Choose and record a new immutable upstream commit SHA.
+3. Update `UPSTREAM_COMMIT` in `docker-compose.yml`.
+4. Re-check whether the local `/messages` endpoint patch is still required.
+5. Run `docker compose config` from this template directory.
+6. Run `python3 templates/validate.py` from the repository root.
+7. Run smoke probes against a local or Phala Cloud deployment.
+
+Do not switch this template back to `leechael/mcp-server-sequentialthinking:latest` unless the image is public, maintained, and verified by manifest inspection and a Phala Cloud smoke test.

--- a/templates/prebuilt/mcp-server-sequential-thinking/docker-compose.yml
+++ b/templates/prebuilt/mcp-server-sequential-thinking/docker-compose.yml
@@ -1,0 +1,57 @@
+services:
+  mcp-server-sequential-thinking:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM node:22.12-alpine AS builder
+
+        ARG UPSTREAM_COMMIT=ded1d9211d0c713161cec146a96fe901e61e5fa7
+
+        WORKDIR /app
+
+        RUN apk add --no-cache ca-certificates wget
+
+        RUN wget -O /tmp/mcp-servers.tar.gz "https://github.com/Leechael/mcp-servers/archive/$${UPSTREAM_COMMIT}.tar.gz" \
+            && mkdir -p /tmp/mcp-servers \
+            && tar -xzf /tmp/mcp-servers.tar.gz -C /tmp/mcp-servers --strip-components=1 \
+            && cp -R /tmp/mcp-servers/src/sequentialthinking/. /app/ \
+            && cp /tmp/mcp-servers/tsconfig.json /tsconfig.json \
+            && rm -rf /tmp/mcp-servers /tmp/mcp-servers.tar.gz
+
+        RUN sed -i 's|const POST_ENDPOINT = "/message";|const POST_ENDPOINT = "/messages";|' index.ts \
+            && sed -i 's|const sessionId = req.query.sessionId;|const sessionId = req.query.sessionId ?? req.query.session_id;|' index.ts \
+            && npm pkg set dependencies.@modelcontextprotocol/sdk=1.11.0 \
+            && npm pkg set dependencies.chalk=5.3.0 \
+            && npm pkg set dependencies.yargs=17.7.2 \
+            && npm pkg set dependencies.express=5.1.0 \
+            && npm pkg set devDependencies.@types/express=5.0.1 \
+            && npm pkg set devDependencies.@types/node=22.10.2 \
+            && npm pkg set devDependencies.@types/yargs=17.0.33 \
+            && npm pkg set devDependencies.shx=0.3.4 \
+            && npm pkg set devDependencies.typescript=5.8.2
+
+        RUN NODE_ENV=development npm install --ignore-scripts --no-audit --no-fund \
+            && npm run build \
+            && npm prune --omit=dev --ignore-scripts --no-audit --no-fund
+
+        FROM node:22.12-alpine AS runtime
+
+        ENV NODE_ENV=production
+        ENV PORT=3001
+
+        WORKDIR /app
+
+        COPY --from=builder /app/package.json /app/package-lock.json ./
+        COPY --from=builder /app/node_modules ./node_modules
+        COPY --from=builder /app/dist ./dist
+
+        EXPOSE 3001
+
+        USER node
+
+        CMD ["node", "dist/index.js"]
+    image: mcp-server-sequential-thinking:latest
+    pull_policy: build
+    ports:
+      - "8000:3001"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add a Phala-maintained prebuilt template for MCP Server Sequential Thinking.
- Replace the external `leechael/mcp-server-sequentialthinking:latest` image dependency, which is not publicly pullable, with a self-contained `dockerfile_inline` build from pinned upstream commit `ded1d9211d0c713161cec146a96fe901e61e5fa7`.
- Update `templates/config.json` to point users to the local Phala Cloud prebuilt template path.

## Validation
- `docker compose -f templates/prebuilt/mcp-server-sequential-thinking/docker-compose.yml config`
- `python3 templates/validate.py`
- Live Phala smoke test with profile `hermes-admin-cvm-check` in workspace `h4x's projects`:
  - Original external compose failed: Docker image pull access denied.
  - Fixed compose reached CVM online/running with one running container.
  - `GET /` -> HTTP 404 app response.
  - `POST /messages` without session -> HTTP 400 app response.
  - `GET /sse` -> HTTP 200 SSE stream.
- Both smoke CVMs were deleted and verified as not found/deleted.

## Notes
This PR intentionally avoids depending on an external upstream PR or missing upstream image publication. The update path and upstream license/commit are documented in the new README.

cc @Marvin-Cypher for review/check/merge.
