### PR TITLE
fix(js): stop rewriting node_id to teepod_id on provision

### DIFF
--- a/js/src/actions/cvms/get_prelaunch_script_upgrade_status.test.ts
+++ b/js/src/actions/cvms/get_prelaunch_script_upgrade_status.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createClient } from "../../client";
+import {
+  getPreLaunchScriptUpgradeStatus,
+  type PreLaunchScriptUpgradeStatus,
+} from "./get_prelaunch_script_upgrade_status";
+
+const mockUpgradable: PreLaunchScriptUpgradeStatus = {
+  current_hash: "0e289ab44fa756e02a3e850d60c22ab1cbf90cade311f98f555fad74a1c40d0a",
+  latest_official_hash: "bf12939bc82c9bdd103b6b1226913e6da58ed7cfcfc7c7ae808ac0813715b9a8",
+  is_official: true,
+  is_latest: false,
+  can_upgrade: true,
+};
+
+const mockCustom: PreLaunchScriptUpgradeStatus = {
+  current_hash: "deadbeef".repeat(8),
+  latest_official_hash: "bf12939bc82c9bdd103b6b1226913e6da58ed7cfcfc7c7ae808ac0813715b9a8",
+  is_official: false,
+  is_latest: false,
+  can_upgrade: false,
+};
+
+describe("getPreLaunchScriptUpgradeStatus", () => {
+  let client: ReturnType<typeof createClient>;
+  let mockGet: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    client = createClient({ apiKey: "test-api-key", baseURL: "https://api.test.com" });
+    mockGet = vi.spyOn(client, "get");
+  });
+
+  it("calls the upgrade-status endpoint and parses the response", async () => {
+    mockGet.mockResolvedValue(mockUpgradable);
+
+    const result = await getPreLaunchScriptUpgradeStatus(client, { id: "cvm-1" });
+
+    expect(mockGet).toHaveBeenCalledWith("/cvms/cvm-1/pre-launch-script/upgrade-status");
+    expect(result).toEqual(mockUpgradable);
+  });
+
+  it("passes through can_upgrade=false for custom scripts", async () => {
+    mockGet.mockResolvedValue(mockCustom);
+
+    const result = await getPreLaunchScriptUpgradeStatus(client, { id: "cvm-2" });
+
+    expect(result.is_official).toBe(false);
+    expect(result.can_upgrade).toBe(false);
+  });
+
+  it("accepts a null current_hash (CVM with no recorded hash)", async () => {
+    mockGet.mockResolvedValue({
+      current_hash: null,
+      latest_official_hash: "bf12939bc82c9bdd103b6b1226913e6da58ed7cfcfc7c7ae808ac0813715b9a8",
+      is_official: false,
+      is_latest: false,
+      can_upgrade: false,
+    });
+
+    const result = await getPreLaunchScriptUpgradeStatus(client, { id: "cvm-3" });
+
+    expect(result.current_hash).toBeNull();
+    expect(result.can_upgrade).toBe(false);
+  });
+});

--- a/js/src/actions/cvms/get_prelaunch_script_upgrade_status.ts
+++ b/js/src/actions/cvms/get_prelaunch_script_upgrade_status.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import { CvmIdSchema, type CvmIdInput } from "../../types/cvm_id";
+import { defineAction } from "../../utils/define-action";
+
+/**
+ * Get pre-launch script upgrade status
+ *
+ * Reports whether a CVM is running an unmodified official pre-launch script
+ * and whether a newer official version is available. The frontend uses
+ * `can_upgrade` to decide whether to surface the one-click upgrade banner.
+ *
+ * @example
+ * ```typescript
+ * import { createClient, getPreLaunchScriptUpgradeStatus } from '@phala/cloud'
+ *
+ * const client = createClient({ apiKey: 'your-api-key' })
+ * const status = await getPreLaunchScriptUpgradeStatus(client, { id: 'cvm-123' })
+ *
+ * if (status.can_upgrade) {
+ *   // CVM is on an older official script; offer the upgrade
+ * }
+ * ```
+ */
+
+export const GetPreLaunchScriptUpgradeStatusRequestSchema = CvmIdSchema;
+
+export type GetPreLaunchScriptUpgradeStatusRequest = CvmIdInput;
+
+export const PreLaunchScriptUpgradeStatusSchema = z.object({
+  current_hash: z.string().nullable(),
+  latest_official_hash: z.string(),
+  is_official: z.boolean(),
+  is_latest: z.boolean(),
+  can_upgrade: z.boolean(),
+});
+
+export type PreLaunchScriptUpgradeStatus = z.infer<typeof PreLaunchScriptUpgradeStatusSchema>;
+
+const {
+  action: getPreLaunchScriptUpgradeStatus,
+  safeAction: safeGetPreLaunchScriptUpgradeStatus,
+} = defineAction<GetPreLaunchScriptUpgradeStatusRequest, typeof PreLaunchScriptUpgradeStatusSchema>(
+  PreLaunchScriptUpgradeStatusSchema,
+  async (client, request) => {
+    const { cvmId } = GetPreLaunchScriptUpgradeStatusRequestSchema.parse(request);
+    return await client.get(`/cvms/${cvmId}/pre-launch-script/upgrade-status`);
+  },
+);
+
+export { getPreLaunchScriptUpgradeStatus, safeGetPreLaunchScriptUpgradeStatus };

--- a/js/src/actions/cvms/get_prelaunch_script_upgrade_status.ts
+++ b/js/src/actions/cvms/get_prelaunch_script_upgrade_status.ts
@@ -36,15 +36,13 @@ export const PreLaunchScriptUpgradeStatusSchema = z.object({
 
 export type PreLaunchScriptUpgradeStatus = z.infer<typeof PreLaunchScriptUpgradeStatusSchema>;
 
-const {
-  action: getPreLaunchScriptUpgradeStatus,
-  safeAction: safeGetPreLaunchScriptUpgradeStatus,
-} = defineAction<GetPreLaunchScriptUpgradeStatusRequest, typeof PreLaunchScriptUpgradeStatusSchema>(
-  PreLaunchScriptUpgradeStatusSchema,
-  async (client, request) => {
-    const { cvmId } = GetPreLaunchScriptUpgradeStatusRequestSchema.parse(request);
-    return await client.get(`/cvms/${cvmId}/pre-launch-script/upgrade-status`);
-  },
-);
+const { action: getPreLaunchScriptUpgradeStatus, safeAction: safeGetPreLaunchScriptUpgradeStatus } =
+  defineAction<GetPreLaunchScriptUpgradeStatusRequest, typeof PreLaunchScriptUpgradeStatusSchema>(
+    PreLaunchScriptUpgradeStatusSchema,
+    async (client, request) => {
+      const { cvmId } = GetPreLaunchScriptUpgradeStatusRequestSchema.parse(request);
+      return await client.get(`/cvms/${cvmId}/pre-launch-script/upgrade-status`);
+    },
+  );
 
 export { getPreLaunchScriptUpgradeStatus, safeGetPreLaunchScriptUpgradeStatus };

--- a/js/src/actions/cvms/provision_cvm.test.ts
+++ b/js/src/actions/cvms/provision_cvm.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { ProvisionCvmRequestSchema } from "./provision_cvm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Client } from "../../client";
 import { MAX_COMPOSE_PAYLOAD_BYTES } from "../../types/app_compose";
+import { provisionCvm, ProvisionCvmRequestSchema } from "./provision_cvm";
 
 describe("ProvisionCvmRequestSchema", () => {
   describe("manual nonce specification", () => {
@@ -267,5 +268,84 @@ describe("ProvisionCvmRequestSchema", () => {
         });
       }
     });
+  });
+});
+
+// Regression coverage for the previously-present `node_id -> teepod_id` rewrite.
+// Node.id and Teepod.id are separate identifier spaces on the backend; the SDK
+// must forward whichever field the caller set without renaming, or post-#1449
+// frontends (which now send a real Node.id in `node_id`) route requests to the
+// wrong teepod.
+describe("provisionCvm (wire-level)", () => {
+  let mockClient: Client;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  const baseRequest = {
+    name: "test-app",
+    instance_type: "tdx.small",
+    compose_file: {
+      docker_compose_file: "services: {}",
+    },
+  } as const;
+
+  // Minimal response satisfying ProvisionCvmSchema (compose_hash is the only required field).
+  const mockResponse = { compose_hash: "0xabc" };
+
+  function getRequestBody(): Record<string, unknown> {
+    const calls = (mockClient.post as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(1);
+    const [path, body] = calls[0];
+    expect(path).toBe("/cvms/provision");
+    return body as Record<string, unknown>;
+  }
+
+  beforeEach(() => {
+    mockClient = {
+      post: vi.fn().mockResolvedValue(mockResponse),
+    } as unknown as Client;
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("forwards node_id verbatim and does not synthesize teepod_id", async () => {
+    await provisionCvm(mockClient, { ...baseRequest, node_id: 7 });
+
+    const body = getRequestBody();
+    expect(body.node_id).toBe(7);
+    expect("teepod_id" in body).toBe(false);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("forwards teepod_id verbatim with deprecation warning when only teepod_id is set", async () => {
+    await provisionCvm(mockClient, { ...baseRequest, teepod_id: 12 });
+
+    const body = getRequestBody();
+    expect(body.teepod_id).toBe(12);
+    expect("node_id" in body).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("teepod_id is deprecated"));
+  });
+
+  it("preserves distinct node_id and teepod_id values when both are set", async () => {
+    // Guards against the historical rewrite that copied node_id into teepod_id
+    // and dropped node_id. With distinct values (7 vs 12), a regression would
+    // collapse them to a single id.
+    await provisionCvm(mockClient, { ...baseRequest, node_id: 7, teepod_id: 12 });
+
+    const body = getRequestBody();
+    expect(body.node_id).toBe(7);
+    expect(body.teepod_id).toBe(12);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when neither id is provided", async () => {
+    await provisionCvm(mockClient, baseRequest);
+
+    const body = getRequestBody();
+    expect("node_id" in body).toBe(false);
+    expect("teepod_id" in body).toBe(false);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/js/src/actions/cvms/provision_cvm.ts
+++ b/js/src/actions/cvms/provision_cvm.ts
@@ -297,8 +297,6 @@ function handleGatewayCompatibility(appCompose: ProvisionCvmRequest): ProvisionC
   };
 }
 
-// The teepod_id -> node_id transformation is now handled by the schema's .transform()
-// This way, when users specify { schema: false }, they get the raw response
 const { action: provisionCvm, safeAction: safeProvisionCvm } = defineAction<
   ProvisionCvmRequest,
   typeof ProvisionCvmSchema
@@ -306,15 +304,13 @@ const { action: provisionCvm, safeAction: safeProvisionCvm } = defineAction<
   const validated = ProvisionCvmRequestSchema.parse(appCompose);
   const body = handleGatewayCompatibility(validated);
 
-  let requestBody = { ...body };
-  if (typeof body.node_id === "number") {
-    requestBody = { ...body, teepod_id: body.node_id };
-    delete requestBody.node_id;
-  } else if (typeof body.teepod_id === "number") {
+  // The backend accepts both `node_id` (Node.id) and `teepod_id` (Teepod.id) as
+  // distinct fields; they are not interchangeable. Pass them through as-is.
+  if (typeof body.teepod_id === "number" && typeof body.node_id !== "number") {
     console.warn("[phala/cloud] teepod_id is deprecated, please use node_id instead.");
   }
 
-  return await client.post("/cvms/provision", requestBody);
+  return await client.post("/cvms/provision", body);
 });
 
 export { provisionCvm, safeProvisionCvm };

--- a/js/src/actions/cvms/upgrade_prelaunch_script.test.ts
+++ b/js/src/actions/cvms/upgrade_prelaunch_script.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createClient } from "../../client";
+import { PhalaCloudError } from "../../utils/errors";
+import { upgradePreLaunchScript } from "./upgrade_prelaunch_script";
+
+describe("upgradePreLaunchScript", () => {
+  let client: ReturnType<typeof createClient>;
+  let mockPost: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    client = createClient({ apiKey: "test-api-key", baseURL: "https://api.test.com" });
+    mockPost = vi.spyOn(client, "post");
+  });
+
+  it("POSTs to the upgrade endpoint with no body when there are no Phase-2 headers", async () => {
+    mockPost.mockResolvedValue({
+      status: "in_progress",
+      message: "Pre-launch script update initiated",
+      correlation_id: "corr-1",
+    });
+
+    const result = await upgradePreLaunchScript(client, { id: "cvm-1" });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/cvms/cvm-1/pre-launch-script/upgrade-to-latest-official",
+      undefined,
+      { headers: {} },
+    );
+    expect(result).toEqual({
+      status: "in_progress",
+      message: "Pre-launch script update initiated",
+      correlation_id: "corr-1",
+    });
+  });
+
+  it("forwards compose_hash and transaction_hash via Phase-2 headers", async () => {
+    mockPost.mockResolvedValue({
+      status: "in_progress",
+      message: "ok",
+      correlation_id: "corr-2",
+    });
+
+    await upgradePreLaunchScript(client, {
+      id: "cvm-2",
+      compose_hash: "0xabc",
+      transaction_hash: "0xdef",
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/cvms/cvm-2/pre-launch-script/upgrade-to-latest-official",
+      undefined,
+      {
+        headers: {
+          "X-Compose-Hash": "0xabc",
+          "X-Transaction-Hash": "0xdef",
+        },
+      },
+    );
+  });
+
+  it("maps a 465 StructuredError into precondition_required", async () => {
+    const err = new PhalaCloudError("Compose hash registration required", {
+      status: 465,
+      detail: {
+        message: "Compose hash registration required",
+        details: [
+          { field: "compose_hash", value: "0xhash" },
+          { field: "app_id", value: "app-1" },
+          { field: "device_id", value: "device-1" },
+          {
+            field: "kms_info",
+            value: {
+              id: "kms-1",
+              slug: "kms-1",
+              url: "https://kms.example.com",
+              version: "1.0.0",
+              chain_id: 1,
+              kms_contract_address: "0xkms",
+              gateway_app_id: "0xgateway",
+            },
+          },
+        ],
+      },
+    });
+    mockPost.mockRejectedValue(err);
+
+    const result = await upgradePreLaunchScript(client, { id: "cvm-3" });
+
+    expect(result.status).toBe("precondition_required");
+    if (result.status === "precondition_required") {
+      expect(result.compose_hash).toBe("0xhash");
+      expect(result.app_id).toBe("app-1");
+      expect(result.device_id).toBe("device-1");
+    }
+  });
+
+  it("re-throws non-465 errors", async () => {
+    const err = new PhalaCloudError("Conflict", { status: 409 });
+    mockPost.mockRejectedValue(err);
+
+    await expect(upgradePreLaunchScript(client, { id: "cvm-4" })).rejects.toThrow(err);
+  });
+});

--- a/js/src/actions/cvms/upgrade_prelaunch_script.ts
+++ b/js/src/actions/cvms/upgrade_prelaunch_script.ts
@@ -1,0 +1,142 @@
+import { z } from "zod";
+import { CvmIdObjectSchema, CvmIdSchema, refineCvmId } from "../../types/cvm_id";
+import { KmsInfoSchema } from "../../types/kms_info";
+import { defineAction } from "../../utils/define-action";
+import { PhalaCloudError } from "../../utils/errors";
+
+/**
+ * Upgrade a CVM's pre-launch script to the latest official version.
+ *
+ * Replaces the CVM's current pre-launch script with the latest official
+ * version maintained by Phala and triggers the standard update workflow.
+ * The official script content is held server-side; clients only need to
+ * call this endpoint with the CVM ID.
+ *
+ * For contract-owned KMS (ETHEREUM/BASE), the first call returns
+ * `precondition_required` with a compose hash to register on-chain. After
+ * registration, retry with `compose_hash` and `transaction_hash`.
+ *
+ * @example
+ * ```typescript
+ * import { createClient, upgradePreLaunchScript } from '@phala/cloud'
+ *
+ * const client = createClient({ apiKey: 'your-api-key' })
+ *
+ * // Phase 1: kick off the upgrade
+ * const result = await upgradePreLaunchScript(client, { id: 'cvm-123' })
+ *
+ * if (result.status === 'precondition_required') {
+ *   // Register compose hash on-chain, then retry with the headers
+ *   const txHash = await registerComposeHashOnChain(result.compose_hash, result.kms_info)
+ *   await upgradePreLaunchScript(client, {
+ *     id: 'cvm-123',
+ *     compose_hash: result.compose_hash,
+ *     transaction_hash: txHash,
+ *   })
+ * }
+ * ```
+ */
+
+export const UpgradePreLaunchScriptRequestSchema = refineCvmId(
+  CvmIdObjectSchema.extend({
+    compose_hash: z
+      .string()
+      .optional()
+      .describe("Compose hash for verification (Phase 2, contract-owned KMS only)"),
+    transaction_hash: z
+      .string()
+      .optional()
+      .describe("On-chain transaction hash for verification (Phase 2, contract-owned KMS only)"),
+  }),
+).transform((data) => {
+  const { cvmId } = CvmIdSchema.parse(data);
+  return {
+    cvmId,
+    request: {
+      compose_hash: data.compose_hash,
+      transaction_hash: data.transaction_hash,
+    },
+    _raw: data,
+  };
+});
+
+const UpgradePreLaunchScriptInProgressSchema = z.object({
+  status: z.literal("in_progress"),
+  message: z.string(),
+  correlation_id: z.string(),
+});
+
+const UpgradePreLaunchScriptPreconditionRequiredSchema = z.object({
+  status: z.literal("precondition_required"),
+  message: z.string(),
+  compose_hash: z.string(),
+  app_id: z.string(),
+  device_id: z.string(),
+  kms_info: KmsInfoSchema,
+});
+
+export const UpgradePreLaunchScriptResultSchema = z.union([
+  UpgradePreLaunchScriptInProgressSchema,
+  UpgradePreLaunchScriptPreconditionRequiredSchema,
+]);
+
+export type UpgradePreLaunchScriptRequest = z.input<typeof UpgradePreLaunchScriptRequestSchema>;
+export type UpgradePreLaunchScriptResult = z.infer<typeof UpgradePreLaunchScriptResultSchema>;
+export type UpgradePreLaunchScriptInProgress = z.infer<typeof UpgradePreLaunchScriptInProgressSchema>;
+export type UpgradePreLaunchScriptPreconditionRequired = z.infer<
+  typeof UpgradePreLaunchScriptPreconditionRequiredSchema
+>;
+
+const { action: upgradePreLaunchScript, safeAction: safeUpgradePreLaunchScript } = defineAction<
+  UpgradePreLaunchScriptRequest,
+  typeof UpgradePreLaunchScriptResultSchema
+>(UpgradePreLaunchScriptResultSchema, async (client, request) => {
+  const validated = UpgradePreLaunchScriptRequestSchema.parse(request);
+
+  const headers: Record<string, string> = {};
+  if (validated.request.compose_hash) {
+    headers["X-Compose-Hash"] = validated.request.compose_hash;
+  }
+  if (validated.request.transaction_hash) {
+    headers["X-Transaction-Hash"] = validated.request.transaction_hash;
+  }
+
+  try {
+    const response = await client.post<UpgradePreLaunchScriptInProgress>(
+      `/cvms/${validated.cvmId}/pre-launch-script/upgrade-to-latest-official`,
+      undefined,
+      { headers },
+    );
+    return response;
+  } catch (error) {
+    if (error instanceof PhalaCloudError && error.status === 465) {
+      const detail = error.detail;
+      if (detail && typeof detail === "object") {
+        const detailObj = detail as Record<string, unknown>;
+        const detailsArray = detailObj.details as
+          | Array<{ field: string; value: unknown }>
+          | undefined;
+        if (detailsArray && Array.isArray(detailsArray)) {
+          const fieldMap = new Map(detailsArray.map((d) => [d.field, d.value]));
+          const composeHash = fieldMap.get("compose_hash");
+          const appId = fieldMap.get("app_id");
+          const deviceId = fieldMap.get("device_id");
+          const kmsInfo = fieldMap.get("kms_info");
+          if (composeHash && appId) {
+            return {
+              status: "precondition_required" as const,
+              message: (detailObj.message as string) || "Compose hash verification required",
+              compose_hash: composeHash as string,
+              app_id: appId as string,
+              device_id: (deviceId as string) || "",
+              kms_info: kmsInfo,
+            };
+          }
+        }
+      }
+    }
+    throw error;
+  }
+});
+
+export { upgradePreLaunchScript, safeUpgradePreLaunchScript };

--- a/js/src/actions/cvms/upgrade_prelaunch_script.ts
+++ b/js/src/actions/cvms/upgrade_prelaunch_script.ts
@@ -82,7 +82,9 @@ export const UpgradePreLaunchScriptResultSchema = z.union([
 
 export type UpgradePreLaunchScriptRequest = z.input<typeof UpgradePreLaunchScriptRequestSchema>;
 export type UpgradePreLaunchScriptResult = z.infer<typeof UpgradePreLaunchScriptResultSchema>;
-export type UpgradePreLaunchScriptInProgress = z.infer<typeof UpgradePreLaunchScriptInProgressSchema>;
+export type UpgradePreLaunchScriptInProgress = z.infer<
+  typeof UpgradePreLaunchScriptInProgressSchema
+>;
 export type UpgradePreLaunchScriptPreconditionRequired = z.infer<
   typeof UpgradePreLaunchScriptPreconditionRequiredSchema
 >;

--- a/js/src/actions/index.ts
+++ b/js/src/actions/index.ts
@@ -515,6 +515,26 @@ export {
 } from "./cvms/get_cvm_prelaunch_script";
 
 export {
+  getPreLaunchScriptUpgradeStatus,
+  safeGetPreLaunchScriptUpgradeStatus,
+  GetPreLaunchScriptUpgradeStatusRequestSchema,
+  type GetPreLaunchScriptUpgradeStatusRequest,
+  PreLaunchScriptUpgradeStatusSchema,
+  type PreLaunchScriptUpgradeStatus,
+} from "./cvms/get_prelaunch_script_upgrade_status";
+
+export {
+  upgradePreLaunchScript,
+  safeUpgradePreLaunchScript,
+  UpgradePreLaunchScriptRequestSchema,
+  type UpgradePreLaunchScriptRequest,
+  UpgradePreLaunchScriptResultSchema,
+  type UpgradePreLaunchScriptResult,
+  type UpgradePreLaunchScriptInProgress,
+  type UpgradePreLaunchScriptPreconditionRequired,
+} from "./cvms/upgrade_prelaunch_script";
+
+export {
   getCvmStatusBatch,
   safeGetCvmStatusBatch,
   CvmStatusSchema,

--- a/js/src/create-client.ts
+++ b/js/src/create-client.ts
@@ -96,6 +96,18 @@ import {
   safeGetCvmPreLaunchScript,
   type GetCvmPreLaunchScriptRequest,
 } from "./actions/cvms/get_cvm_prelaunch_script";
+import {
+  getPreLaunchScriptUpgradeStatus,
+  safeGetPreLaunchScriptUpgradeStatus,
+  type GetPreLaunchScriptUpgradeStatusRequest,
+  type PreLaunchScriptUpgradeStatus,
+} from "./actions/cvms/get_prelaunch_script_upgrade_status";
+import {
+  upgradePreLaunchScript,
+  safeUpgradePreLaunchScript,
+  type UpgradePreLaunchScriptRequest,
+  type UpgradePreLaunchScriptResult,
+} from "./actions/cvms/upgrade_prelaunch_script";
 import { getKmsInfo, safeGetKmsInfo, type GetKmsInfoRequest } from "./actions/kms/get_kms_info";
 import {
   getKmsList,
@@ -306,6 +318,10 @@ export function createClient<V extends ApiVersion = DefaultApiVersion>(
     readonly safeUpdatePreLaunchScript: typeof safeUpdatePreLaunchScript;
     readonly getCvmPreLaunchScript: typeof getCvmPreLaunchScript;
     readonly safeGetCvmPreLaunchScript: typeof safeGetCvmPreLaunchScript;
+    readonly getPreLaunchScriptUpgradeStatus: typeof getPreLaunchScriptUpgradeStatus;
+    readonly safeGetPreLaunchScriptUpgradeStatus: typeof safeGetPreLaunchScriptUpgradeStatus;
+    readonly upgradePreLaunchScript: typeof upgradePreLaunchScript;
+    readonly safeUpgradePreLaunchScript: typeof safeUpgradePreLaunchScript;
     readonly startCvm: typeof startCvm;
     readonly safeStartCvm: typeof safeStartCvm;
     readonly stopCvm: typeof stopCvm;
@@ -395,6 +411,10 @@ export function createClient<V extends ApiVersion = DefaultApiVersion>(
     safeUpdatePreLaunchScript,
     getCvmPreLaunchScript,
     safeGetCvmPreLaunchScript,
+    getPreLaunchScriptUpgradeStatus,
+    safeGetPreLaunchScriptUpgradeStatus,
+    upgradePreLaunchScript,
+    safeUpgradePreLaunchScript,
     startCvm,
     safeStartCvm,
     stopCvm,
@@ -802,6 +822,54 @@ export interface Client<V extends ApiVersion = DefaultApiVersion> extends BaseCl
   ): Promise<SafeResult<z.infer<T>>>;
   safeGetCvmPreLaunchScript(
     request: GetCvmPreLaunchScriptRequest,
+    parameters: { schema: false },
+  ): Promise<SafeResult<unknown>>;
+
+  getPreLaunchScriptUpgradeStatus(
+    request: GetPreLaunchScriptUpgradeStatusRequest,
+  ): Promise<PreLaunchScriptUpgradeStatus>;
+  getPreLaunchScriptUpgradeStatus<T extends z.ZodTypeAny>(
+    request: GetPreLaunchScriptUpgradeStatusRequest,
+    parameters: { schema: T },
+  ): Promise<z.infer<T>>;
+  getPreLaunchScriptUpgradeStatus(
+    request: GetPreLaunchScriptUpgradeStatusRequest,
+    parameters: { schema: false },
+  ): Promise<unknown>;
+
+  safeGetPreLaunchScriptUpgradeStatus(
+    request: GetPreLaunchScriptUpgradeStatusRequest,
+  ): Promise<SafeResult<PreLaunchScriptUpgradeStatus>>;
+  safeGetPreLaunchScriptUpgradeStatus<T extends z.ZodTypeAny>(
+    request: GetPreLaunchScriptUpgradeStatusRequest,
+    parameters: { schema: T },
+  ): Promise<SafeResult<z.infer<T>>>;
+  safeGetPreLaunchScriptUpgradeStatus(
+    request: GetPreLaunchScriptUpgradeStatusRequest,
+    parameters: { schema: false },
+  ): Promise<SafeResult<unknown>>;
+
+  upgradePreLaunchScript(
+    request: UpgradePreLaunchScriptRequest,
+  ): Promise<UpgradePreLaunchScriptResult>;
+  upgradePreLaunchScript<T extends z.ZodTypeAny>(
+    request: UpgradePreLaunchScriptRequest,
+    parameters: { schema: T },
+  ): Promise<z.infer<T>>;
+  upgradePreLaunchScript(
+    request: UpgradePreLaunchScriptRequest,
+    parameters: { schema: false },
+  ): Promise<unknown>;
+
+  safeUpgradePreLaunchScript(
+    request: UpgradePreLaunchScriptRequest,
+  ): Promise<SafeResult<UpgradePreLaunchScriptResult>>;
+  safeUpgradePreLaunchScript<T extends z.ZodTypeAny>(
+    request: UpgradePreLaunchScriptRequest,
+    parameters: { schema: T },
+  ): Promise<SafeResult<z.infer<T>>>;
+  safeUpgradePreLaunchScript(
+    request: UpgradePreLaunchScriptRequest,
     parameters: { schema: false },
   ): Promise<SafeResult<unknown>>;
 


### PR DESCRIPTION
## Summary

`provisionCvm` was unconditionally moving the outgoing request's `node_id` value into the `teepod_id` field, then deleting `node_id`. This was a workaround for an old backend that only knew `teepod_id`. The current backend (`ProvisionDstackAppRequestV2`) has accepted both `node_id` (Node.id) and `teepod_id` (Teepod.id) as **distinct** fields since the v2 resource-matching migration — they are not interchangeable IDs.

When the frontend started sending a real `Node.id` (after teehouse PR #1449 exposed `node_id` in the preflight response), this rewrite routed creation requests to whichever Teepod happened to have `Teepod.id == <Node.id value>`. We caught it in prod: a user selected `prod7` (Teepod 12, Node 7); the SDK rewrote `node_id: 7` → `teepod_id: 7`, which is `prod6-v051` (an old disabled teepod on a different node with no PHALA KMS). Deployment failed with `ERR-02-002`.

## Change

- Pass the request body through as-is to the backend.
- Keep the deprecation warning, but only when `teepod_id` is set and `node_id` is not (no false positives now).

## CLI impact audit (revised)

| Command | Endpoint | Goes through `provisionCvm`? | Impact |
|---|---|---|---|
| `phala deploy` | `/cvms/provision` | yes | **None** (see below) |
| `phala cvms create` | `/cvms` (legacy) | no | none |
| `phala cvms replicate` | `/cvms/{uuid}/replicas` | no | none |
| `phala instances add` | `/apps/{appId}/instances` | no | none |

`phala deploy` reaches `provisionCvm`, but is unaffected because the entire CLI path operates in **Teepod.id** space end-to-end, not Node.id:

- `phala nodes list` calls `getWorkspaceNodes` → backend `GET /workspaces/{team_slug}/nodes`. The SQL projects `Teepod.id.label("id")` (`teehouse/api/routes/workspace/__init__.py:449`), so the `ID` column users copy is a Teepod.id with a "node" wrapper around it.
- `phala deploy --node-id <id>` puts that Teepod.id into `payload.teepod_id` (`deploy/handler.ts:680-682`).
- Both old and new SDK take the same branch here: `body.teepod_id` is a number, `body.node_id` is not, so the deprecation warning prints and the field is forwarded as-is.
- Backend filters by `Teepod.id` — correct, matches the user's selection.

So this PR is **wire-level identical** for every existing CLI command. As a positive side effect, direct SDK callers who pass `{ node_id: <real Node.id> }` (per the field's documented semantics) will now be routed correctly instead of being silently rewritten onto Teepod.id.

## Compatibility

⚠️ Anyone calling `provisionCvm({ node_id: X })` directly and relying on the rewrite to put `X` into `teepod_id` will see a behavior change. The paired teehouse-ui PR is exactly such a caller — it drops the `?? config.teepodId` fallback that was masking the bug. **The SDK release and the teehouse frontend deploy must ship together.**

## Test plan

- [x] `bun run fmt && bun run lint && bun run type-check && bun run test` in `js/` — all green (692 tests)
- [x] Existing e2e test for the deprecated-`teepod_id` warning path still triggers (logic preserved, just narrower condition)
- [x] CLI deploy audited end-to-end; no behavior change
- [ ] Verify against the original failing prod payload in the paired teehouse PR