### PR TITLE
fix: secure chatnio template defaults

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -576,7 +576,9 @@
     "icon": "chatnio.png",
     "envs": [
       { "key": "MYSQL_ROOT_PASSWORD", "required": true },
-      { "key": "MYSQL_PASSWORD", "required": true }
+      { "key": "MYSQL_PASSWORD", "required": true },
+      { "key": "SECRET", "required": true },
+      { "key": "CHATNIO_ROOT_PASSWORD", "required": true }
     ],
     "tags": ["Chat"]
   },

--- a/templates/prebuilt/chatnio/README.md
+++ b/templates/prebuilt/chatnio/README.md
@@ -6,4 +6,20 @@ The platform offers flexible deployment options including open-source, commercia
 
 **Notice**
 
-Please make sure the `MYSQL_ROOT_PASSWORD` and `MYSQL_PASSWORD` are set in the environment variable.
+Set these required environment variables before deploying:
+
+- `MYSQL_ROOT_PASSWORD`: internal MySQL root password.
+- `MYSQL_PASSWORD`: internal password for the `chatnio` MySQL user.
+- `SECRET`: Chatnio JWT signing secret. Use at least 32 characters.
+- `CHATNIO_ROOT_PASSWORD`: initial password for the `root` Chatnio admin user. Use 12-36 characters, do not include whitespace, and do not use Chatnio's public default password.
+
+Example generation commands:
+
+```sh
+openssl rand -base64 32 # MYSQL_ROOT_PASSWORD
+openssl rand -base64 32 # MYSQL_PASSWORD
+openssl rand -hex 32    # SECRET
+openssl rand -base64 24 # CHATNIO_ROOT_PASSWORD
+```
+
+Keep these values stable across redeploys. The template initializes the `root` admin user with `CHATNIO_ROOT_PASSWORD` before Chatnio starts, so the upstream fallback admin password `chatnio123456` is not used. MySQL and Redis are only reachable on the private compose network; the public web port remains `8000`.

--- a/templates/prebuilt/chatnio/docker-compose.yml
+++ b/templates/prebuilt/chatnio/docker-compose.yml
@@ -1,24 +1,35 @@
-version: '3'
 services:
   mysql:
-    image: mysql:latest
+    image: mysql:8.4
+    platform: linux/amd64
     container_name: db
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?Set MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: chatnio
       MYSQL_USER: chatnio
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:?Set MYSQL_PASSWORD}
       TZ: Asia/Shanghai
     expose:
       - "3306"
     volumes:
-        - db:/var/lib/mysql
+      - db:/var/lib/mysql
     networks:
       - chatnio-network
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "MYSQL_PWD=\"$${MYSQL_ROOT_PASSWORD}\" mysqladmin ping -h 127.0.0.1 -uroot --silent",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
 
   redis:
-    image: redis:latest
+    image: redis:7.4-alpine
+    platform: linux/amd64
     container_name: redis
     restart: always
     expose:
@@ -27,39 +38,102 @@ services:
       - redis:/data
     networks:
       - chatnio-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  init-root-user:
+    image: mysql:8.4
+    platform: linux/amd64
+    container_name: chatnio-init-root
+    restart: "no"
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      MYSQL_HOST: mysql
+      MYSQL_USER: chatnio
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:?Set MYSQL_PASSWORD}
+      MYSQL_DATABASE: chatnio
+      SECRET: ${SECRET:?Set SECRET}
+      CHATNIO_ROOT_PASSWORD: ${CHATNIO_ROOT_PASSWORD:?Set CHATNIO_ROOT_PASSWORD}
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -eu
+        if [ $${#SECRET} -lt 32 ]; then
+          echo "SECRET must be at least 32 characters." >&2
+          exit 1
+        fi
+        if [ "$${CHATNIO_ROOT_PASSWORD}" = "chatnio123456" ]; then
+          echo "CHATNIO_ROOT_PASSWORD must not use Chatnio's public default password." >&2
+          exit 1
+        fi
+        if [ $${#CHATNIO_ROOT_PASSWORD} -lt 12 ] || [ $${#CHATNIO_ROOT_PASSWORD} -gt 36 ]; then
+          echo "CHATNIO_ROOT_PASSWORD must be 12-36 characters." >&2
+          exit 1
+        fi
+        case "$${CHATNIO_ROOT_PASSWORD}" in
+          *[[:space:]]*)
+            echo "CHATNIO_ROOT_PASSWORD must not contain whitespace." >&2
+            exit 1
+            ;;
+        esac
+        password_hash="$$(printf '%s' "$${CHATNIO_ROOT_PASSWORD}" | sha256sum | awk '{print $$1}')"
+        export MYSQL_PWD="$${MYSQL_PASSWORD}"
+        mysql --host="$${MYSQL_HOST}" --user="$${MYSQL_USER}" "$${MYSQL_DATABASE}" <<SQL
+        CREATE TABLE IF NOT EXISTS auth (
+          id INT PRIMARY KEY AUTO_INCREMENT,
+          bind_id INT UNIQUE,
+          username VARCHAR(24) UNIQUE,
+          token VARCHAR(255) NOT NULL,
+          email VARCHAR(255) UNIQUE,
+          password VARCHAR(64) NOT NULL,
+          is_admin BOOLEAN DEFAULT FALSE,
+          is_banned BOOLEAN DEFAULT FALSE
+        );
+        INSERT INTO auth (username, password, email, is_admin, bind_id, token)
+        SELECT 'root', '$${password_hash}', 'root@example.com', TRUE, 0, 'root'
+        WHERE NOT EXISTS (SELECT 1 FROM auth LIMIT 1);
+        SQL
+    networks:
+      - chatnio-network
 
   chatnio:
-      image: programzmh/chatnio
-      container_name: chatnio
-      restart: always
-      ports:
-          - "8000:8094"
-      depends_on:
-          - mysql
-          - redis
-      links:
-          - mysql
-          - redis
-      ulimits:
-        nofile:
-          soft: 65535
-          hard: 65535
-      environment:
-          MYSQL_HOST: mysql
-          MYSQL_USER: chatnio
-          MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-          MYSQL_DB: chatnio
-          REDIS_HOST: redis
-          REDIS_PORT: 6379
-          REDIS_PASSWORD: ""
-          REDIS_DB: 0
-          SERVE_STATIC: "true"
-      volumes:
-        - config:/config
-        - logs:/logs
-        - storage:/storage
-      networks:
-        - chatnio-network
+    image: programzmh/chatnio:latest
+    platform: linux/amd64
+    container_name: chatnio
+    restart: always
+    ports:
+      - "8000:8094"
+    depends_on:
+      init-root-user:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+    ulimits:
+      nofile:
+        soft: 65535
+        hard: 65535
+    environment:
+      MYSQL_HOST: mysql
+      MYSQL_USER: chatnio
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:?Set MYSQL_PASSWORD}
+      MYSQL_DB: chatnio
+      SECRET: ${SECRET:?Set SECRET}
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: ""
+      REDIS_DB: 0
+      SERVE_STATIC: "true"
+    volumes:
+      - config:/config
+      - logs:/logs
+      - storage:/storage
+    networks:
+      - chatnio-network
 volumes:
   db:
   redis:


### PR DESCRIPTION
## Summary
- Require Chatnio `SECRET` and `CHATNIO_ROOT_PASSWORD` in the template metadata.
- Add a self-contained MySQL init service that creates the first root admin user with the configured password before Chatnio starts.
- Pass a strong `SECRET` to Chatnio and document generation guidance; MySQL/Redis remain private-only and web stays on port 8000.

## Live smoke evidence
- Original template deployed and returned HTTP 200, but logs showed weak upstream `secret` fallback and public default admin creation.
- Fixed template deployed in `h4x's projects` with `hermes-admin-cvm-check`: CVM online/running, Chatnio/MySQL/Redis running, init container exited 0.
- Fixed root URL returned HTTP 200; public default admin login failed; configured admin login succeeded (token redacted in artifacts).
- Both original and fixed smoke CVMs were deleted and verified not found.

## Validation
- `docker compose --env-file /tmp/... -f templates/prebuilt/chatnio/docker-compose.yml config`
- `python templates/validate.py`
- `git diff --check -- templates/config.json templates/prebuilt/chatnio/docker-compose.yml templates/prebuilt/chatnio/README.md`
- `docker manifest inspect mysql:8.4`, `redis:7.4-alpine`, `programzmh/chatnio:latest` (linux/amd64 present)

cc @Marvin-Cypher for review/check/merge.
