### PR TITLE
fix: vendor lightclient prebuilt template

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -460,7 +460,7 @@
     "id": "lightclient",
     "name": "TEE Coprocessors in Dstack",
     "description": "Minimal docker file for using the Helios light client to provide a trustworthy view of the blockchain.",
-    "repo": "https://github.com/Dstack-TEE/dstack-examples/tree/main/lightclient",
+    "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/lightclient",
     "author": "Dstack-TEE",
     "envs": [{ "key": "ETH_RPC_URL", "required": true }],
     "tags": ["Dstack"]

--- a/templates/prebuilt/lightclient/README.md
+++ b/templates/prebuilt/lightclient/README.md
@@ -1,0 +1,77 @@
+# TEE Coprocessors in Dstack
+
+This Phala Cloud prebuilt template runs the Helios Ethereum light client inside a Dstack CVM, queries the latest block through Helios, and requests a tappd attestation over the hash of the captured block response.
+
+It is maintained locally so Phala Cloud users are not blocked on upstream template changes.
+
+## Source
+
+- Upstream repository: https://github.com/Dstack-TEE/dstack-examples
+- Upstream template path: `tutorial/07-lightclient/`
+- Inspected upstream commit: `50d05e0e2b3c8703e6abf1e21c63a8447f4fd34a`
+- Upstream license: Apache License 2.0
+- Base image: `ubuntu:24.04@sha256:b59d21599a2b151e23eea5f6602f4af4d7d31c4e236d22bf0b62b86d2e386b8f`
+
+This template keeps the upstream shape: inline Dockerfile, Foundry `cast`, Helios, and `/var/run/tappd.sock`. It follows the maintained upstream tutorial behavior for Helios `0.11.0` on mainnet with fallback checkpoint endpoint `https://sync-mainnet.beaconcha.in`, while keeping `ETH_RPC_URL` required for Phala Cloud deployment. The local runtime script uses `set -euo pipefail`, waits for `eth_blockNumber`, retries `cast block`, prints block data, hashes `response.txt`, then requests the tappd quote.
+
+## Runtime Dependency Note
+
+The original external lightclient template used Holesky with consensus endpoint `http://testing.holesky.beacon-api.nimbus.team`. That endpoint is currently unavailable from the CVM runtime and caused Helios to fail syncing with `could not fetch bootstrap`. This local Phala-maintained template avoids that external Holesky runtime dependency by using mainnet Helios with the fallback checkpoint endpoint from `tutorial/07-lightclient`.
+
+## Environment
+
+- `ETH_RPC_URL` (required): Ethereum execution RPC URL used by Helios as its untrusted execution RPC.
+
+Use a credentialed RPC endpoint for production or long-lived deployments. A public uncredentialed RPC endpoint is only appropriate for smoke testing because it may be rate-limited, unavailable, or shared with unrelated users.
+
+## Behavior
+
+The service is a one-shot smoke/evidence job. It does not expose public ports.
+
+At runtime it:
+
+1. Starts Helios mainnet on `127.0.0.1:8545`.
+2. Polls `eth_blockNumber` on `localhost:8545` for up to five minutes.
+3. Retries `cast block latest --rpc-url http://127.0.0.1:8545`.
+4. Writes the block output to `response.txt` and prints it to logs.
+5. Computes `sha256sum response.txt`.
+6. Sends the hash as tappd `report_data`.
+7. Appends and prints `ATTEST=<tappd response>`.
+
+The template intentionally does not redact output. Do not put secrets in values that are expected to be printed by the workload.
+
+## Expected Smoke Evidence
+
+A successful Phala Cloud smoke run should show:
+
+- Helios startup logs, including an RPC listener on `127.0.0.1:8545`.
+- `Helios eth_blockNumber ready: 0x...`.
+- `Fetching latest block through Helios`.
+- `cast block` output with block fields such as `hash`, `number`, `timestamp`, `transactions`, and gas fields.
+- `response.txt sha256=<64 hex characters>`.
+- `ATTEST=...` from `/var/run/tappd.sock`.
+
+If Helios cannot sync or the RPC endpoint is invalid, the container should exit non-zero after the retry window instead of producing attestation-only evidence.
+
+## Local Checks
+
+From the repository root:
+
+```bash
+ETH_RPC_URL=https://ethereum-rpc.publicnode.com docker compose -f templates/prebuilt/lightclient/docker-compose.yml config
+python3 templates/validate.py
+git diff --check
+```
+
+The `docker compose config` command only validates the template shape. It does not contact the RPC endpoint unless the service is built or run.
+
+## Update Procedure
+
+1. Inspect the current upstream `Dstack-TEE/dstack-examples/tutorial/07-lightclient` files and record the source commit in this README.
+2. Compare upstream Dockerfile, Helios, Foundry, network, fallback checkpoint endpoint, and tappd request changes against this local template.
+3. Keep the template self-contained with `dockerfile_inline` and `configs.run.sh.content`; do not depend on deploy-time files from the upstream repository.
+4. Keep the Ubuntu base image pinned by digest and verify that the digest is still available for `linux/amd64`.
+5. Re-run the local checks above.
+6. Deploy a Phala Cloud smoke instance with a safe RPC URL and confirm the smoke evidence includes block data and an attestation.
+
+Do not commit real RPC credentials or smoke secrets to this directory.

--- a/templates/prebuilt/lightclient/docker-compose.yml
+++ b/templates/prebuilt/lightclient/docker-compose.yml
@@ -1,0 +1,129 @@
+services:
+  tapp:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM ubuntu:24.04@sha256:b59d21599a2b151e23eea5f6602f4af4d7d31c4e236d22bf0b62b86d2e386b8f
+
+        ENV DEBIAN_FRONTEND=noninteractive
+
+        RUN apt-get update \
+            && apt-get install -y --no-install-recommends \
+                ca-certificates \
+                curl \
+                wget \
+            && rm -rf /var/lib/apt/lists/*
+
+        WORKDIR /root
+
+        RUN wget -O /tmp/foundry.tar.gz "https://github.com/foundry-rs/foundry/releases/download/nightly-c3069a50ba18cccfc4e7d5de9b9b388811d9cc7b/foundry_nightly_linux_amd64.tar.gz" \
+            && tar -xzf /tmp/foundry.tar.gz -C /usr/local/bin \
+            && rm /tmp/foundry.tar.gz
+
+        RUN wget -O /tmp/helios.tar.gz "https://github.com/a16z/helios/releases/download/0.11.0/helios_linux_amd64.tar.gz" \
+            && tar -xzf /tmp/helios.tar.gz -C /usr/local/bin \
+            && rm /tmp/helios.tar.gz
+
+        CMD ["bash", "/root/run.sh"]
+    image: phala-lightclient:latest
+    pull_policy: build
+    platform: linux/amd64
+    init: true
+    environment:
+      ETH_RPC_URL: ${ETH_RPC_URL:?Set ETH_RPC_URL to an Ethereum execution RPC URL}
+    configs:
+      - source: run.sh
+        target: /root/run.sh
+    volumes:
+      - /var/run/tappd.sock:/var/run/tappd.sock
+
+configs:
+  run.sh:
+    content: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      : "$${ETH_RPC_URL:?ETH_RPC_URL is required}"
+
+      HELIOS_PID=""
+
+      cleanup() {
+        if [[ -n "$${HELIOS_PID}" ]] && kill -0 "$${HELIOS_PID}" 2>/dev/null; then
+          kill "$${HELIOS_PID}"
+          wait "$${HELIOS_PID}" 2>/dev/null || true
+        fi
+      }
+      trap cleanup EXIT INT TERM
+
+      echo "Starting Helios mainnet light client on 127.0.0.1:8545"
+      helios ethereum \
+        --network mainnet \
+        --execution-rpc "$${ETH_RPC_URL}" \
+        --fallback https://sync-mainnet.beaconcha.in \
+        --rpc-bind-ip 127.0.0.1 &
+      HELIOS_PID="$$!"
+
+      wait_for_block_number() {
+        local attempt
+        local block_number
+
+        for attempt in $$(seq 1 60); do
+          if ! kill -0 "$${HELIOS_PID}" 2>/dev/null; then
+            echo "Helios exited before eth_blockNumber was available" >&2
+            wait "$${HELIOS_PID}" || true
+            return 1
+          fi
+
+          block_number="$$(curl -fsS --max-time 5 \
+            -H "Content-Type: application/json" \
+            -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' \
+            http://127.0.0.1:8545 2>/dev/null \
+            | sed -n 's/.*"result":"\([^"]*\)".*/\1/p' || true)"
+
+          if printf "%s" "$${block_number}" | grep -Eq '^0x[[:xdigit:]]+$$'; then
+            echo "Helios eth_blockNumber ready: $${block_number}"
+            return 0
+          fi
+
+          echo "Waiting for Helios RPC ($${attempt}/60)"
+          sleep 5
+        done
+
+        echo "Timed out waiting for Helios eth_blockNumber on localhost:8545" >&2
+        return 1
+      }
+
+      fetch_block() {
+        local attempt
+
+        for attempt in $$(seq 1 12); do
+          if cast block latest --rpc-url http://127.0.0.1:8545 | tee response.txt; then
+            return 0
+          fi
+
+          echo "Waiting for cast block through Helios ($${attempt}/12)"
+          sleep 5
+        done
+
+        echo "Timed out waiting for cast block through Helios" >&2
+        return 1
+      }
+
+      wait_for_block_number
+
+      echo "Fetching latest block through Helios"
+      fetch_block
+
+      RESPONSE_HASH="$$(sha256sum response.txt | cut -d " " -f 1)"
+      REPORT_DATA="$$(printf "%s" "$${RESPONSE_HASH}" | od -An -v -tx1 | tr -d " \n")"
+      PAYLOAD="{\"report_data\":\"$${REPORT_DATA}\"}"
+
+      echo "response.txt sha256=$${RESPONSE_HASH}"
+      echo "Requesting tappd attestation for response hash"
+      ATTEST="$$(curl -fsS \
+        --unix-socket /var/run/tappd.sock \
+        -H "Content-Type: application/json" \
+        -d "$${PAYLOAD}" \
+        http://localhost/prpc/Tappd.TdxQuote?json)"
+
+      printf "ATTEST=%s\n" "$${ATTEST}" | tee -a response.txt


### PR DESCRIPTION
## Summary
- Adds a Phala-maintained local prebuilt template for `lightclient` under `templates/prebuilt/lightclient`.
- Replaces the catalog `repo` link for `lightclient` with the local template path so deployment no longer depends on external upstream changes.
- Uses the upstream Dstack tutorial lightclient flow (`Helios 0.11.0`, mainnet, fallback checkpoint endpoint) and a robust `set -euo pipefail` runner that waits for Helios, prints block evidence, hashes `response.txt`, and requests tappd attestation.

## Why
The existing external template uses Holesky plus `http://testing.holesky.beacon-api.nimbus.team`. Live smoke showed the original container exited 0 but produced only `ATTEST=...` with no block data, because the script did not fail when Helios/cast failed. A first fixed smoke confirmed the Holesky consensus endpoint is unavailable from the CVM runtime (`could not fetch bootstrap`). This PR vendors a maintained, reproducible template in Phala Cloud and avoids depending on an external upstream PR/merge.

## Live smoke evidence
Profile/workspace: `hermes-admin-cvm-check` / `h4x's projects`.

- Original external compose: CVM running/online, container `Exited (0)`, logs had `ATTEST=...` but no block evidence.
- First local Holesky fix attempt: CVM running/online, container `Exited (1)`, Helios failed to fetch bootstrap from the Holesky consensus endpoint.
- Final local mainnet/fallback template: CVM running/online, container `Exited (0)`, logs included block fields (`hash`, `timestamp`), `response.txt sha256=<64 hex>`, and `ATTEST=...`.
- All smoke CVMs were stopped/deleted and deletion verified.

## Validation
- `ETH_RPC_URL=https://ethereum-rpc.publicnode.com docker compose -f templates/prebuilt/lightclient/docker-compose.yml config`
- `python3 templates/validate.py`
- `git diff --check`

cc @Marvin-Cypher for review/check/merge.
