### PR TITLE
docs: clarify NEAR Shade Agent smoke checks

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -663,12 +663,12 @@
       { 
         "key": "NEAR_ACCOUNT_ID", 
         "required": true, 
-        "description": "NEAR account ID obtained from near-cli-rs" 
+        "description": "NEAR testnet account ID obtained from near-cli-rs; real account required for agent-account and transaction behavior"
       },
       { 
         "key": "NEAR_SEED_PHRASE", 
         "required": true, 
-        "description": "NEAR account seed phrase for authentication" 
+        "description": "Matching NEAR testnet account seed phrase; dummy values are only suitable for shallow smoke tests"
       },
       { 
         "key": "NEXT_PUBLIC_contractId", 
@@ -697,7 +697,7 @@
       { 
         "key": "PHALA_API_KEY", 
         "required": true, 
-        "description": "Phala API key from https://cloud.phala.com/dashboard/tokens" 
+        "description": "Phala API key from https://cloud.phala.com/dashboard/tokens; real key required for full agent behavior"
       }
     ],
     "tags": ["Agent", "NEAR", "Oracle", "TEE"]

--- a/templates/prebuilt/near-shade-agent/README.md
+++ b/templates/prebuilt/near-shade-agent/README.md
@@ -84,63 +84,46 @@ Configure the following environment variables:
 The template provides these REST API endpoints:
 
 ### Agent Account Details
-- **GET** `/api/agent/account`
+- **GET** `/api/agent-account`
 - **Description**: Returns NEAR agent account information and status
-- **Authentication**: None required for basic status
+- **Authentication**: None at the HTTP layer; requires a real NEAR testnet account, seed phrase, and Phala API key for a successful agent-account response
 - **Response**:
 ```json
 {
-  "status": "success",
-  "data": {
-    "accountId": "your-agent.testnet",
-    "balance": "1000.5 NEAR",
-    "contractDeployed": true,
-    "lastActivity": "2025-08-08T10:30:00Z"
-  }
+  "accountId": "your-agent.testnet",
+  "balance": "1000.5 NEAR"
 }
 ```
 
 ### Ethereum Account Details  
-- **GET** `/api/eth/account`
+- **GET** `/api/eth-account`
 - **Description**: Get Ethereum account information for oracle operations
-- **Authentication**: Bearer token required
+- **Authentication**: None at the HTTP layer
 - **Response**:
 ```json
 {
-  "status": "success", 
-  "data": {
-    "address": "0x1234567890123456789012345678901234567890",
-    "balance": "0.5 ETH",
-    "nonce": 42,
-    "network": "mainnet"
-  }
+  "senderAddress": "0x1234567890123456789012345678901234567890",
+  "balance": 0.5
 }
 ```
 
 ### Send Transaction
-- **POST** `/api/eth/send`
-- **Description**: Send Ethereum transactions through the TEE agent
-- **Authentication**: Bearer token required
-- **Request**:
-```json
-{
-  "to": "0x1234567890123456789012345678901234567890",
-  "value": "0.1",
-  "gasLimit": 21000,
-  "data": "0x"
-}
-```
+- **GET** `/api/transaction`
+- **Description**: Send the ETH price oracle update transaction through the TEE agent
+- **Authentication**: None at the HTTP layer; requires real NEAR testnet credentials, a valid Phala API key, and funding for the derived Ethereum account
 - **Response**:
 ```json
 {
-  "status": "success",
-  "data": {
-    "transactionHash": "0xabcdef...",
-    "gasUsed": 21000,
-    "status": "pending"
-  }
+  "txHash": "0xabcdef...",
+  "newPrice": "2500.00"
 }
 ```
+
+## Smoke Testing
+
+For shallow deployment smoke tests, generated dummy values for `NEAR_SEED_PHRASE` and `PHALA_API_KEY` can bring up the web app and allow `GET /` plus `GET /api/eth-account` to respond. These checks only verify that the image is serving and that the Ethereum account derivation route is reachable.
+
+`GET /api/agent-account` and `GET /api/transaction` are expected to fail with dummy NEAR or Phala credentials. Full agent-account and transaction behavior requires a real NEAR testnet account ID, the matching seed phrase, a valid Phala API key, the correct `NEXT_PUBLIC_contractId`, and any required funding for the derived Ethereum account. During dummy-credential smoke tests, the `shade-agent-api` sidecar may restart while failing to authenticate; treat that as expected unless real credentials were provided.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Correct NEAR Shade Agent README endpoint paths to match the live app image/source (`/api/agent-account`, `/api/eth-account`, `/api/transaction`).
- Document the dummy-credential smoke-test boundary: shallow checks can validate `/` and `/api/eth-account`, but full agent-account/transaction behavior requires real NEAR testnet credentials, a valid Phala API key, the correct contract ID, and funding.
- Clarify template metadata descriptions for real-vs-dummy credential expectations.

## Live smoke evidence
- `docker compose config` passed for `templates/prebuilt/near-shade-agent/docker-compose.yml` with generated dummy values.
- Deployed to Phala Cloud profile `hermes-admin-cvm-check` in workspace `h4x's projects`.
- CVM reached `running`/online and the public app endpoint returned:
  - `GET /` -> HTTP 200
  - `GET /api/eth-account` -> HTTP 200
  - `GET /api/agent-account` -> HTTP 500 with dummy credentials
  - `GET /api/transaction` -> HTTP 500 with dummy credentials
- The `shade-agent-api` sidecar restarted with dummy credentials; this PR documents that boundary instead of changing runtime behavior.
- Test CVM was deleted and verified not found / not existing.

## Validation
- `jq empty templates/config.json`
- `git diff --check`
- no stale `/api/agent/account`, `/api/eth/account`, or `/api/eth/send` references remain

cc @Marvin-Cypher for review.
