### PR TITLE
fix: add ERC-8004 TEE Agent prebuilt wrapper

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -808,15 +808,30 @@
     "id": "erc-8004-tee-agent",
     "name": "ERC-8004 TEE Agent",
     "description": "An ERC-8004 Compliant TEE Agent with a TEE Registry Extension for Secure & Verifiable Trustless Agents in a CVM on Phala Cloud. Combines on-chain identity verification, Intel TDX attestation, and AI chat interface for autonomous blockchain agents.",
-    "repo": "https://github.com/Phala-Network/erc-8004-tee-agent",
+    "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/erc-8004-tee-agent",
     "author": "Phala-Network",
     "envs": [
       { "key": "AGENT_SALT", "required": true, "description": "Unique secret salt for key derivation" },
       { "key": "REDPILL_API_KEY", "required": true, "description": "API key for confidential AI inference" },
       { "key": "SUBGRAPH_API_KEY", "required": true, "description": "Access token for blockchain data queries" },
-      { "key": "CHAIN_NAME", "required": true, "description": "Target blockchain (e.g., eth-sepolia)" },
       { "key": "RPC_URL", "required": true, "description": "Blockchain node endpoint" },
-      { "key": "ANTHROPIC_MODEL", "required": false, "description": "AI model selection", "default": "moonshotai/kimi-k2.5" }
+      { "key": "CHAIN_NAME", "required": true, "description": "Target blockchain (e.g., eth-sepolia)" },
+      { "key": "ERC8004_AGENT_PASSWORD_HASH", "required": true, "description": "Caddy bcrypt password hash for Basic Auth" },
+      { "key": "ERC8004_AGENT_USERNAME", "required": false, "description": "Caddy Basic Auth username", "default": "agent" },
+      { "key": "AGENT_DOMAIN", "required": false, "description": "Public agent domain override; derived at startup when omitted" },
+      { "key": "TRUST_CENTER_URL", "required": false, "description": "Trust Center widget URL override; derived at startup when omitted" },
+      { "key": "ANTHROPIC_MODEL", "required": false, "description": "Chat model selection", "default": "openai/gpt-oss-120b" },
+      { "key": "AI_MODEL", "required": false, "description": "RedPill model used by the code-generation helper", "default": "phala/qwen-2.5-7b-instruct" },
+      { "key": "AI_TEMPERATURE", "required": false, "description": "AI sampling temperature", "default": "0.3" },
+      { "key": "AI_MAX_TOKENS", "required": false, "description": "AI response token limit", "default": "2000" },
+      { "key": "CODE_EXECUTION_TIMEOUT", "required": false, "description": "Code execution timeout in seconds", "default": "30" },
+      { "key": "REDPILL_API_URL", "required": false, "description": "RedPill API base URL", "default": "https://api.redpill.ai" },
+      { "key": "ANTHROPIC_BASE_URL", "required": false, "description": "Anthropic-compatible API base URL", "default": "https://api.redpill.ai" },
+      { "key": "CHAIN_ID", "required": false, "description": "EVM chain ID override", "default": "11155111" },
+      { "key": "IDENTITY_REGISTRY_ADDRESS", "required": false, "description": "ERC-8004 identity registry contract override", "default": "0x8004A818BFB912233c491871b3d84c89A494BD9e" },
+      { "key": "REPUTATION_REGISTRY_ADDRESS", "required": false, "description": "ERC-8004 reputation registry contract override", "default": "0x8004B663056A597Dffe9eCcC1965A193B7388713" },
+      { "key": "SESSION_TIMEOUT_MINUTES", "required": false, "description": "Chat session timeout in minutes", "default": "60" },
+      { "key": "MAX_SESSIONS", "required": false, "description": "Maximum in-memory chat sessions", "default": "100" }
     ],
     "tags": ["Agent", "TEE", "ERC-8004", "AI"]
   }

--- a/templates/prebuilt/erc-8004-tee-agent/README.md
+++ b/templates/prebuilt/erc-8004-tee-agent/README.md
@@ -1,0 +1,104 @@
+# ERC-8004 TEE Agent
+
+Phala Cloud prebuilt template for the ERC-8004 TEE Agent. The app provides an ERC-8004 agent dashboard, TEE attestation endpoints, AI chat, code execution, and TEE-backed signing.
+
+## Source
+
+- Upstream repository: https://github.com/Phala-Network/erc-8004-tee-agent
+- Upstream commit: `3196a3c68571da28eef78d296ae0e65ff3d83569`
+- Upstream license: MIT, copyright 2025 ERC-8004 TEE Agents Contributors
+
+This template is maintained in the Phala Cloud prebuilt catalog. It does not clone source code when the container starts and it does not depend on an unmerged upstream PR. The inline Dockerfile fetches the pinned upstream archive during image build and installs the Python package. The template also applies three Phala deployment patches:
+
+- Redact `AGENT_SALT` from startup and key-derivation logs.
+- Move Phala domain and Trust Center URL construction into the container startup command so `DSTACK_APP_ID` and `DSTACK_GATEWAY_DOMAIN` are read from the container runtime environment, not interpolated while Compose is rendered.
+- Generate Caddy's Basic Auth configuration from `ERC8004_AGENT_USERNAME` and `ERC8004_AGENT_PASSWORD_HASH` at proxy container startup so the password hash is read from the container runtime environment.
+
+## Services
+
+- `app`: ERC-8004 TEE Agent built from the pinned upstream commit.
+- `proxy`: Caddy Basic Auth proxy exposed on public port `8000`.
+
+The `app` service is only reachable on the internal Docker network. Public traffic goes through Caddy on port `8000` because the app includes chat, code-execution, and signing endpoints.
+
+## Environment Variables
+
+Required:
+
+- `AGENT_SALT`: Secret salt used for deterministic TEE key derivation. Changing it changes the agent wallet.
+- `REDPILL_API_KEY`: RedPill Confidential AI API key.
+- `SUBGRAPH_API_KEY`: The Graph Gateway API key for ERC-8004 subgraph queries.
+- `RPC_URL`: RPC endpoint for the selected chain.
+- `CHAIN_NAME`: Chain selector. The pinned upstream source currently supports `eth-sepolia`.
+- `ERC8004_AGENT_PASSWORD_HASH`: Caddy bcrypt password hash for Basic Auth.
+
+Optional:
+
+- `ERC8004_AGENT_USERNAME`: Basic Auth username. Defaults to `agent`.
+- `AGENT_DOMAIN`: Public agent domain override. When unset, startup derives it from `DSTACK_APP_ID` and `DSTACK_GATEWAY_DOMAIN`, or uses `localhost:8000` for local compose checks.
+- `TRUST_CENTER_URL`: Trust Center widget URL override. When unset, startup derives it from `DSTACK_APP_ID` when available.
+- `ANTHROPIC_MODEL`: Chat model used through the Anthropic-compatible RedPill endpoint. Defaults to `openai/gpt-oss-120b`.
+- `AI_MODEL`: Code-generation model used by the RedPill helper. Defaults to `phala/qwen-2.5-7b-instruct`.
+- `AI_TEMPERATURE`: AI sampling temperature. Defaults to `0.3`.
+- `AI_MAX_TOKENS`: AI response token limit. Defaults to `2000`.
+- `CODE_EXECUTION_TIMEOUT`: Code execution timeout in seconds. Defaults to `30`.
+- `REDPILL_API_URL`: RedPill API base URL. Defaults to `https://api.redpill.ai`.
+- `ANTHROPIC_BASE_URL`: Anthropic-compatible API base URL. Defaults to `https://api.redpill.ai`.
+- `CHAIN_ID`: Chain ID override. Defaults to `11155111`.
+- `IDENTITY_REGISTRY_ADDRESS`: ERC-8004 identity registry override.
+- `REPUTATION_REGISTRY_ADDRESS`: ERC-8004 reputation registry override.
+- `SESSION_TIMEOUT_MINUTES`: Chat session timeout. Defaults to `60`.
+- `MAX_SESSIONS`: Maximum in-memory chat sessions. Defaults to `100`.
+
+Generate the Caddy bcrypt hash with Caddy:
+
+```bash
+docker run --rm caddy:2.8 caddy hash-password --plaintext 'replace-with-a-strong-password'
+```
+
+When exporting the hash in a shell, quote it so the `$` characters are preserved:
+
+```bash
+export ERC8004_AGENT_PASSWORD_HASH='$2a$14$...'
+```
+
+Use the same single-quote style in a local Compose `.env` file.
+
+Do not commit real salts, API keys, RPC credentials, or password hashes.
+
+## Runtime Domain
+
+On Phala Cloud, the startup command computes:
+
+```text
+AGENT_DOMAIN=<DSTACK_APP_ID>-8000.<DSTACK_GATEWAY_DOMAIN>
+TRUST_CENTER_URL=https://trust.phala.com/widget/app/<DSTACK_APP_ID>
+```
+
+The compose file intentionally does not render these values from `${DSTACK_APP_ID}` or `${DSTACK_GATEWAY_DOMAIN}`. Those variables are expected from the Phala/dstack container runtime. For local compose checks where they are absent, `AGENT_DOMAIN` falls back to `localhost:8000`.
+
+Set `AGENT_DOMAIN` or `TRUST_CENTER_URL` in the Compose environment to override the runtime-derived values explicitly.
+
+## Validate
+
+From the repository root:
+
+```bash
+AGENT_SALT=dummy \
+REDPILL_API_KEY=dummy \
+SUBGRAPH_API_KEY=dummy \
+RPC_URL=https://example.invalid \
+CHAIN_NAME=eth-sepolia \
+ERC8004_AGENT_PASSWORD_HASH='$2b$12$DaaKDdf3fI3DqD5Sg56fuuPDjBv2m4X3QiGHpGFMtGEAcw1FMm6tm' \
+docker compose -f templates/prebuilt/erc-8004-tee-agent/docker-compose.yml config
+```
+
+## Update Procedure
+
+1. Review upstream changes in https://github.com/Phala-Network/erc-8004-tee-agent.
+2. Update `UPSTREAM_COMMIT` and the local image tag in `docker-compose.yml`.
+3. Re-check upstream environment variables, exposed ports, dstack socket usage, and whether the local log-redaction patches are still needed.
+4. Keep the app behind Caddy Basic Auth unless the upstream app removes or protects chat, code-execution, and signing endpoints.
+5. Run `docker compose config` with dummy values from the repository root.
+6. Run `python3 templates/validate.py` from the repository root.
+7. Run `git diff --check` before opening a pull request.

--- a/templates/prebuilt/erc-8004-tee-agent/docker-compose.yml
+++ b/templates/prebuilt/erc-8004-tee-agent/docker-compose.yml
@@ -1,0 +1,124 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM python:3.11-slim-bookworm
+
+        ARG UPSTREAM_COMMIT=3196a3c68571da28eef78d296ae0e65ff3d83569
+
+        ENV PYTHONDONTWRITEBYTECODE=1
+        ENV PYTHONUNBUFFERED=1
+        ENV PIP_NO_CACHE_DIR=1
+
+        WORKDIR /app
+
+        RUN apt-get update && apt-get install -y --no-install-recommends \
+            bash \
+            ca-certificates \
+            curl \
+            wget \
+            && rm -rf /var/lib/apt/lists/*
+
+        RUN wget -O /tmp/erc-8004-tee-agent.tar.gz "https://github.com/Phala-Network/erc-8004-tee-agent/archive/$${UPSTREAM_COMMIT}.tar.gz" \
+            && mkdir -p /tmp/erc-8004-tee-agent \
+            && tar -xzf /tmp/erc-8004-tee-agent.tar.gz -C /tmp/erc-8004-tee-agent --strip-components=1 \
+            && cp -a /tmp/erc-8004-tee-agent/. /app/ \
+            && rm -rf /tmp/erc-8004-tee-agent /tmp/erc-8004-tee-agent.tar.gz
+
+        RUN sed -i '/Salt: {salt}/c\    print("Salt: [configured]" if salt else "Salt: [missing]")' deployment/local_agent_server.py \
+            && sed -i '/Deriving key for agent with path:/c\        print("Deriving key for agent path: wallet/erc8004-[redacted]")' src/agent/tee_auth.py
+
+        RUN pip install --upgrade pip \
+            && pip install -e . \
+            && python -m compileall deployment src
+
+        LABEL org.opencontainers.image.source="https://github.com/Phala-Network/erc-8004-tee-agent" \
+              org.opencontainers.image.revision="$${UPSTREAM_COMMIT}" \
+              org.opencontainers.image.licenses="MIT"
+
+        EXPOSE 8000
+    image: erc-8004-tee-agent:3196a3c
+    pull_policy: build
+    environment:
+      AGENT_HOST: 0.0.0.0
+      AGENT_PORT: "8000"
+      AGENT_DOMAIN: ${AGENT_DOMAIN:-}
+      TRUST_CENTER_URL: ${TRUST_CENTER_URL:-}
+      AGENT_SALT: ${AGENT_SALT:?AGENT_SALT is required}
+      CHAIN_NAME: ${CHAIN_NAME:?CHAIN_NAME is required}
+      CHAIN_ID: ${CHAIN_ID:-11155111}
+      RPC_URL: ${RPC_URL:?RPC_URL is required}
+      SUBGRAPH_API_KEY: ${SUBGRAPH_API_KEY:?SUBGRAPH_API_KEY is required}
+      IDENTITY_REGISTRY_ADDRESS: ${IDENTITY_REGISTRY_ADDRESS:-0x8004A818BFB912233c491871b3d84c89A494BD9e}
+      REPUTATION_REGISTRY_ADDRESS: ${REPUTATION_REGISTRY_ADDRESS:-0x8004B663056A597Dffe9eCcC1965A193B7388713}
+      REDPILL_API_KEY: ${REDPILL_API_KEY:?REDPILL_API_KEY is required}
+      REDPILL_API_URL: ${REDPILL_API_URL:-https://api.redpill.ai}
+      ANTHROPIC_AUTH_TOKEN: ${ANTHROPIC_AUTH_TOKEN:-}
+      ANTHROPIC_BASE_URL: ${ANTHROPIC_BASE_URL:-https://api.redpill.ai}
+      ANTHROPIC_MODEL: ${ANTHROPIC_MODEL:-openai/gpt-oss-120b}
+      AI_MODEL: ${AI_MODEL:-phala/qwen-2.5-7b-instruct}
+      AI_TEMPERATURE: ${AI_TEMPERATURE:-0.3}
+      AI_MAX_TOKENS: ${AI_MAX_TOKENS:-2000}
+      SESSION_TIMEOUT_MINUTES: ${SESSION_TIMEOUT_MINUTES:-60}
+      MAX_SESSIONS: ${MAX_SESSIONS:-100}
+      CODE_EXECUTION_TIMEOUT: ${CODE_EXECUTION_TIMEOUT:-30}
+    volumes:
+      - /var/run/dstack.sock:/var/run/dstack.sock
+    command:
+      - /bin/bash
+      - -ceu
+      - |
+        if [ -z "$${AGENT_DOMAIN:-}" ]; then
+          if [ -n "$${DSTACK_APP_ID:-}" ] && [ -n "$${DSTACK_GATEWAY_DOMAIN:-}" ]; then
+            export AGENT_DOMAIN="$${DSTACK_APP_ID}-8000.$${DSTACK_GATEWAY_DOMAIN}"
+          else
+            export AGENT_DOMAIN="localhost:8000"
+          fi
+        fi
+
+        if [ -z "$${TRUST_CENTER_URL:-}" ] && [ -n "$${DSTACK_APP_ID:-}" ]; then
+          export TRUST_CENTER_URL="https://trust.phala.com/widget/app/$${DSTACK_APP_ID}"
+        fi
+
+        export ANTHROPIC_AUTH_TOKEN="$${ANTHROPIC_AUTH_TOKEN:-$${REDPILL_API_KEY}}"
+        exec python3 deployment/local_agent_server.py
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "8000:80"
+    environment:
+      ERC8004_AGENT_USERNAME: ${ERC8004_AGENT_USERNAME:-agent}
+      ERC8004_AGENT_PASSWORD_HASH: ${ERC8004_AGENT_PASSWORD_HASH:?ERC8004_AGENT_PASSWORD_HASH is required}
+    entrypoint:
+      - /bin/sh
+      - -ceu
+    command:
+      - |
+        : "$${ERC8004_AGENT_USERNAME:?ERC8004_AGENT_USERNAME is required}"
+        : "$${ERC8004_AGENT_PASSWORD_HASH:?ERC8004_AGENT_PASSWORD_HASH is required}"
+
+        {
+          printf '%s\n' ':80 {'
+          printf '%s\n' '    basic_auth {'
+          printf '        %s %s\n' "$${ERC8004_AGENT_USERNAME}" "$${ERC8004_AGENT_PASSWORD_HASH}"
+          printf '%s\n' '    }'
+          printf '%s\n' ''
+          printf '%s\n' '    reverse_proxy app:8000'
+          printf '%s\n' '}'
+        } > /etc/caddy/Caddyfile
+
+        exec caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
+    depends_on:
+      - app
+    restart: unless-stopped
+    networks:
+      - internal
+
+networks:
+  internal:
+    driver: bridge


### PR DESCRIPTION
## Summary
- Add a Phala Cloud-maintained `erc-8004-tee-agent` prebuilt template wrapper pinned to upstream commit `3196a3c68571da28eef78d296ae0e65ff3d83569`.
- Keep the app container internal-only and expose only a Caddy proxy on port 8000.
- Generate the Caddyfile at proxy container startup from `ERC8004_AGENT_USERNAME` and `ERC8004_AGENT_PASSWORD_HASH`, avoiding Compose-time Basic Auth placeholder rendering issues.
- Preserve runtime shell expansion for `ANTHROPIC_AUTH_TOKEN`, falling back to `REDPILL_API_KEY` inside the container.
- Pass optional `AGENT_DOMAIN` and `TRUST_CENTER_URL` overrides into the app container; when omitted, startup still attempts runtime derivation from dstack-provided vars and falls back to localhost for local compose checks.
- Redact salt/key-derivation log output and document source/update/license/smoke-test guidance.

## Validation
- `docker compose --env-file /tmp/final2-smoke.env -f templates/prebuilt/erc-8004-tee-agent/docker-compose.yml config`
- `python3 templates/validate.py`
- `git diff --check`
- Live Phala smoke in `hermes-admin-cvm-check` / `h4x's projects`: CVM reached running/online with proxy + app containers running; unauthenticated routes returned 401; authenticated `/`, `/api/status`, `/agent.json`, and `/.well-known/agent-card.json` returned HTTP 200.

## Notes
- This PR keeps the runnable template in Phala Cloud, so users are not blocked on an external upstream PR/merge.
- Smoke used dummy placeholder API keys/secrets only; real RedPill/Subgraph/RPC behavior beyond boot and route checks was not exercised.