### PR TITLE
fix: add secured Akave Link prebuilt template

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -740,14 +740,15 @@
   {
     "id": "akave-link",
     "name": "Akave Link (Confidential Storage API)",
-    "description": "A production-ready Akave decentralized storage API with interactive UI, password-gated access (optional), and wallet connect/disconnect, running in Phala Cloud's TEE.",
-    "repo": "https://github.com/DylanCkawalec/akavelink",
+    "description": "A production-ready Akave decentralized storage API with interactive UI, Caddy Basic Auth protection, and wallet connect/disconnect, running in Phala Cloud's TEE.",
+    "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/akave-link",
     "author": "DylanCkawalec",
     "icon": "akave-link.png",
     "envs": [
       { "key": "NODE_ADDRESS", "required": true, "default": "connect.akave.ai:5500", "description": "Akave node endpoint" },
       { "key": "PRIVATE_KEY", "required": true, "description": "Ethereum private key for Akave" },
-      { "key": "ADMIN_PASSWORD_HASH", "required": false, "description": "bcrypt hash for API password (protects all routes)" },
+      { "key": "ADMIN_PASSWORD_HASH", "required": true, "description": "Caddy bcrypt hash for the Basic Auth password that protects all routes" },
+      { "key": "AKAVELINK_USERNAME", "required": false, "default": "admin", "description": "Caddy Basic Auth username" },
       { "key": "PORT", "required": false, "default": "80" },
       { "key": "CORS_ORIGIN", "required": false, "default": "*" },
       { "key": "DEBUG", "required": false, "default": "true" }

--- a/templates/prebuilt/akave-link/README.md
+++ b/templates/prebuilt/akave-link/README.md
@@ -1,0 +1,99 @@
+# Akave Link
+
+This prebuilt template deploys Akave Link behind a Caddy Basic Auth reverse proxy for Phala Cloud. The Akave Link app is kept on an internal Docker network and Caddy is the only service that publishes port `80`.
+
+## Source
+
+- Reference repo: https://github.com/DylanCkawalec/akavelink
+- Reference commit: `69124a575eba00f97f3b344cffca5a3e088b1d5d`
+- Upstream image: `dylanckawalec/akavelink@sha256:b2c4a351869d6ed0665e4e6a15c5c73fbea38489589d2547ed4a9026f0cdf73b`
+- Caddy image: `caddy:2.8@sha256:b95ed06fbc6d74d24a40902090c8cc6086ce7d08ba60a3a7e8e62bf164a9d7bb`
+- Platform: `linux/amd64`
+- Upstream source license: GPL-3.0, based on the `LICENSE` file at the reference commit.
+
+This Phala Cloud template does not vendor or modify upstream source code. It uses the pinned published upstream image plus local Docker Compose and Caddy wrapper files for deployment.
+
+## Services
+
+- `app`: Akave Link, listening only on the internal Docker network at port `80`.
+- `caddy`: Public reverse proxy on `80:80`, protecting all routes with Basic Auth.
+- `akave_downloads`: Named volume mounted at `/app/downloads`, replacing the upstream `./downloads` bind mount.
+
+The app healthcheck is overridden to probe `http://localhost:80/health`, matching the configured app port. The Caddy healthcheck validates the local Caddyfile because the public `/health` route is intentionally protected and cannot be checked without the plaintext Basic Auth password.
+
+## Environment
+
+Required:
+
+- `NODE_ADDRESS`: Akave node endpoint, for example `connect.akave.ai:5500`.
+- `PRIVATE_KEY`: EVM private key used by Akave Link for bucket and file operations.
+- `ADMIN_PASSWORD_HASH`: Caddy bcrypt hash for the Basic Auth password.
+
+Optional:
+
+- `AKAVELINK_USERNAME`: Basic Auth username. Defaults to `admin`.
+- `PORT`: Catalog compatibility setting. Keep this at `80`; the compose file runs the app on internal port `80`.
+- `CORS_ORIGIN`: App CORS origin. Defaults to `*`.
+- `DEBUG`: App debug logging flag. Defaults to `true`.
+
+`ADMIN_PASSWORD_HASH` is also passed to the app for forward compatibility, although the pinned upstream app currently ignores it for route authorization. Caddy is the enforced public access control layer.
+
+## Generate `ADMIN_PASSWORD_HASH`
+
+Use Caddy's bcrypt helper:
+
+```bash
+docker run --rm --platform linux/amd64 caddy:2.8@sha256:b95ed06fbc6d74d24a40902090c8cc6086ce7d08ba60a3a7e8e62bf164a9d7bb caddy hash-password --plaintext 'replace-with-a-long-random-password'
+```
+
+Set the generated hash as `ADMIN_PASSWORD_HASH`. If you use a local `.env` file with Docker Compose, wrap the bcrypt hash in single quotes so the `$` characters are preserved:
+
+```env
+AKAVELINK_USERNAME=admin
+ADMIN_PASSWORD_HASH='$2a$14$replace.with.the.hash.from.caddy'
+```
+
+Keep the plaintext password outside the deployment environment. It is only needed by clients when sending Basic Auth credentials.
+
+## Local Validation
+
+Validate compose rendering with dummy values:
+
+```bash
+NODE_ADDRESS=connect.akave.ai:5500 \
+PRIVATE_KEY=0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+ADMIN_PASSWORD_HASH='$2a$14$replace.with.a.real.caddy.hash.before.running' \
+docker compose -f docker-compose.yml config --quiet
+```
+
+Use a real hash before starting the stack. After deployment, these probes are safe because they do not create buckets or write storage data:
+
+```bash
+BASE_URL=http://localhost
+AKAVELINK_USERNAME=admin
+AKAVELINK_ADMIN_PASSWORD='the-plaintext-password-used-for-the-hash'
+
+curl -i "$BASE_URL/health"
+curl -fsS -u "$AKAVELINK_USERNAME:$AKAVELINK_ADMIN_PASSWORD" "$BASE_URL/health"
+curl -fsS -u "$AKAVELINK_USERNAME:$AKAVELINK_ADMIN_PASSWORD" "$BASE_URL/" >/dev/null
+```
+
+The unauthenticated `/health` request should return `401 Unauthorized`. The authenticated `/health` request should return the app health JSON.
+
+For Phala Cloud, use the deployment gateway URL as `BASE_URL`, for example:
+
+```bash
+BASE_URL=https://<app-id>-80.<gateway-domain>
+```
+
+## Akave Operations
+
+A syntactically valid but unfunded dummy private key can validate container boot, the UI, Caddy authentication, and `/health`. Real Akave bucket and file operations require a real funded private key for the target Akave network.
+
+## Update Path
+
+1. Review upstream changes from commit `69124a575eba00f97f3b344cffca5a3e088b1d5d`.
+2. Choose and verify a replacement `linux/amd64` image digest.
+3. Update `docker-compose.yml` with the new digest and keep the app unexposed behind Caddy.
+4. Re-run Docker Compose config validation with dummy values.
+5. Smoke test unauthenticated `401`, authenticated `/health`, and authenticated UI loading before updating the catalog entry.

--- a/templates/prebuilt/akave-link/docker-compose.yml
+++ b/templates/prebuilt/akave-link/docker-compose.yml
@@ -1,0 +1,84 @@
+services:
+  app:
+    image: dylanckawalec/akavelink@sha256:b2c4a351869d6ed0665e4e6a15c5c73fbea38489589d2547ed4a9026f0cdf73b
+    platform: linux/amd64
+    restart: unless-stopped
+    expose:
+      - "80"
+    environment:
+      NODE_ADDRESS: "${NODE_ADDRESS}"
+      PRIVATE_KEY: "${PRIVATE_KEY}"
+      PORT: "80"
+      CORS_ORIGIN: "${CORS_ORIGIN:-*}"
+      DEBUG: "${DEBUG:-true}"
+      ADMIN_PASSWORD_HASH: "${ADMIN_PASSWORD_HASH}"
+    volumes:
+      - /var/run/tappd.sock:/var/run/tappd.sock
+      - akave_downloads:/app/downloads
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "wget",
+          "--no-verbose",
+          "--tries=1",
+          "--spider",
+          "http://localhost:80/health"
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - internal
+
+  caddy:
+    image: caddy:2.8@sha256:b95ed06fbc6d74d24a40902090c8cc6086ce7d08ba60a3a7e8e62bf164a9d7bb
+    platform: linux/amd64
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    environment:
+      AKAVELINK_USERNAME: "${AKAVELINK_USERNAME:-admin}"
+      ADMIN_PASSWORD_HASH: "${ADMIN_PASSWORD_HASH}"
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    depends_on:
+      app:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "caddy",
+          "validate",
+          "--config",
+          "/etc/caddy/Caddyfile",
+          "--adapter",
+          "caddyfile"
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          basic_auth {
+              {$$AKAVELINK_USERNAME} {$$ADMIN_PASSWORD_HASH}
+          }
+
+          reverse_proxy app:80
+      }
+
+networks:
+  internal:
+    driver: bridge
+
+volumes:
+  akave_downloads:


### PR DESCRIPTION
## Summary
- Add a Phala-maintained `templates/prebuilt/akave-link` compose/README wrapper for Akave Link.
- Pin the upstream Akave Link image and Caddy image by linux/amd64 digest.
- Put Akave Link behind a Caddy Basic Auth proxy, remove direct public app exposure, replace `./downloads` bind with a named volume, and override the app healthcheck to `localhost:80/health`.
- Update the catalog entry to point to the Phala Cloud template path and require `ADMIN_PASSWORD_HASH`.

## Why
The current catalog entry points to the external upstream compose. Live smoke found the app deploys, but the published image reports `unhealthy` because its image healthcheck probes port `3000` while the app listens on `80`; it also exposes PRIVATE_KEY-backed admin/storage endpoints publicly without auth. This PR keeps the working upstream runtime image but wraps it safely in Phala Cloud so users are not blocked on an external upstream merge.

## Validation
- `python3 -m json.tool templates/config.json`
- `docker compose --env-file <dummy env> -f templates/prebuilt/akave-link/docker-compose.yml config --quiet`
- Live smoke on profile `hermes-admin-cvm-check` / workspace `h4x's projects`:
  - original external compose: CVM running/online, `/` 200, `/health` 200, `/admin/status` 200, `/buckets` 200, but container status `unhealthy` and endpoints unauthenticated.
  - fixed Phala Cloud template: CVM running/online, both containers healthy; unauthenticated `/` and `/health` returned 401; authenticated `/` and `/health` returned 200; authenticated `/buckets` returned 200 with empty data using a generated dummy private key.
- Cleanup verified for both smoke CVMs via delete + follow-up not-found/admin exists=0 checks.

cc @Marvin-Cypher for review/merge.
