### PR TITLE
fix: add zep graphiti mcp prebuilt template

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -631,15 +631,45 @@
     "id": "zep-graphiti-mcp",
     "name": "Zep Graphiti MCP",
     "description": "A Zep Graphiti MCP server deployed on Phala Cloud to build private Real-Time Knowledge Graphs for AI Agents.",
-    "repo": "https://github.com/HashWarlock/graphiti/tree/main/mcp_server",
+    "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/zep-graphiti-mcp",
     "author": "HashWarlock",
     "icon": "zep.png",
     "envs": [
-      { "key": "OPENAI_API_KEY", "required": true },
-      { "key": "MODEL_NAME", "required": true },
-      { "key": "NEO4J_URI", "required": false },
-      { "key": "NEO4J_USER", "required": false },
-      { "key": "NEO4J_PASSWORD", "required": false }
+      {
+        "key": "OPENAI_API_KEY",
+        "required": true,
+        "description": "OpenAI API key used by Graphiti for LLM and embedding operations"
+      },
+      {
+        "key": "MODEL_NAME",
+        "required": false,
+        "default": "gpt-4.1-mini",
+        "description": "OpenAI model used for Graphiti LLM calls"
+      },
+      {
+        "key": "NEO4J_URI",
+        "required": false,
+        "default": "bolt://neo4j:7687",
+        "description": "Neo4j Bolt URI; the default uses the internal bundled Neo4j service"
+      },
+      {
+        "key": "NEO4J_USER",
+        "required": false,
+        "default": "neo4j",
+        "description": "Neo4j username"
+      },
+      {
+        "key": "NEO4J_PASSWORD",
+        "required": false,
+        "default": "demodemo",
+        "description": "Neo4j password for the bundled internal Neo4j service"
+      },
+      {
+        "key": "SEMAPHORE_LIMIT",
+        "required": false,
+        "default": "1",
+        "description": "Episode processing concurrency; keep low to reduce LLM provider rate-limit pressure"
+      }
     ],
     "tags": ["MCP", "Knowledge Graph"]
   },

--- a/templates/prebuilt/zep-graphiti-mcp/README.md
+++ b/templates/prebuilt/zep-graphiti-mcp/README.md
@@ -1,0 +1,73 @@
+# Zep Graphiti MCP
+
+Phala Cloud prebuilt template for running the Zep Graphiti MCP server with an internal Neo4j database.
+
+## Source
+
+- Upstream repository: https://github.com/HashWarlock/graphiti/tree/main/mcp_server
+- Pinned upstream commit: `9ceeb5418605f91bb919151d388f786cfbea8c4a`
+- Upstream license: Apache-2.0, verified from the upstream repository `LICENSE` file at the pinned commit.
+- Runtime database image: `neo4j:5.26.0`
+
+## Why This Wrapper Exists
+
+The upstream `mcp_server/docker-compose.yml` builds `graphiti-mcp` from a local `Dockerfile` in the upstream repository. During Phala Cloud prebuilt deployment, the guest build can receive the compose file without that upstream build context, so Docker fails with `open Dockerfile: no such file or directory`.
+
+This Phala-maintained wrapper keeps the deployment self-contained by embedding a Compose `dockerfile_inline` build. The inline Dockerfile fetches the pinned upstream archive, copies the MCP server files from `mcp_server`, installs the locked Python dependencies, and runs the SSE server. It does not depend on an external upstream pull request or a local user-provided Dockerfile.
+
+## Services
+
+- `graphiti-mcp`: Graphiti MCP server exposed on host port `8000`.
+- `neo4j`: Neo4j `5.26.0` database on the internal Compose network only.
+
+Neo4j is intentionally not exposed as a public port. The MCP service connects to it over the internal Docker network using `bolt://neo4j:7687`.
+
+## Environment Variables
+
+- `OPENAI_API_KEY` (required): OpenAI API key used by Graphiti for LLM and embedding operations. The compose config fails if this is omitted.
+- `MODEL_NAME` (optional): OpenAI model used for LLM calls. Defaults to `gpt-4.1-mini`.
+- `NEO4J_URI` (optional): Neo4j Bolt URI. Defaults to `bolt://neo4j:7687`.
+- `NEO4J_USER` (optional): Neo4j username. Defaults to `neo4j`.
+- `NEO4J_PASSWORD` (optional): Neo4j password. Defaults to `demodemo`.
+- `SEMAPHORE_LIMIT` (optional): Episode processing concurrency. Defaults to `1` to reduce provider rate-limit pressure on small deployments.
+
+Do not commit real API keys or secrets to this directory.
+
+## Endpoint
+
+After deploying on Phala Cloud, use the MCP SSE endpoint for port `8000`:
+
+```text
+https://APP_HOST/sse
+```
+
+Quick probe:
+
+```bash
+curl -iN "https://APP_HOST/sse"
+```
+
+An SSE response confirms that the MCP transport is reachable. The server initializes Graphiti and Neo4j before serving requests, so startup can take longer on the first boot while the image builds and Neo4j creates its data store.
+
+## Local Validation
+
+From the repository root:
+
+```bash
+OPENAI_API_KEY=dummy docker compose -f templates/prebuilt/zep-graphiti-mcp/docker-compose.yml config
+python3 templates/validate.py
+```
+
+The first command validates compose interpolation and confirms `OPENAI_API_KEY` is wired as a required variable. The second validates the template catalog metadata.
+
+## Update Path
+
+1. Review upstream changes in https://github.com/HashWarlock/graphiti/tree/main/mcp_server.
+2. Choose and record a new immutable upstream commit SHA.
+3. Update `UPSTREAM_COMMIT` and the image tag in `docker-compose.yml`.
+4. Re-check upstream environment variables, dependency lockfile behavior, and the Graphiti MCP launch command.
+5. Run `OPENAI_API_KEY=dummy docker compose -f templates/prebuilt/zep-graphiti-mcp/docker-compose.yml config`.
+6. Run `python3 templates/validate.py` from the repository root.
+7. Smoke test `/sse` after deploying on Phala Cloud.
+
+Keep this template self-contained. Do not replace the inline Dockerfile with an external `Dockerfile` path unless Phala Cloud deployment is also changed to provide that exact build context.

--- a/templates/prebuilt/zep-graphiti-mcp/docker-compose.yml
+++ b/templates/prebuilt/zep-graphiti-mcp/docker-compose.yml
@@ -1,0 +1,99 @@
+services:
+  neo4j:
+    image: neo4j:5.26.0
+    restart: unless-stopped
+    environment:
+      NEO4J_AUTH: ${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD:-demodemo}
+      NEO4J_server_memory_heap_initial__size: 512m
+      NEO4J_server_memory_heap_max__size: 1G
+      NEO4J_server_memory_pagecache_size: 512m
+    volumes:
+      - neo4j_data:/data
+      - neo4j_logs:/logs
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "cypher-shell",
+          "-a",
+          "bolt://localhost:7687",
+          "-u",
+          "${NEO4J_USER:-neo4j}",
+          "-p",
+          "${NEO4J_PASSWORD:-demodemo}",
+          "RETURN 1",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+    networks:
+      - graphiti
+
+  graphiti-mcp:
+    build:
+      context: .
+      dockerfile_inline: |
+        # syntax=docker/dockerfile:1.9
+        FROM python:3.12-slim
+
+        ARG UPSTREAM_COMMIT=9ceeb5418605f91bb919151d388f786cfbea8c4a
+        ARG UV_VERSION=0.7.13
+
+        WORKDIR /app
+
+        RUN apt-get update \
+            && apt-get install -y --no-install-recommends ca-certificates wget \
+            && rm -rf /var/lib/apt/lists/*
+
+        RUN pip install --no-cache-dir "uv==$${UV_VERSION}"
+
+        ENV UV_COMPILE_BYTECODE=1 \
+            UV_LINK_MODE=copy \
+            UV_PYTHON_DOWNLOADS=never \
+            MCP_SERVER_HOST=0.0.0.0 \
+            PYTHONUNBUFFERED=1
+
+        RUN wget -O /tmp/graphiti.tar.gz "https://github.com/HashWarlock/graphiti/archive/$${UPSTREAM_COMMIT}.tar.gz" \
+            && mkdir -p /tmp/graphiti \
+            && tar -xzf /tmp/graphiti.tar.gz -C /tmp/graphiti --strip-components=1 \
+            && cp /tmp/graphiti/mcp_server/pyproject.toml /tmp/graphiti/mcp_server/uv.lock ./ \
+            && cp /tmp/graphiti/mcp_server/graphiti_mcp_server.py ./ \
+            && rm -rf /tmp/graphiti /tmp/graphiti.tar.gz
+
+        RUN uv sync --frozen --no-dev --no-install-project
+
+        RUN groupadd -r app \
+            && useradd -r -d /app -g app app \
+            && chown -R app:app /app
+
+        USER app
+
+        EXPOSE 8000
+
+        CMD ["/app/.venv/bin/python", "graphiti_mcp_server.py", "--transport", "sse"]
+    image: zep-graphiti-mcp:9ceeb5418605f91bb919151d388f786cfbea8c4a
+    pull_policy: build
+    restart: unless-stopped
+    depends_on:
+      neo4j:
+        condition: service_healthy
+    environment:
+      NEO4J_URI: ${NEO4J_URI:-bolt://neo4j:7687}
+      NEO4J_USER: ${NEO4J_USER:-neo4j}
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-demodemo}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:?OPENAI_API_KEY is required}
+      MODEL_NAME: ${MODEL_NAME:-gpt-4.1-mini}
+      SEMAPHORE_LIMIT: ${SEMAPHORE_LIMIT:-1}
+    ports:
+      - "8000:8000"
+    networks:
+      - graphiti
+
+networks:
+  graphiti:
+    driver: bridge
+
+volumes:
+  neo4j_data:
+  neo4j_logs:


### PR DESCRIPTION
## Summary
- Add a maintained Phala Cloud prebuilt template for `zep-graphiti-mcp`.
- Replace the external compose/build-context deployment path with a self-contained `dockerfile_inline` wrapper pinned to HashWarlock/graphiti commit `9ceeb5418605f91bb919151d388f786cfbea8c4a`.
- Update template catalog metadata to point at the local prebuilt path and document required/default envs.

## Live audit finding
The original external compose deployed a CVM but failed before app startup because the guest attempted to build `graphiti-mcp` from `Dockerfile` without the upstream build context:

```text
failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
```

This PR avoids dependency on an external upstream PR merge or user-provided local Dockerfile by keeping the runnable wrapper in the Phala Cloud repo.

## Validation
- `OPENAI_API_KEY=dummy-openai-api-key-for-phala-template-smoke docker compose -f templates/prebuilt/zep-graphiti-mcp/docker-compose.yml config` ✅
- `env -u OPENAI_API_KEY docker compose -f templates/prebuilt/zep-graphiti-mcp/docker-compose.yml config` fails as expected with required-var error ✅
- `python3 templates/validate.py` ✅
- `git diff --check` ✅
- Live Phala smoke on profile `hermes-admin-cvm-check` / workspace `h4x's projects` ✅
  - CVM reached `running`, `is_online=true`
  - containers running: `dstack-graphiti-mcp-1`, `dstack-neo4j-1 (healthy)`
  - `/sse` returned `HTTP 200` `text/event-stream`
  - root returned expected `404 Not Found`
- Cleanup verified for both original failed smoke CVM and fixed smoke CVM ✅

cc @Marvin-Cypher for review/check/merge.
