### PR TITLE
fix: add Moralis MCP prebuilt template

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -610,7 +610,7 @@
     "id": "moralis-mcp",
     "name": "Moralis MCP",
     "description": "A Moralis MCP server deployed on Phala Cloud is an engine that connects natural language prompts to real blockchain insights — allowing AI models to query wallet activity, token metrics, dapp usage, and more without custom code or SQL.",
-    "repo": "https://github.com/HashWarlock/moralis-mcp-server",
+    "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/moralis-mcp",
     "author": "HashWarlock",
     "icon": "moralis.png",
     "envs": [

--- a/templates/prebuilt/moralis-mcp/README.md
+++ b/templates/prebuilt/moralis-mcp/README.md
@@ -1,0 +1,80 @@
+# Moralis MCP
+
+Moralis MCP server prebuilt template for Phala Cloud. The app is built locally at deploy time from pinned upstream source and exposed through a Caddy bearer-token proxy.
+
+## Upstream
+
+- Source repository: https://github.com/HashWarlock/moralis-mcp-server
+- Pinned commit: `bcd9bf0ec430bb0dc68955973f13d61f9e3725d3`
+- Upstream branch at inspection time: `phala-cloud`; deploy-time builds use the commit SHA, not the branch name.
+- Package version: `@moralisweb3/api-mcp-server` `1.8.2`
+- License: ISC, as declared in upstream `package.json`. The inspected commit does not include a standalone license file.
+
+## Why This Template Builds Locally
+
+The external compose file for the Phala Cloud support branch used `hashwarlock/moralis-mcp-server:v0.0.1`. Live smoke deployment showed the app container restarting and exiting with status 0 while the proxy stayed up. This template avoids the broken public image by building the server from the pinned source commit with Compose `dockerfile_inline`.
+
+The inline Dockerfile downloads the immutable upstream archive, installs dependencies with `npm ci`, builds the TypeScript server, prunes development dependencies, and runs:
+
+```bash
+node ./dist/index.js --transport streamable-http
+```
+
+## Services
+
+- `app`: Moralis MCP server on the internal Docker network at port `3000`.
+- `proxy`: Caddy 2.8 on public port `18080`, requiring a bearer authorization header before forwarding to the app.
+
+The app container does not publish port `3000` directly.
+
+## Environment Variables
+
+- `BEARER_TOKEN` (required): Bearer token checked by the Caddy proxy.
+- `MORALIS_API_KEY` (required): Moralis API key used by the MCP tools when calling Moralis APIs.
+
+Do not commit real API keys or bearer tokens to this directory.
+
+## Local Compose Check
+
+From the repository root:
+
+```bash
+BEARER_TOKEN=dummy MORALIS_API_KEY=dummy docker compose -f templates/prebuilt/moralis-mcp/docker-compose.yml config
+```
+
+## Smoke Probes
+
+After deployment, replace `APP_HOST` with the Phala CVM endpoint for public port `18080`.
+
+```bash
+curl -i "https://APP_HOST/health"
+```
+
+Expected: `401 Unauthorized`, proving unauthenticated requests are blocked by Caddy.
+
+Set AUTH_HEADER in your shell to the required bearer authorization header before running the authenticated examples.
+
+```bash
+curl -i -H "$AUTH_HEADER" "https://APP_HOST/health"
+```
+
+Expected: `200 OK` with JSON including `status: "OK"` and `server: "Moralis MCP"`.
+
+```bash
+curl -i -H "$AUTH_HEADER" "https://APP_HOST/mcp"
+```
+
+Expected: `405 Method Not Allowed`. The streamable HTTP MCP endpoint is `/mcp` and accepts MCP JSON-RPC over POST, so GET is rejected when the app is healthy.
+
+## Update Path
+
+1. Review upstream changes in https://github.com/HashWarlock/moralis-mcp-server.
+2. Choose and record a new immutable upstream commit SHA.
+3. Update `UPSTREAM_COMMIT` in `docker-compose.yml`.
+4. Re-check the upstream runtime command, transport support, port, package license, and required environment variables.
+5. Run the local compose check above.
+6. Run `python3 templates/validate.py` from the repository root.
+7. Run `git diff --check` before opening a pull request.
+8. Smoke test `/health` and `/mcp` on a local or Phala Cloud deployment.
+
+Do not switch this template back to `hashwarlock/moralis-mcp-server:v0.0.1` unless that image has been rebuilt, published for the expected platform, and verified by a Phala Cloud smoke deployment.

--- a/templates/prebuilt/moralis-mcp/docker-compose.yml
+++ b/templates/prebuilt/moralis-mcp/docker-compose.yml
@@ -1,0 +1,82 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM node:22.12-alpine AS builder
+
+        ARG UPSTREAM_REPO=HashWarlock/moralis-mcp-server
+        ARG UPSTREAM_COMMIT=bcd9bf0ec430bb0dc68955973f13d61f9e3725d3
+
+        WORKDIR /app
+
+        RUN apk add --no-cache ca-certificates tar wget
+
+        RUN wget -O /tmp/moralis-mcp-server.tar.gz "https://github.com/$${UPSTREAM_REPO}/archive/$${UPSTREAM_COMMIT}.tar.gz" \
+            && tar -xzf /tmp/moralis-mcp-server.tar.gz -C /app --strip-components=1 \
+            && rm /tmp/moralis-mcp-server.tar.gz
+
+        RUN NODE_ENV=development npm ci --ignore-scripts --no-audit --no-fund \
+            && npm run build \
+            && npm prune --omit=dev --ignore-scripts --no-audit --no-fund
+
+        FROM node:22.12-alpine AS runtime
+
+        ENV NODE_ENV=production
+
+        WORKDIR /app
+
+        COPY --from=builder /app/package.json /app/package-lock.json ./
+        COPY --from=builder /app/node_modules ./node_modules
+        COPY --from=builder /app/dist ./dist
+
+        EXPOSE 3000
+
+        USER node
+
+        CMD ["node", "./dist/index.js", "--transport", "streamable-http"]
+    image: moralis-mcp:phala-bcd9bf0
+    pull_policy: build
+    environment:
+      NODE_ENV: production
+      MORALIS_API_KEY: ${MORALIS_API_KEY:?MORALIS_API_KEY is required}
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      BEARER_TOKEN: ${BEARER_TOKEN:?BEARER_TOKEN is required}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    depends_on:
+      - app
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header Authorization "Bearer $BEARER_TOKEN"
+          }
+          route @valid_auth {
+              reverse_proxy app:3000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge


### PR DESCRIPTION
## Summary
- Add a Phala-maintained `templates/prebuilt/moralis-mcp` template that builds Moralis MCP from pinned upstream commit `bcd9bf0ec430bb0dc68955973f13d61f9e3725d3` via `dockerfile_inline`.
- Avoid the external `hashwarlock/moralis-mcp-server:v0.0.1` image observed to restart-loop/exit during live smoke deployment.
- Update the template catalog to point Moralis MCP at the local Phala Cloud template path and document source, license, update path, and smoke probes.

## Live audit evidence
- Original external compose deployed, but `dstack-app-1` was `restarting` while `dstack-proxy-1` stayed up.
- Fixed Phala Cloud template deployed successfully as `moralis-mcp-fixed-smoke-0516-0849` on profile `hermes-admin-cvm-check` / workspace `h4x's projects`.
- Fixed CVM reached `running` + online with both `dstack-app-1` and `dstack-proxy-1` running.
- Public probes on port `18080`:
  - unauth `/health` -> `401 Unauthorized`
  - authenticated `/health` -> `200` JSON `{status: OK, server: Moralis MCP}`
  - authenticated `GET /mcp` -> `405 Method Not Allowed` (expected for streamable HTTP)
  - authenticated MCP initialize `POST /mcp` with correct `Accept` -> `200 text/event-stream`

## Validation
- `BEARER_TOKEN=dummy MORALIS_API_KEY=dummy docker compose -f templates/prebuilt/moralis-mcp/docker-compose.yml config`
- `python3 templates/validate.py`
- `git diff --check`
- Live deploy smoke + cleanup verified for both original and fixed CVMs.

cc @Marvin-Cypher for review/merge.
