### PR TITLE
fix: add Armor Crypto prebuilt template

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -513,9 +513,27 @@
     "id": "armor-crypto",
     "name": "Armor Crypto",
     "description": "A single source for integrating AI Agents with the Crypto ecosystem. This includes Wallet creation and management, swaps, transfers, event-based trades like DCA, stop loss and take profit, and much more. The Armor MCP supports Solana in Alpha and, when in beta, will support more than a dozen blockchains, including Ethereum. Base, Avalanche, Bitcoin, Sui, Berachain, megaETH, Optimism, Ton, BNB, and Arbitrum, among others. Using Armor's MCP you can bring all of crypto into your AI Agent with unified logic and a complete set of tools.",
-    "repo": "https://github.com/HashWarlock/armor-crypto-mcp/tree/phala-mcp",
+    "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/armor-crypto",
     "author": "Armor Crypto",
     "icon": "armor-crypto.png",
+    "envs": [
+      {
+        "key": "ARMOR_API_KEY",
+        "required": true,
+        "description": "Armor API key."
+      },
+      {
+        "key": "ARMOR_API_URL",
+        "required": false,
+        "default": "https://app.armorwallet.ai/api/v1",
+        "description": "Armor API base URL."
+      },
+      {
+        "key": "ARMOR_ACCESS_TOKEN",
+        "required": false,
+        "description": "Optional Armor access token."
+      }
+    ],
     "tags": ["MCP"]
   },
   {

--- a/templates/prebuilt/armor-crypto/README.md
+++ b/templates/prebuilt/armor-crypto/README.md
@@ -1,0 +1,59 @@
+# Armor Crypto MCP
+
+Armor Crypto MCP prebuilt template for Phala Cloud.
+
+## Source
+
+- Upstream repository: https://github.com/HashWarlock/armor-crypto-mcp
+- Upstream branch: `phala-mcp`
+- Inspected upstream commit: `4835f496b16e25dcd0b604afe374ee51a185bb1a`
+- Pinned image: `hashwarlock/armor-crypto-mcp`
+- Pinned linux/amd64 digest: `sha256:ae7bda1b29077cdb39abf6d42587db630231dff5f2d38c7980108b9c14e48e1e`
+- Upstream license: GNU General Public License v3.0, from the upstream `LICENSE` file at the inspected commit.
+
+The compose file uses the digest reference:
+
+```text
+hashwarlock/armor-crypto-mcp@sha256:ae7bda1b29077cdb39abf6d42587db630231dff5f2d38c7980108b9c14e48e1e
+```
+
+## Phala Patch
+
+The upstream `docker-compose.yml` publishes port `8000` and sets `PORT=8000`, but it does not pass the README-required `ARMOR_API_KEY` into the container. This template keeps the public upstream image and port, pins the linux/amd64 image digest, and explicitly propagates the required and optional Armor API environment variables.
+
+## Environment Variables
+
+- `ARMOR_API_KEY` (required): Armor API key. The compose config fails if this is omitted.
+- `ARMOR_API_URL` (optional): Armor API base URL. Defaults to `https://app.armorwallet.ai/api/v1`.
+- `ARMOR_ACCESS_TOKEN` (optional): Armor access token, if your Armor setup requires one.
+
+Do not commit real API keys or secrets to this directory.
+
+## Smoke Test Probes
+
+After deployment, replace `APP_HOST` with the Phala CVM endpoint.
+
+```bash
+curl -iN "https://APP_HOST/sse"
+# Expect HTTP 200 with an SSE stream. The request may stay open.
+
+curl -i "https://APP_HOST/messages"
+# Expect an HTTP response from the MCP message endpoint.
+```
+
+Dummy `ARMOR_API_KEY` or `ARMOR_ACCESS_TOKEN` values only validate that the server boots and exposes the MCP transport. They do not validate real Armor API calls.
+
+## Update Procedure
+
+1. Inspect the new upstream source commit and record it in this README.
+2. Confirm the upstream license is still GPL v3.0 or update the license note if it changed.
+3. Verify the public linux/amd64 image digest for the image being deployed.
+4. Update `docker-compose.yml` to the new digest reference.
+5. Re-check upstream environment variable names and defaults, then update the compose environment block and this README if needed.
+6. Run:
+
+```bash
+ARMOR_API_KEY=dummy docker compose -f templates/prebuilt/armor-crypto/docker-compose.yml config
+```
+
+7. Smoke test `/sse` and `/messages` after deploying on Phala Cloud. Use a real Armor key for any test that exercises Armor API tools.

--- a/templates/prebuilt/armor-crypto/docker-compose.yml
+++ b/templates/prebuilt/armor-crypto/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  app:
+    image: hashwarlock/armor-crypto-mcp@sha256:ae7bda1b29077cdb39abf6d42587db630231dff5f2d38c7980108b9c14e48e1e
+    platform: linux/amd64
+    ports:
+      - "8000:8000"
+    environment:
+      PORT: "8000"
+      ARMOR_API_KEY: ${ARMOR_API_KEY:?ARMOR_API_KEY is required}
+      ARMOR_API_URL: ${ARMOR_API_URL:-https://app.armorwallet.ai/api/v1}
+      ARMOR_ACCESS_TOKEN: ${ARMOR_ACCESS_TOKEN:-}
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add a Phala Cloud maintained `templates/prebuilt/armor-crypto` compose/README.
- Pin the tested linux/amd64 `hashwarlock/armor-crypto-mcp` image by digest.
- Wire the README-required `ARMOR_API_KEY` plus optional `ARMOR_API_URL` / `ARMOR_ACCESS_TOKEN` into the container environment.
- Point the catalog entry at the local Phala Cloud template and add env metadata.

This avoids depending on an external upstream PR/merge for the template wiring fix; users can deploy the working template from the Phala Cloud repo.

## Smoke test
Original external compose:
- CVM reached running/online and `/sse` responded.
- Problem: upstream compose only set `PORT=8000`; README-required Armor API env was not propagated, so normal users could provide a key in the template UI but the container would not receive it.

Fixed Phala Cloud template:
- Profile/workspace: `hermes-admin-cvm-check` / `h4x's projects`
- CVM: `cvm_AjWa3lKb`, app `a8c68f252fea749e54d236b73ecabbc8097fa3f7`
- Result: running/online, container running, `/sse` returned HTTP 200 and `/messages` returned an app-level response.
- Cleanup: fixed smoke CVM deleted and verified not found. Original smoke CVM also deleted and verified.

## Validation
- `python3 templates/validate.py`
- `ARMOR_API_KEY=dummy_armor_api_key_for_smoke_only docker compose -f templates/prebuilt/armor-crypto/docker-compose.yml config`
- `docker manifest inspect hashwarlock/armor-crypto-mcp@sha256:ae7bda1b29077cdb39abf6d42587db630231dff5f2d38c7980108b9c14e48e1e`

cc @Marvin-Cypher for review/check/merge.
