### PR TITLE
feat: add GitHub MCP Registry templates

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -1373,5 +1373,27 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "playwright-mcp",
+    "name": "Playwright",
+    "description": "Automate web browsers using accessibility trees for testing and data extraction deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/microsoft/playwright-mcp",
+    "author": "microsoft",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1513,5 +1513,27 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "desktop-commander-mcp",
+    "name": "Desktop Commander",
+    "description": "MCP server for terminal commands, file operations, and process management deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/wonderwhy-er/DesktopCommanderMCP",
+    "author": "wonderwhy-er",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -25,12 +25,7 @@
       "memory": 4096,
       "diskSize": 40
     },
-    "tags": [
-      "VibeVM",
-      "TEE",
-      "AI",
-      "VSCode"
-    ]
+    "tags": ["VibeVM", "TEE", "AI", "VSCode"]
   },
   {
     "id": "openclaw",
@@ -76,12 +71,7 @@
       "memory": 4096,
       "diskSize": 40
     },
-    "tags": [
-      "Agent",
-      "AI",
-      "Automation",
-      "Messaging"
-    ]
+    "tags": ["Agent", "AI", "Automation", "Messaging"]
   },
   {
     "id": "ironclaw",
@@ -200,12 +190,7 @@
       "memory": 4096,
       "diskSize": 40
     },
-    "tags": [
-      "Agent",
-      "AI",
-      "Gateway",
-      "NEAR"
-    ]
+    "tags": ["Agent", "AI", "Gateway", "NEAR"]
   },
   {
     "id": "hermes-agent",
@@ -251,12 +236,7 @@
       "memory": 4096,
       "diskSize": 40
     },
-    "tags": [
-      "Agent",
-      "AI",
-      "Automation",
-      "Messaging"
-    ]
+    "tags": ["Agent", "AI", "Automation", "Messaging"]
   },
   {
     "id": "llm-wiki",
@@ -302,12 +282,7 @@
       "memory": 4096,
       "diskSize": 40
     },
-    "tags": [
-      "AI",
-      "Knowledge Graph",
-      "Wiki",
-      "Research"
-    ]
+    "tags": ["AI", "Knowledge Graph", "Wiki", "Research"]
   },
   {
     "id": "anyone-anon-service",
@@ -316,10 +291,7 @@
     "repo": "https://github.com/rA3ka/dstack-examples/tree/main/anyone-anon-service",
     "author": "Anyone",
     "icon": "Anyone-anon-hs.png",
-    "tags": [
-      "Anyone",
-      "anon"
-    ]
+    "tags": ["Anyone", "anon"]
   },
   {
     "id": "anyone-anon-relay",
@@ -328,11 +300,7 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/anyone-anon-relay",
     "author": "Anyone",
     "icon": "Anyone-anon-hs.png",
-    "tags": [
-      "Anyone",
-      "anon",
-      "relay"
-    ]
+    "tags": ["Anyone", "anon", "relay"]
   },
   {
     "id": "evm-mcp",
@@ -341,34 +309,14 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/evm-mcp-server",
     "author": "MCP-DAO",
     "envs": [
-      {
-        "key": "BEARER_TOKEN",
-        "required": true
-      },
-      {
-        "key": "EVM_PRIVATE_KEY",
-        "required": true
-      },
-      {
-        "key": "RPC_URL",
-        "required": true
-      },
-      {
-        "key": "OPENAI_API_KEY",
-        "required": true
-      },
-      {
-        "key": "PERPLEXITY_API_KEY",
-        "required": true
-      },
-      {
-        "key": "COINGECKO_PRO_API_KEY",
-        "required": true
-      }
+      { "key": "BEARER_TOKEN", "required": true },
+      { "key": "EVM_PRIVATE_KEY", "required": true },
+      { "key": "RPC_URL", "required": true },
+      { "key": "OPENAI_API_KEY", "required": true },
+      { "key": "PERPLEXITY_API_KEY", "required": true },
+      { "key": "COINGECKO_PRO_API_KEY", "required": true }
     ],
-    "tags": [
-      "MCP"
-    ]
+    "tags": ["MCP"]
   },
   {
     "id": "demap-defillama",
@@ -377,15 +325,8 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/demap-defilama",
     "author": "DeMCP",
     "icon": "mcp-defillama.svg",
-    "envs": [
-      {
-        "key": "BEARER_TOKEN",
-        "required": true
-      }
-    ],
-    "tags": [
-      "MCP"
-    ]
+    "envs": [{ "key": "BEARER_TOKEN", "required": true }],
+    "tags": ["MCP"]
   },
   {
     "id": "near-mcp",
@@ -394,27 +335,13 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/near-mcp-server",
     "author": "Phala-Network",
     "envs": [
-      {
-        "key": "BEARER_TOKEN",
-        "required": true
-      },
-      {
-        "key": "NEAR_KEYSTOREDATA",
-        "required": true
-      },
-      {
-        "key": "NEAR_NETWORK",
-        "required": false
-      },
-      {
-        "key": "NEAR_ACCOUNT_ID",
-        "required": true
-      }
+      { "key": "BEARER_TOKEN", "required": true },
+      { "key": "NEAR_KEYSTOREDATA", "required": true },
+      { "key": "NEAR_NETWORK", "required": false },
+      { "key": "NEAR_ACCOUNT_ID", "required": true }
     ],
     "icon": "mcp-near.svg",
-    "tags": [
-      "MCP"
-    ]
+    "tags": ["MCP"]
   },
   {
     "id": "solana-mcp",
@@ -423,27 +350,13 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/solana-mcp",
     "author": "SendAI & DARK",
     "envs": [
-      {
-        "key": "BEARER_TOKEN",
-        "required": true
-      },
-      {
-        "key": "SOLANA_PRIVATE_KEY",
-        "required": true
-      },
-      {
-        "key": "RPC_URL",
-        "required": true
-      },
-      {
-        "key": "OPENAI_API_KEY",
-        "required": false
-      }
+      { "key": "BEARER_TOKEN", "required": true },
+      { "key": "SOLANA_PRIVATE_KEY", "required": true },
+      { "key": "RPC_URL", "required": true },
+      { "key": "OPENAI_API_KEY", "required": false }
     ],
     "icon": "mcp-solana.svg",
-    "tags": [
-      "MCP"
-    ]
+    "tags": ["MCP"]
   },
   {
     "id": "context7-mcp",
@@ -452,15 +365,8 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/context7-mcp",
     "author": "Phala-Network",
     "icon": "mcp-context7.png",
-    "envs": [
-      {
-        "key": "BEARER_TOKEN",
-        "required": true
-      }
-    ],
-    "tags": [
-      "MCP"
-    ]
+    "envs": [{ "key": "BEARER_TOKEN", "required": true }],
+    "tags": ["MCP"]
   },
   {
     "id": "mcd-mcp",
@@ -481,16 +387,8 @@
         "description": "Bearer token required by clients that call this Phala Cloud proxy"
       }
     ],
-    "defaultResource": {
-      "vCPU": 1,
-      "memory": 1024,
-      "diskSize": 10
-    },
-    "tags": [
-      "MCP",
-      "Food",
-      "China"
-    ]
+    "defaultResource": { "vCPU": 1, "memory": 1024, "diskSize": 10 },
+    "tags": ["MCP", "Food", "China"]
   },
   {
     "id": "elevenlabs-mcp",
@@ -499,23 +397,12 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/elevenlabs-mcp-server",
     "author": "Phala-Network",
     "envs": [
-      {
-        "key": "BEARER_TOKEN",
-        "required": true
-      },
-      {
-        "key": "ELEVENLABS_API_KEY",
-        "required": true
-      },
-      {
-        "key": "ELEVENLABS_MCP_BASE_PATH",
-        "required": true
-      }
+      { "key": "BEARER_TOKEN", "required": true },
+      { "key": "ELEVENLABS_API_KEY", "required": true },
+      { "key": "ELEVENLABS_MCP_BASE_PATH", "required": true }
     ],
     "icon": "elevenlabs.png",
-    "tags": [
-      "MCP"
-    ]
+    "tags": ["MCP"]
   },
   {
     "id": "supabase-db",
@@ -524,19 +411,11 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/supabase-db",
     "author": "Phala-Network",
     "envs": [
-      {
-        "key": "BEARER_TOKEN",
-        "required": true
-      },
-      {
-        "key": "SUPABASE_ACCESS_TOKEN",
-        "required": true
-      }
+      { "key": "BEARER_TOKEN", "required": true },
+      { "key": "SUPABASE_ACCESS_TOKEN", "required": true }
     ],
     "icon": "supabase.svg",
-    "tags": [
-      "MCP"
-    ]
+    "tags": ["MCP"]
   },
   {
     "id": "figma-mcp",
@@ -545,19 +424,11 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/figma-mcp",
     "author": "Phala-Network",
     "envs": [
-      {
-        "key": "BEARER_TOKEN",
-        "required": true
-      },
-      {
-        "key": "FIGMA_API_KEY",
-        "required": true
-      }
+      { "key": "BEARER_TOKEN", "required": true },
+      { "key": "FIGMA_API_KEY", "required": true }
     ],
     "icon": "mcp-figma.svg",
-    "tags": [
-      "MCP"
-    ]
+    "tags": ["MCP"]
   },
   {
     "id": "mcp-server-fetch",
@@ -565,9 +436,7 @@
     "description": "A MCP server deployed on Phala Cloud that enables AI agents to fetch real-time data from a given URL.",
     "repo": "https://github.com/Leechael/mcp-servers/tree/main/src/fetch",
     "author": "Leechael",
-    "tags": [
-      "MCP"
-    ]
+    "tags": ["MCP"]
   },
   {
     "id": "mcp-server-sequential-thinking",
@@ -575,9 +444,7 @@
     "description": "A MCP server deployed on Phala Cloud that enables AI agents to think sequentially.",
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/mcp-server-sequential-thinking",
     "author": "Phala-Network",
-    "tags": [
-      "MCP"
-    ]
+    "tags": ["MCP"]
   },
   {
     "id": "mcp-swarms-agent",
@@ -587,24 +454,15 @@
     "author": "The-Swarm-Corporation",
     "icon": "mcp-swarms.svg",
     "envs": [
-      {
-        "key": "OPENAI_API_KEY",
-        "required": true
-      },
+      { "key": "OPENAI_API_KEY", "required": true },
       {
         "key": "OPENAI_API_BASE",
         "default": "https://api.openai.com/v1",
         "required": false
       },
-      {
-        "key": "MODEL_NAME",
-        "default": "gpt-4o-mini",
-        "required": false
-      }
+      { "key": "MODEL_NAME", "default": "gpt-4o-mini", "required": false }
     ],
-    "tags": [
-      "MCP"
-    ]
+    "tags": ["MCP"]
   },
   {
     "id": "tor-hidden-service",
@@ -612,9 +470,7 @@
     "description": "This docker compose example sets up a Tor hidden service and serves an nginx website from that.",
     "repo": "https://github.com/Dstack-TEE/dstack-examples/tree/main/tor-hidden-service",
     "author": "Dstack-TEE",
-    "tags": [
-      "Dstack"
-    ]
+    "tags": ["Dstack"]
   },
   {
     "id": "lightclient",
@@ -622,15 +478,8 @@
     "description": "Minimal docker file for using the Helios light client to provide a trustworthy view of the blockchain.",
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/lightclient",
     "author": "Dstack-TEE",
-    "envs": [
-      {
-        "key": "ETH_RPC_URL",
-        "required": true
-      }
-    ],
-    "tags": [
-      "Dstack"
-    ]
+    "envs": [{ "key": "ETH_RPC_URL", "required": true }],
+    "tags": ["Dstack"]
   },
   {
     "id": "webshell",
@@ -651,9 +500,7 @@
         "description": "HTTP basic auth username for ttyd."
       }
     ],
-    "tags": [
-      "Dstack"
-    ]
+    "tags": ["Dstack"]
   },
   {
     "id": "nextjs-starter",
@@ -662,9 +509,7 @@
     "repo": "https://github.com/Phala-Network/phala-cloud-nextjs-starter",
     "author": "Phala-Network",
     "icon": "nextjs-starter.svg",
-    "tags": [
-      "Starter"
-    ]
+    "tags": ["Starter"]
   },
   {
     "id": "python-starter",
@@ -673,9 +518,7 @@
     "repo": "https://github.com/Phala-Network/phala-cloud-python-starter",
     "author": "Phala-Network",
     "icon": "python-starter.png",
-    "tags": [
-      "Starter"
-    ]
+    "tags": ["Starter"]
   },
   {
     "id": "bun-starter",
@@ -684,9 +527,7 @@
     "repo": "https://github.com/Phala-Network/phala-cloud-bun-starter",
     "author": "Phala-Network",
     "icon": "bun-starter.svg",
-    "tags": [
-      "Starter"
-    ]
+    "tags": ["Starter"]
   },
   {
     "id": "node-starter",
@@ -695,9 +536,7 @@
     "repo": "https://github.com/Gldywn/phala-cloud-node-starter",
     "author": "Gldywn",
     "icon": "node-starter.svg",
-    "tags": [
-      "Starter"
-    ]
+    "tags": ["Starter"]
   },
   {
     "id": "armor-crypto",
@@ -724,9 +563,7 @@
         "description": "Optional Armor access token."
       }
     ],
-    "tags": [
-      "MCP"
-    ]
+    "tags": ["MCP"]
   },
   {
     "id": "coinbase-x402-tee",
@@ -749,10 +586,7 @@
         "required": true
       }
     ],
-    "tags": [
-      "Starter",
-      "x402"
-    ]
+    "tags": ["Starter", "x402"]
   },
   {
     "id": "vrf",
@@ -762,18 +596,10 @@
     "author": "Phala-Network",
     "icon": "vrf.png",
     "envs": [
-      {
-        "key": "RPC_URL",
-        "required": true
-      },
-      {
-        "key": "CONTRACT_ADDRESS",
-        "required": true
-      }
+      { "key": "RPC_URL", "required": true },
+      { "key": "CONTRACT_ADDRESS", "required": true }
     ],
-    "tags": [
-      "VRF"
-    ]
+    "tags": ["VRF"]
   },
   {
     "id": "blinko",
@@ -783,18 +609,10 @@
     "author": "Blinko Space",
     "icon": "blinko.png",
     "envs": [
-      {
-        "key": "NEXTAUTH_SECRET",
-        "required": true
-      },
-      {
-        "key": "POSTGRES_PASSWORD",
-        "required": true
-      }
+      { "key": "NEXTAUTH_SECRET", "required": true },
+      { "key": "POSTGRES_PASSWORD", "required": true }
     ],
-    "tags": [
-      "Notebook"
-    ]
+    "tags": ["Notebook"]
   },
   {
     "id": "chatnio",
@@ -804,26 +622,12 @@
     "author": "coaidev",
     "icon": "chatnio.png",
     "envs": [
-      {
-        "key": "MYSQL_ROOT_PASSWORD",
-        "required": true
-      },
-      {
-        "key": "MYSQL_PASSWORD",
-        "required": true
-      },
-      {
-        "key": "SECRET",
-        "required": true
-      },
-      {
-        "key": "CHATNIO_ROOT_PASSWORD",
-        "required": true
-      }
+      { "key": "MYSQL_ROOT_PASSWORD", "required": true },
+      { "key": "MYSQL_PASSWORD", "required": true },
+      { "key": "SECRET", "required": true },
+      { "key": "CHATNIO_ROOT_PASSWORD", "required": true }
     ],
-    "tags": [
-      "Chat"
-    ]
+    "tags": ["Chat"]
   },
   {
     "id": "n8n-automation",
@@ -844,29 +648,12 @@
         "default": "UTC",
         "description": "Timezone for schedule-oriented n8n nodes"
       },
-      {
-        "key": "OPENAI_API_KEY",
-        "required": false
-      },
-      {
-        "key": "GOOGLE_OAUTH_CLIENT_ID",
-        "required": false
-      },
-      {
-        "key": "GOOGLE_OAUTH_CLIENT_SECRET",
-        "required": false
-      }
+      { "key": "OPENAI_API_KEY", "required": false },
+      { "key": "GOOGLE_OAUTH_CLIENT_ID", "required": false },
+      { "key": "GOOGLE_OAUTH_CLIENT_SECRET", "required": false }
     ],
-    "defaultResource": {
-      "vCPU": 2,
-      "memory": 4096,
-      "diskSize": 40
-    },
-    "tags": [
-      "Automation",
-      "Workflow",
-      "Integration"
-    ]
+    "defaultResource": { "vCPU": 2, "memory": 4096, "diskSize": 40 },
+    "tags": ["Automation", "Workflow", "Integration"]
   },
   {
     "id": "moralis-mcp",
@@ -933,10 +720,7 @@
         "description": "Episode processing concurrency; keep low to reduce LLM provider rate-limit pressure"
       }
     ],
-    "tags": [
-      "MCP",
-      "Knowledge Graph"
-    ]
+    "tags": ["MCP", "Knowledge Graph"]
   },
   {
     "id": "msft-presidio-app",
@@ -945,9 +729,7 @@
     "repo": "https://github.com/HashWarlock/presidio/tree/phala-cloud/docs/samples/python/streamlit",
     "author": "HashWarlock",
     "icon": "msft-presidio.png",
-    "tags": [
-      "De-Identification"
-    ]
+    "tags": ["De-Identification"]
   },
   {
     "id": "near-shade-agent",
@@ -957,52 +739,47 @@
     "author": "HashWarlock",
     "icon": "mcp-near.svg",
     "envs": [
-      {
-        "key": "NEAR_ACCOUNT_ID",
-        "required": true,
+      { 
+        "key": "NEAR_ACCOUNT_ID", 
+        "required": true, 
         "description": "NEAR testnet account ID obtained from near-cli-rs; real account required for agent-account and transaction behavior"
       },
-      {
-        "key": "NEAR_SEED_PHRASE",
-        "required": true,
+      { 
+        "key": "NEAR_SEED_PHRASE", 
+        "required": true, 
         "description": "Matching NEAR testnet account seed phrase; dummy values are only suitable for shallow smoke tests"
       },
-      {
-        "key": "NEXT_PUBLIC_contractId",
-        "required": true,
-        "description": "Contract ID (ac-proxy.[NEAR_ACCOUNT_ID] for local, ac-sandbox.[NEAR_ACCOUNT_ID] for Phala Cloud)",
-        "default": "ac-proxy.NEAR_ACCOUNT_ID"
+      { 
+        "key": "NEXT_PUBLIC_contractId", 
+        "required": true, 
+        "description": "Contract ID (ac-proxy.[NEAR_ACCOUNT_ID] for local, ac-sandbox.[NEAR_ACCOUNT_ID] for Phala Cloud)", 
+        "default": "ac-proxy.NEAR_ACCOUNT_ID" 
       },
-      {
-        "key": "API_CODEHASH",
-        "required": true,
-        "description": "Shade agent API code hash (do not change)",
-        "default": "a86e3a4300b069c08d629a38d61a3d780f7992eaf36aa505e4527e466553e2e5"
+      { 
+        "key": "API_CODEHASH", 
+        "required": true, 
+        "description": "Shade agent API code hash (do not change)", 
+        "default": "a86e3a4300b069c08d629a38d61a3d780f7992eaf36aa505e4527e466553e2e5" 
       },
-      {
-        "key": "APP_CODEHASH",
-        "required": true,
-        "description": "Your app's code hash (updates automatically with shade-agent-cli)",
-        "default": "af0c4432864489eb8c6650a6dc61f03ef831240a4199e602cd4d6bd8f4d7163f"
+      { 
+        "key": "APP_CODEHASH", 
+        "required": true, 
+        "description": "Your app's code hash (updates automatically with shade-agent-cli)", 
+        "default": "af0c4432864489eb8c6650a6dc61f03ef831240a4199e602cd4d6bd8f4d7163f" 
       },
-      {
-        "key": "DOCKER_TAG",
-        "required": true,
-        "description": "Docker tag in format docker_username/image_name",
-        "default": "pivortex/my-app"
+      { 
+        "key": "DOCKER_TAG", 
+        "required": true, 
+        "description": "Docker tag in format docker_username/image_name", 
+        "default": "pivortex/my-app" 
       },
-      {
-        "key": "PHALA_API_KEY",
-        "required": true,
+      { 
+        "key": "PHALA_API_KEY", 
+        "required": true, 
         "description": "Phala API key from https://cloud.phala.com/dashboard/tokens; real key required for full agent behavior"
       }
     ],
-    "tags": [
-      "Agent",
-      "NEAR",
-      "Oracle",
-      "TEE"
-    ]
+    "tags": ["Agent", "NEAR", "Oracle", "TEE"]
   },
   {
     "id": "bytebot",
@@ -1039,10 +816,7 @@
         "description": "Google Gemini API key for AI task planning and execution (at least one API key required)"
       }
     ],
-    "tags": [
-      "AI",
-      "Automation"
-    ]
+    "tags": ["AI", "Automation"]
   },
   {
     "id": "node-oracle-template",
@@ -1051,10 +825,7 @@
     "repo": "https://github.com/Gldywn/phala-cloud-oracle-template",
     "author": "Gldywn",
     "icon": "hha.png",
-    "tags": [
-      "Oracle",
-      "Node"
-    ]
+    "tags": ["Oracle", "Node"]
   },
   {
     "id": "akave-link",
@@ -1064,55 +835,16 @@
     "author": "DylanCkawalec",
     "icon": "akave-link.png",
     "envs": [
-      {
-        "key": "NODE_ADDRESS",
-        "required": true,
-        "default": "connect.akave.ai:5500",
-        "description": "Akave node endpoint"
-      },
-      {
-        "key": "PRIVATE_KEY",
-        "required": true,
-        "description": "Ethereum private key for Akave"
-      },
-      {
-        "key": "ADMIN_PASSWORD_HASH",
-        "required": true,
-        "description": "Caddy bcrypt hash for the Basic Auth password that protects all routes"
-      },
-      {
-        "key": "AKAVELINK_USERNAME",
-        "required": false,
-        "default": "admin",
-        "description": "Caddy Basic Auth username"
-      },
-      {
-        "key": "PORT",
-        "required": false,
-        "default": "80"
-      },
-      {
-        "key": "CORS_ORIGIN",
-        "required": false,
-        "default": "*"
-      },
-      {
-        "key": "DEBUG",
-        "required": false,
-        "default": "true"
-      }
+      { "key": "NODE_ADDRESS", "required": true, "default": "connect.akave.ai:5500", "description": "Akave node endpoint" },
+      { "key": "PRIVATE_KEY", "required": true, "description": "Ethereum private key for Akave" },
+      { "key": "ADMIN_PASSWORD_HASH", "required": true, "description": "Caddy bcrypt hash for the Basic Auth password that protects all routes" },
+      { "key": "AKAVELINK_USERNAME", "required": false, "default": "admin", "description": "Caddy Basic Auth username" },
+      { "key": "PORT", "required": false, "default": "80" },
+      { "key": "CORS_ORIGIN", "required": false, "default": "*" },
+      { "key": "DEBUG", "required": false, "default": "true" }
     ],
-    "defaultResource": {
-      "vCPU": 2,
-      "memory": 2048,
-      "diskSize": 20
-    },
-    "tags": [
-      "Storage",
-      "Akave",
-      "REST",
-      "TEE"
-    ]
+    "defaultResource": { "vCPU": 2, "memory": 2048, "diskSize": 20 },
+    "tags": ["Storage", "Akave", "REST", "TEE"]
   },
   {
     "id": "open-webui",
@@ -1122,22 +854,10 @@
     "author": "Phala-Network",
     "icon": "open-webui.png",
     "envs": [
-      {
-        "key": "WEBUI_SECRET_KEY",
-        "required": false,
-        "description": "Secret key for Open WebUI authentication"
-      }
+      { "key": "WEBUI_SECRET_KEY", "required": false, "description": "Secret key for Open WebUI authentication" }
     ],
-    "defaultResource": {
-      "vCPU": 2,
-      "memory": 2048,
-      "diskSize": 20
-    },
-    "tags": [
-      "OpenWebUI",
-      "REST",
-      "TEE"
-    ]
+    "defaultResource": { "vCPU": 2, "memory": 2048, "diskSize": 20 },
+    "tags": ["OpenWebUI", "REST", "TEE"]
   },
   {
     "id": "primus-attestor-node",
@@ -1182,131 +902,29 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/erc-8004-tee-agent",
     "author": "Phala-Network",
     "envs": [
-      {
-        "key": "AGENT_SALT",
-        "required": true,
-        "description": "Unique secret salt for key derivation"
-      },
-      {
-        "key": "REDPILL_API_KEY",
-        "required": true,
-        "description": "API key for confidential AI inference"
-      },
-      {
-        "key": "SUBGRAPH_API_KEY",
-        "required": true,
-        "description": "Access token for blockchain data queries"
-      },
-      {
-        "key": "RPC_URL",
-        "required": true,
-        "description": "Blockchain node endpoint"
-      },
-      {
-        "key": "CHAIN_NAME",
-        "required": true,
-        "description": "Target blockchain (e.g., eth-sepolia)"
-      },
-      {
-        "key": "ERC8004_AGENT_PASSWORD_HASH",
-        "required": true,
-        "description": "Caddy bcrypt password hash for Basic Auth"
-      },
-      {
-        "key": "ERC8004_AGENT_USERNAME",
-        "required": false,
-        "description": "Caddy Basic Auth username",
-        "default": "agent"
-      },
-      {
-        "key": "AGENT_DOMAIN",
-        "required": false,
-        "description": "Public agent domain override; derived at startup when omitted"
-      },
-      {
-        "key": "TRUST_CENTER_URL",
-        "required": false,
-        "description": "Trust Center widget URL override; derived at startup when omitted"
-      },
-      {
-        "key": "ANTHROPIC_MODEL",
-        "required": false,
-        "description": "Chat model selection",
-        "default": "openai/gpt-oss-120b"
-      },
-      {
-        "key": "AI_MODEL",
-        "required": false,
-        "description": "RedPill model used by the code-generation helper",
-        "default": "phala/qwen-2.5-7b-instruct"
-      },
-      {
-        "key": "AI_TEMPERATURE",
-        "required": false,
-        "description": "AI sampling temperature",
-        "default": "0.3"
-      },
-      {
-        "key": "AI_MAX_TOKENS",
-        "required": false,
-        "description": "AI response token limit",
-        "default": "2000"
-      },
-      {
-        "key": "CODE_EXECUTION_TIMEOUT",
-        "required": false,
-        "description": "Code execution timeout in seconds",
-        "default": "30"
-      },
-      {
-        "key": "REDPILL_API_URL",
-        "required": false,
-        "description": "RedPill API base URL",
-        "default": "https://api.redpill.ai"
-      },
-      {
-        "key": "ANTHROPIC_BASE_URL",
-        "required": false,
-        "description": "Anthropic-compatible API base URL",
-        "default": "https://api.redpill.ai"
-      },
-      {
-        "key": "CHAIN_ID",
-        "required": false,
-        "description": "EVM chain ID override",
-        "default": "11155111"
-      },
-      {
-        "key": "IDENTITY_REGISTRY_ADDRESS",
-        "required": false,
-        "description": "ERC-8004 identity registry contract override",
-        "default": "0x8004A818BFB912233c491871b3d84c89A494BD9e"
-      },
-      {
-        "key": "REPUTATION_REGISTRY_ADDRESS",
-        "required": false,
-        "description": "ERC-8004 reputation registry contract override",
-        "default": "0x8004B663056A597Dffe9eCcC1965A193B7388713"
-      },
-      {
-        "key": "SESSION_TIMEOUT_MINUTES",
-        "required": false,
-        "description": "Chat session timeout in minutes",
-        "default": "60"
-      },
-      {
-        "key": "MAX_SESSIONS",
-        "required": false,
-        "description": "Maximum in-memory chat sessions",
-        "default": "100"
-      }
+      { "key": "AGENT_SALT", "required": true, "description": "Unique secret salt for key derivation" },
+      { "key": "REDPILL_API_KEY", "required": true, "description": "API key for confidential AI inference" },
+      { "key": "SUBGRAPH_API_KEY", "required": true, "description": "Access token for blockchain data queries" },
+      { "key": "RPC_URL", "required": true, "description": "Blockchain node endpoint" },
+      { "key": "CHAIN_NAME", "required": true, "description": "Target blockchain (e.g., eth-sepolia)" },
+      { "key": "ERC8004_AGENT_PASSWORD_HASH", "required": true, "description": "Caddy bcrypt password hash for Basic Auth" },
+      { "key": "ERC8004_AGENT_USERNAME", "required": false, "description": "Caddy Basic Auth username", "default": "agent" },
+      { "key": "AGENT_DOMAIN", "required": false, "description": "Public agent domain override; derived at startup when omitted" },
+      { "key": "TRUST_CENTER_URL", "required": false, "description": "Trust Center widget URL override; derived at startup when omitted" },
+      { "key": "ANTHROPIC_MODEL", "required": false, "description": "Chat model selection", "default": "openai/gpt-oss-120b" },
+      { "key": "AI_MODEL", "required": false, "description": "RedPill model used by the code-generation helper", "default": "phala/qwen-2.5-7b-instruct" },
+      { "key": "AI_TEMPERATURE", "required": false, "description": "AI sampling temperature", "default": "0.3" },
+      { "key": "AI_MAX_TOKENS", "required": false, "description": "AI response token limit", "default": "2000" },
+      { "key": "CODE_EXECUTION_TIMEOUT", "required": false, "description": "Code execution timeout in seconds", "default": "30" },
+      { "key": "REDPILL_API_URL", "required": false, "description": "RedPill API base URL", "default": "https://api.redpill.ai" },
+      { "key": "ANTHROPIC_BASE_URL", "required": false, "description": "Anthropic-compatible API base URL", "default": "https://api.redpill.ai" },
+      { "key": "CHAIN_ID", "required": false, "description": "EVM chain ID override", "default": "11155111" },
+      { "key": "IDENTITY_REGISTRY_ADDRESS", "required": false, "description": "ERC-8004 identity registry contract override", "default": "0x8004A818BFB912233c491871b3d84c89A494BD9e" },
+      { "key": "REPUTATION_REGISTRY_ADDRESS", "required": false, "description": "ERC-8004 reputation registry contract override", "default": "0x8004B663056A597Dffe9eCcC1965A193B7388713" },
+      { "key": "SESSION_TIMEOUT_MINUTES", "required": false, "description": "Chat session timeout in minutes", "default": "60" },
+      { "key": "MAX_SESSIONS", "required": false, "description": "Maximum in-memory chat sessions", "default": "100" }
     ],
-    "tags": [
-      "Agent",
-      "TEE",
-      "ERC-8004",
-      "AI"
-    ]
+    "tags": ["Agent", "TEE", "ERC-8004", "AI"]
   },
   {
     "id": "markitdown-mcp",

--- a/templates/config.json
+++ b/templates/config.json
@@ -1395,5 +1395,32 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "github-mcp-server",
+    "name": "GitHub",
+    "description": "Connect AI assistants to GitHub - manage repos, issues, PRs, and workflows through natural language deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/github/github-mcp-server",
+    "author": "github",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      },
+      {
+        "key": "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "required": true,
+        "description": "GitHub fine-grained or classic PAT used by the MCP server."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -2037,5 +2037,53 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "elasticsearch-mcp",
+    "name": "Elasticsearch",
+    "description": "MCP server for connecting to Elasticsearch data and indices. Supports search queries, mappings, ES|QL, and shard information through natural language interactions deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/elastic/mcp-server-elasticsearch",
+    "author": "elastic",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      },
+      {
+        "key": "ES_URL",
+        "required": true,
+        "description": "Elasticsearch cluster URL."
+      },
+      {
+        "key": "ES_API_KEY",
+        "required": false,
+        "description": "Elasticsearch API key."
+      },
+      {
+        "key": "ES_USERNAME",
+        "required": false,
+        "description": "Elasticsearch username for basic auth."
+      },
+      {
+        "key": "ES_PASSWORD",
+        "required": false,
+        "description": "Elasticsearch password for basic auth."
+      },
+      {
+        "key": "ES_SSL_SKIP_VERIFY",
+        "required": false,
+        "description": "Set to true to skip Elasticsearch TLS verification.",
+        "default": "false"
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1557,5 +1557,48 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "azure-mcp",
+    "name": "Azure MCP Server",
+    "description": "All Azure MCP tools to create a seamless connection between AI agents and Azure services deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/microsoft/mcp",
+    "author": "microsoft",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      },
+      {
+        "key": "AZURE_TENANT_ID",
+        "required": false,
+        "description": "Azure tenant ID for service-principal authentication."
+      },
+      {
+        "key": "AZURE_CLIENT_ID",
+        "required": false,
+        "description": "Azure client ID for service-principal authentication."
+      },
+      {
+        "key": "AZURE_CLIENT_SECRET",
+        "required": false,
+        "description": "Azure client secret for service-principal authentication."
+      },
+      {
+        "key": "AZURE_MCP_COLLECT_TELEMETRY",
+        "required": false,
+        "description": "Set to false to disable Azure MCP telemetry.",
+        "default": "false"
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1637,5 +1637,32 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "dbhub",
+    "name": "DBHub",
+    "description": "Minimal, token-efficient Database MCP Server for PostgreSQL, MySQL, SQL Server, SQLite, MariaDB deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/bytebase/dbhub",
+    "author": "bytebase",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      },
+      {
+        "key": "DBHUB_DSN",
+        "required": true,
+        "description": "Database DSN, for example postgres://user:pass@host:5432/dbname?sslmode=require."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1535,5 +1535,27 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "notion-mcp-server",
+    "name": "Notion",
+    "description": "Official MCP server for Notion API deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/makenotion/notion-mcp-server",
+    "author": "makenotion",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1951,5 +1951,32 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "next-devtools-mcp",
+    "name": "Vercel Next Dev Tools",
+    "description": "Next.js development tools MCP server with stdio transport deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/vercel/next-devtools-mcp",
+    "author": "vercel",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      },
+      {
+        "key": "NEXT_DEV_SERVER_URL",
+        "required": false,
+        "description": "Optional URL for the Next.js dev server this MCP should inspect."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1449,5 +1449,37 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "unity-mcp",
+    "name": "Unity",
+    "description": "Control the Unity Editor from MCP clients via a Unity bridge + local Python server deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/CoplayDev/unity-mcp",
+    "author": "CoplayDev",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      },
+      {
+        "key": "UNITY_HOST",
+        "required": false,
+        "description": "Optional Unity bridge host if your Unity Editor can reach this CVM."
+      },
+      {
+        "key": "UNITY_PORT",
+        "required": false,
+        "description": "Optional Unity bridge port."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -25,7 +25,12 @@
       "memory": 4096,
       "diskSize": 40
     },
-    "tags": ["VibeVM", "TEE", "AI", "VSCode"]
+    "tags": [
+      "VibeVM",
+      "TEE",
+      "AI",
+      "VSCode"
+    ]
   },
   {
     "id": "openclaw",
@@ -71,7 +76,12 @@
       "memory": 4096,
       "diskSize": 40
     },
-    "tags": ["Agent", "AI", "Automation", "Messaging"]
+    "tags": [
+      "Agent",
+      "AI",
+      "Automation",
+      "Messaging"
+    ]
   },
   {
     "id": "ironclaw",
@@ -190,7 +200,12 @@
       "memory": 4096,
       "diskSize": 40
     },
-    "tags": ["Agent", "AI", "Gateway", "NEAR"]
+    "tags": [
+      "Agent",
+      "AI",
+      "Gateway",
+      "NEAR"
+    ]
   },
   {
     "id": "hermes-agent",
@@ -236,7 +251,12 @@
       "memory": 4096,
       "diskSize": 40
     },
-    "tags": ["Agent", "AI", "Automation", "Messaging"]
+    "tags": [
+      "Agent",
+      "AI",
+      "Automation",
+      "Messaging"
+    ]
   },
   {
     "id": "llm-wiki",
@@ -282,7 +302,12 @@
       "memory": 4096,
       "diskSize": 40
     },
-    "tags": ["AI", "Knowledge Graph", "Wiki", "Research"]
+    "tags": [
+      "AI",
+      "Knowledge Graph",
+      "Wiki",
+      "Research"
+    ]
   },
   {
     "id": "anyone-anon-service",
@@ -291,7 +316,10 @@
     "repo": "https://github.com/rA3ka/dstack-examples/tree/main/anyone-anon-service",
     "author": "Anyone",
     "icon": "Anyone-anon-hs.png",
-    "tags": ["Anyone", "anon"]
+    "tags": [
+      "Anyone",
+      "anon"
+    ]
   },
   {
     "id": "anyone-anon-relay",
@@ -300,7 +328,11 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/anyone-anon-relay",
     "author": "Anyone",
     "icon": "Anyone-anon-hs.png",
-    "tags": ["Anyone", "anon", "relay"]
+    "tags": [
+      "Anyone",
+      "anon",
+      "relay"
+    ]
   },
   {
     "id": "evm-mcp",
@@ -309,14 +341,34 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/evm-mcp-server",
     "author": "MCP-DAO",
     "envs": [
-      { "key": "BEARER_TOKEN", "required": true },
-      { "key": "EVM_PRIVATE_KEY", "required": true },
-      { "key": "RPC_URL", "required": true },
-      { "key": "OPENAI_API_KEY", "required": true },
-      { "key": "PERPLEXITY_API_KEY", "required": true },
-      { "key": "COINGECKO_PRO_API_KEY", "required": true }
+      {
+        "key": "BEARER_TOKEN",
+        "required": true
+      },
+      {
+        "key": "EVM_PRIVATE_KEY",
+        "required": true
+      },
+      {
+        "key": "RPC_URL",
+        "required": true
+      },
+      {
+        "key": "OPENAI_API_KEY",
+        "required": true
+      },
+      {
+        "key": "PERPLEXITY_API_KEY",
+        "required": true
+      },
+      {
+        "key": "COINGECKO_PRO_API_KEY",
+        "required": true
+      }
     ],
-    "tags": ["MCP"]
+    "tags": [
+      "MCP"
+    ]
   },
   {
     "id": "demap-defillama",
@@ -325,8 +377,15 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/demap-defilama",
     "author": "DeMCP",
     "icon": "mcp-defillama.svg",
-    "envs": [{ "key": "BEARER_TOKEN", "required": true }],
-    "tags": ["MCP"]
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true
+      }
+    ],
+    "tags": [
+      "MCP"
+    ]
   },
   {
     "id": "near-mcp",
@@ -335,13 +394,27 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/near-mcp-server",
     "author": "Phala-Network",
     "envs": [
-      { "key": "BEARER_TOKEN", "required": true },
-      { "key": "NEAR_KEYSTOREDATA", "required": true },
-      { "key": "NEAR_NETWORK", "required": false },
-      { "key": "NEAR_ACCOUNT_ID", "required": true }
+      {
+        "key": "BEARER_TOKEN",
+        "required": true
+      },
+      {
+        "key": "NEAR_KEYSTOREDATA",
+        "required": true
+      },
+      {
+        "key": "NEAR_NETWORK",
+        "required": false
+      },
+      {
+        "key": "NEAR_ACCOUNT_ID",
+        "required": true
+      }
     ],
     "icon": "mcp-near.svg",
-    "tags": ["MCP"]
+    "tags": [
+      "MCP"
+    ]
   },
   {
     "id": "solana-mcp",
@@ -350,13 +423,27 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/solana-mcp",
     "author": "SendAI & DARK",
     "envs": [
-      { "key": "BEARER_TOKEN", "required": true },
-      { "key": "SOLANA_PRIVATE_KEY", "required": true },
-      { "key": "RPC_URL", "required": true },
-      { "key": "OPENAI_API_KEY", "required": false }
+      {
+        "key": "BEARER_TOKEN",
+        "required": true
+      },
+      {
+        "key": "SOLANA_PRIVATE_KEY",
+        "required": true
+      },
+      {
+        "key": "RPC_URL",
+        "required": true
+      },
+      {
+        "key": "OPENAI_API_KEY",
+        "required": false
+      }
     ],
     "icon": "mcp-solana.svg",
-    "tags": ["MCP"]
+    "tags": [
+      "MCP"
+    ]
   },
   {
     "id": "context7-mcp",
@@ -365,8 +452,15 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/context7-mcp",
     "author": "Phala-Network",
     "icon": "mcp-context7.png",
-    "envs": [{ "key": "BEARER_TOKEN", "required": true }],
-    "tags": ["MCP"]
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true
+      }
+    ],
+    "tags": [
+      "MCP"
+    ]
   },
   {
     "id": "mcd-mcp",
@@ -387,8 +481,16 @@
         "description": "Bearer token required by clients that call this Phala Cloud proxy"
       }
     ],
-    "defaultResource": { "vCPU": 1, "memory": 1024, "diskSize": 10 },
-    "tags": ["MCP", "Food", "China"]
+    "defaultResource": {
+      "vCPU": 1,
+      "memory": 1024,
+      "diskSize": 10
+    },
+    "tags": [
+      "MCP",
+      "Food",
+      "China"
+    ]
   },
   {
     "id": "elevenlabs-mcp",
@@ -397,12 +499,23 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/elevenlabs-mcp-server",
     "author": "Phala-Network",
     "envs": [
-      { "key": "BEARER_TOKEN", "required": true },
-      { "key": "ELEVENLABS_API_KEY", "required": true },
-      { "key": "ELEVENLABS_MCP_BASE_PATH", "required": true }
+      {
+        "key": "BEARER_TOKEN",
+        "required": true
+      },
+      {
+        "key": "ELEVENLABS_API_KEY",
+        "required": true
+      },
+      {
+        "key": "ELEVENLABS_MCP_BASE_PATH",
+        "required": true
+      }
     ],
     "icon": "elevenlabs.png",
-    "tags": ["MCP"]
+    "tags": [
+      "MCP"
+    ]
   },
   {
     "id": "supabase-db",
@@ -411,11 +524,19 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/supabase-db",
     "author": "Phala-Network",
     "envs": [
-      { "key": "BEARER_TOKEN", "required": true },
-      { "key": "SUPABASE_ACCESS_TOKEN", "required": true }
+      {
+        "key": "BEARER_TOKEN",
+        "required": true
+      },
+      {
+        "key": "SUPABASE_ACCESS_TOKEN",
+        "required": true
+      }
     ],
     "icon": "supabase.svg",
-    "tags": ["MCP"]
+    "tags": [
+      "MCP"
+    ]
   },
   {
     "id": "figma-mcp",
@@ -424,11 +545,19 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/figma-mcp",
     "author": "Phala-Network",
     "envs": [
-      { "key": "BEARER_TOKEN", "required": true },
-      { "key": "FIGMA_API_KEY", "required": true }
+      {
+        "key": "BEARER_TOKEN",
+        "required": true
+      },
+      {
+        "key": "FIGMA_API_KEY",
+        "required": true
+      }
     ],
     "icon": "mcp-figma.svg",
-    "tags": ["MCP"]
+    "tags": [
+      "MCP"
+    ]
   },
   {
     "id": "mcp-server-fetch",
@@ -436,7 +565,9 @@
     "description": "A MCP server deployed on Phala Cloud that enables AI agents to fetch real-time data from a given URL.",
     "repo": "https://github.com/Leechael/mcp-servers/tree/main/src/fetch",
     "author": "Leechael",
-    "tags": ["MCP"]
+    "tags": [
+      "MCP"
+    ]
   },
   {
     "id": "mcp-server-sequential-thinking",
@@ -444,7 +575,9 @@
     "description": "A MCP server deployed on Phala Cloud that enables AI agents to think sequentially.",
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/mcp-server-sequential-thinking",
     "author": "Phala-Network",
-    "tags": ["MCP"]
+    "tags": [
+      "MCP"
+    ]
   },
   {
     "id": "mcp-swarms-agent",
@@ -454,15 +587,24 @@
     "author": "The-Swarm-Corporation",
     "icon": "mcp-swarms.svg",
     "envs": [
-      { "key": "OPENAI_API_KEY", "required": true },
+      {
+        "key": "OPENAI_API_KEY",
+        "required": true
+      },
       {
         "key": "OPENAI_API_BASE",
         "default": "https://api.openai.com/v1",
         "required": false
       },
-      { "key": "MODEL_NAME", "default": "gpt-4o-mini", "required": false }
+      {
+        "key": "MODEL_NAME",
+        "default": "gpt-4o-mini",
+        "required": false
+      }
     ],
-    "tags": ["MCP"]
+    "tags": [
+      "MCP"
+    ]
   },
   {
     "id": "tor-hidden-service",
@@ -470,7 +612,9 @@
     "description": "This docker compose example sets up a Tor hidden service and serves an nginx website from that.",
     "repo": "https://github.com/Dstack-TEE/dstack-examples/tree/main/tor-hidden-service",
     "author": "Dstack-TEE",
-    "tags": ["Dstack"]
+    "tags": [
+      "Dstack"
+    ]
   },
   {
     "id": "lightclient",
@@ -478,8 +622,15 @@
     "description": "Minimal docker file for using the Helios light client to provide a trustworthy view of the blockchain.",
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/lightclient",
     "author": "Dstack-TEE",
-    "envs": [{ "key": "ETH_RPC_URL", "required": true }],
-    "tags": ["Dstack"]
+    "envs": [
+      {
+        "key": "ETH_RPC_URL",
+        "required": true
+      }
+    ],
+    "tags": [
+      "Dstack"
+    ]
   },
   {
     "id": "webshell",
@@ -500,7 +651,9 @@
         "description": "HTTP basic auth username for ttyd."
       }
     ],
-    "tags": ["Dstack"]
+    "tags": [
+      "Dstack"
+    ]
   },
   {
     "id": "nextjs-starter",
@@ -509,7 +662,9 @@
     "repo": "https://github.com/Phala-Network/phala-cloud-nextjs-starter",
     "author": "Phala-Network",
     "icon": "nextjs-starter.svg",
-    "tags": ["Starter"]
+    "tags": [
+      "Starter"
+    ]
   },
   {
     "id": "python-starter",
@@ -518,7 +673,9 @@
     "repo": "https://github.com/Phala-Network/phala-cloud-python-starter",
     "author": "Phala-Network",
     "icon": "python-starter.png",
-    "tags": ["Starter"]
+    "tags": [
+      "Starter"
+    ]
   },
   {
     "id": "bun-starter",
@@ -527,7 +684,9 @@
     "repo": "https://github.com/Phala-Network/phala-cloud-bun-starter",
     "author": "Phala-Network",
     "icon": "bun-starter.svg",
-    "tags": ["Starter"]
+    "tags": [
+      "Starter"
+    ]
   },
   {
     "id": "node-starter",
@@ -536,7 +695,9 @@
     "repo": "https://github.com/Gldywn/phala-cloud-node-starter",
     "author": "Gldywn",
     "icon": "node-starter.svg",
-    "tags": ["Starter"]
+    "tags": [
+      "Starter"
+    ]
   },
   {
     "id": "armor-crypto",
@@ -563,7 +724,9 @@
         "description": "Optional Armor access token."
       }
     ],
-    "tags": ["MCP"]
+    "tags": [
+      "MCP"
+    ]
   },
   {
     "id": "coinbase-x402-tee",
@@ -586,7 +749,10 @@
         "required": true
       }
     ],
-    "tags": ["Starter", "x402"]
+    "tags": [
+      "Starter",
+      "x402"
+    ]
   },
   {
     "id": "vrf",
@@ -596,10 +762,18 @@
     "author": "Phala-Network",
     "icon": "vrf.png",
     "envs": [
-      { "key": "RPC_URL", "required": true },
-      { "key": "CONTRACT_ADDRESS", "required": true }
+      {
+        "key": "RPC_URL",
+        "required": true
+      },
+      {
+        "key": "CONTRACT_ADDRESS",
+        "required": true
+      }
     ],
-    "tags": ["VRF"]
+    "tags": [
+      "VRF"
+    ]
   },
   {
     "id": "blinko",
@@ -609,10 +783,18 @@
     "author": "Blinko Space",
     "icon": "blinko.png",
     "envs": [
-      { "key": "NEXTAUTH_SECRET", "required": true },
-      { "key": "POSTGRES_PASSWORD", "required": true }
+      {
+        "key": "NEXTAUTH_SECRET",
+        "required": true
+      },
+      {
+        "key": "POSTGRES_PASSWORD",
+        "required": true
+      }
     ],
-    "tags": ["Notebook"]
+    "tags": [
+      "Notebook"
+    ]
   },
   {
     "id": "chatnio",
@@ -622,12 +804,26 @@
     "author": "coaidev",
     "icon": "chatnio.png",
     "envs": [
-      { "key": "MYSQL_ROOT_PASSWORD", "required": true },
-      { "key": "MYSQL_PASSWORD", "required": true },
-      { "key": "SECRET", "required": true },
-      { "key": "CHATNIO_ROOT_PASSWORD", "required": true }
+      {
+        "key": "MYSQL_ROOT_PASSWORD",
+        "required": true
+      },
+      {
+        "key": "MYSQL_PASSWORD",
+        "required": true
+      },
+      {
+        "key": "SECRET",
+        "required": true
+      },
+      {
+        "key": "CHATNIO_ROOT_PASSWORD",
+        "required": true
+      }
     ],
-    "tags": ["Chat"]
+    "tags": [
+      "Chat"
+    ]
   },
   {
     "id": "n8n-automation",
@@ -648,12 +844,29 @@
         "default": "UTC",
         "description": "Timezone for schedule-oriented n8n nodes"
       },
-      { "key": "OPENAI_API_KEY", "required": false },
-      { "key": "GOOGLE_OAUTH_CLIENT_ID", "required": false },
-      { "key": "GOOGLE_OAUTH_CLIENT_SECRET", "required": false }
+      {
+        "key": "OPENAI_API_KEY",
+        "required": false
+      },
+      {
+        "key": "GOOGLE_OAUTH_CLIENT_ID",
+        "required": false
+      },
+      {
+        "key": "GOOGLE_OAUTH_CLIENT_SECRET",
+        "required": false
+      }
     ],
-    "defaultResource": { "vCPU": 2, "memory": 4096, "diskSize": 40 },
-    "tags": ["Automation", "Workflow", "Integration"]
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 40
+    },
+    "tags": [
+      "Automation",
+      "Workflow",
+      "Integration"
+    ]
   },
   {
     "id": "moralis-mcp",
@@ -720,7 +933,10 @@
         "description": "Episode processing concurrency; keep low to reduce LLM provider rate-limit pressure"
       }
     ],
-    "tags": ["MCP", "Knowledge Graph"]
+    "tags": [
+      "MCP",
+      "Knowledge Graph"
+    ]
   },
   {
     "id": "msft-presidio-app",
@@ -729,7 +945,9 @@
     "repo": "https://github.com/HashWarlock/presidio/tree/phala-cloud/docs/samples/python/streamlit",
     "author": "HashWarlock",
     "icon": "msft-presidio.png",
-    "tags": ["De-Identification"]
+    "tags": [
+      "De-Identification"
+    ]
   },
   {
     "id": "near-shade-agent",
@@ -739,47 +957,52 @@
     "author": "HashWarlock",
     "icon": "mcp-near.svg",
     "envs": [
-      { 
-        "key": "NEAR_ACCOUNT_ID", 
-        "required": true, 
+      {
+        "key": "NEAR_ACCOUNT_ID",
+        "required": true,
         "description": "NEAR testnet account ID obtained from near-cli-rs; real account required for agent-account and transaction behavior"
       },
-      { 
-        "key": "NEAR_SEED_PHRASE", 
-        "required": true, 
+      {
+        "key": "NEAR_SEED_PHRASE",
+        "required": true,
         "description": "Matching NEAR testnet account seed phrase; dummy values are only suitable for shallow smoke tests"
       },
-      { 
-        "key": "NEXT_PUBLIC_contractId", 
-        "required": true, 
-        "description": "Contract ID (ac-proxy.[NEAR_ACCOUNT_ID] for local, ac-sandbox.[NEAR_ACCOUNT_ID] for Phala Cloud)", 
-        "default": "ac-proxy.NEAR_ACCOUNT_ID" 
+      {
+        "key": "NEXT_PUBLIC_contractId",
+        "required": true,
+        "description": "Contract ID (ac-proxy.[NEAR_ACCOUNT_ID] for local, ac-sandbox.[NEAR_ACCOUNT_ID] for Phala Cloud)",
+        "default": "ac-proxy.NEAR_ACCOUNT_ID"
       },
-      { 
-        "key": "API_CODEHASH", 
-        "required": true, 
-        "description": "Shade agent API code hash (do not change)", 
-        "default": "a86e3a4300b069c08d629a38d61a3d780f7992eaf36aa505e4527e466553e2e5" 
+      {
+        "key": "API_CODEHASH",
+        "required": true,
+        "description": "Shade agent API code hash (do not change)",
+        "default": "a86e3a4300b069c08d629a38d61a3d780f7992eaf36aa505e4527e466553e2e5"
       },
-      { 
-        "key": "APP_CODEHASH", 
-        "required": true, 
-        "description": "Your app's code hash (updates automatically with shade-agent-cli)", 
-        "default": "af0c4432864489eb8c6650a6dc61f03ef831240a4199e602cd4d6bd8f4d7163f" 
+      {
+        "key": "APP_CODEHASH",
+        "required": true,
+        "description": "Your app's code hash (updates automatically with shade-agent-cli)",
+        "default": "af0c4432864489eb8c6650a6dc61f03ef831240a4199e602cd4d6bd8f4d7163f"
       },
-      { 
-        "key": "DOCKER_TAG", 
-        "required": true, 
-        "description": "Docker tag in format docker_username/image_name", 
-        "default": "pivortex/my-app" 
+      {
+        "key": "DOCKER_TAG",
+        "required": true,
+        "description": "Docker tag in format docker_username/image_name",
+        "default": "pivortex/my-app"
       },
-      { 
-        "key": "PHALA_API_KEY", 
-        "required": true, 
+      {
+        "key": "PHALA_API_KEY",
+        "required": true,
         "description": "Phala API key from https://cloud.phala.com/dashboard/tokens; real key required for full agent behavior"
       }
     ],
-    "tags": ["Agent", "NEAR", "Oracle", "TEE"]
+    "tags": [
+      "Agent",
+      "NEAR",
+      "Oracle",
+      "TEE"
+    ]
   },
   {
     "id": "bytebot",
@@ -816,7 +1039,10 @@
         "description": "Google Gemini API key for AI task planning and execution (at least one API key required)"
       }
     ],
-    "tags": ["AI", "Automation"]
+    "tags": [
+      "AI",
+      "Automation"
+    ]
   },
   {
     "id": "node-oracle-template",
@@ -825,7 +1051,10 @@
     "repo": "https://github.com/Gldywn/phala-cloud-oracle-template",
     "author": "Gldywn",
     "icon": "hha.png",
-    "tags": ["Oracle", "Node"]
+    "tags": [
+      "Oracle",
+      "Node"
+    ]
   },
   {
     "id": "akave-link",
@@ -835,16 +1064,55 @@
     "author": "DylanCkawalec",
     "icon": "akave-link.png",
     "envs": [
-      { "key": "NODE_ADDRESS", "required": true, "default": "connect.akave.ai:5500", "description": "Akave node endpoint" },
-      { "key": "PRIVATE_KEY", "required": true, "description": "Ethereum private key for Akave" },
-      { "key": "ADMIN_PASSWORD_HASH", "required": true, "description": "Caddy bcrypt hash for the Basic Auth password that protects all routes" },
-      { "key": "AKAVELINK_USERNAME", "required": false, "default": "admin", "description": "Caddy Basic Auth username" },
-      { "key": "PORT", "required": false, "default": "80" },
-      { "key": "CORS_ORIGIN", "required": false, "default": "*" },
-      { "key": "DEBUG", "required": false, "default": "true" }
+      {
+        "key": "NODE_ADDRESS",
+        "required": true,
+        "default": "connect.akave.ai:5500",
+        "description": "Akave node endpoint"
+      },
+      {
+        "key": "PRIVATE_KEY",
+        "required": true,
+        "description": "Ethereum private key for Akave"
+      },
+      {
+        "key": "ADMIN_PASSWORD_HASH",
+        "required": true,
+        "description": "Caddy bcrypt hash for the Basic Auth password that protects all routes"
+      },
+      {
+        "key": "AKAVELINK_USERNAME",
+        "required": false,
+        "default": "admin",
+        "description": "Caddy Basic Auth username"
+      },
+      {
+        "key": "PORT",
+        "required": false,
+        "default": "80"
+      },
+      {
+        "key": "CORS_ORIGIN",
+        "required": false,
+        "default": "*"
+      },
+      {
+        "key": "DEBUG",
+        "required": false,
+        "default": "true"
+      }
     ],
-    "defaultResource": { "vCPU": 2, "memory": 2048, "diskSize": 20 },
-    "tags": ["Storage", "Akave", "REST", "TEE"]
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 2048,
+      "diskSize": 20
+    },
+    "tags": [
+      "Storage",
+      "Akave",
+      "REST",
+      "TEE"
+    ]
   },
   {
     "id": "open-webui",
@@ -854,10 +1122,22 @@
     "author": "Phala-Network",
     "icon": "open-webui.png",
     "envs": [
-      { "key": "WEBUI_SECRET_KEY", "required": false, "description": "Secret key for Open WebUI authentication" }
+      {
+        "key": "WEBUI_SECRET_KEY",
+        "required": false,
+        "description": "Secret key for Open WebUI authentication"
+      }
     ],
-    "defaultResource": { "vCPU": 2, "memory": 2048, "diskSize": 20 },
-    "tags": ["OpenWebUI", "REST", "TEE"]
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 2048,
+      "diskSize": 20
+    },
+    "tags": [
+      "OpenWebUI",
+      "REST",
+      "TEE"
+    ]
   },
   {
     "id": "primus-attestor-node",
@@ -902,28 +1182,152 @@
     "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/erc-8004-tee-agent",
     "author": "Phala-Network",
     "envs": [
-      { "key": "AGENT_SALT", "required": true, "description": "Unique secret salt for key derivation" },
-      { "key": "REDPILL_API_KEY", "required": true, "description": "API key for confidential AI inference" },
-      { "key": "SUBGRAPH_API_KEY", "required": true, "description": "Access token for blockchain data queries" },
-      { "key": "RPC_URL", "required": true, "description": "Blockchain node endpoint" },
-      { "key": "CHAIN_NAME", "required": true, "description": "Target blockchain (e.g., eth-sepolia)" },
-      { "key": "ERC8004_AGENT_PASSWORD_HASH", "required": true, "description": "Caddy bcrypt password hash for Basic Auth" },
-      { "key": "ERC8004_AGENT_USERNAME", "required": false, "description": "Caddy Basic Auth username", "default": "agent" },
-      { "key": "AGENT_DOMAIN", "required": false, "description": "Public agent domain override; derived at startup when omitted" },
-      { "key": "TRUST_CENTER_URL", "required": false, "description": "Trust Center widget URL override; derived at startup when omitted" },
-      { "key": "ANTHROPIC_MODEL", "required": false, "description": "Chat model selection", "default": "openai/gpt-oss-120b" },
-      { "key": "AI_MODEL", "required": false, "description": "RedPill model used by the code-generation helper", "default": "phala/qwen-2.5-7b-instruct" },
-      { "key": "AI_TEMPERATURE", "required": false, "description": "AI sampling temperature", "default": "0.3" },
-      { "key": "AI_MAX_TOKENS", "required": false, "description": "AI response token limit", "default": "2000" },
-      { "key": "CODE_EXECUTION_TIMEOUT", "required": false, "description": "Code execution timeout in seconds", "default": "30" },
-      { "key": "REDPILL_API_URL", "required": false, "description": "RedPill API base URL", "default": "https://api.redpill.ai" },
-      { "key": "ANTHROPIC_BASE_URL", "required": false, "description": "Anthropic-compatible API base URL", "default": "https://api.redpill.ai" },
-      { "key": "CHAIN_ID", "required": false, "description": "EVM chain ID override", "default": "11155111" },
-      { "key": "IDENTITY_REGISTRY_ADDRESS", "required": false, "description": "ERC-8004 identity registry contract override", "default": "0x8004A818BFB912233c491871b3d84c89A494BD9e" },
-      { "key": "REPUTATION_REGISTRY_ADDRESS", "required": false, "description": "ERC-8004 reputation registry contract override", "default": "0x8004B663056A597Dffe9eCcC1965A193B7388713" },
-      { "key": "SESSION_TIMEOUT_MINUTES", "required": false, "description": "Chat session timeout in minutes", "default": "60" },
-      { "key": "MAX_SESSIONS", "required": false, "description": "Maximum in-memory chat sessions", "default": "100" }
+      {
+        "key": "AGENT_SALT",
+        "required": true,
+        "description": "Unique secret salt for key derivation"
+      },
+      {
+        "key": "REDPILL_API_KEY",
+        "required": true,
+        "description": "API key for confidential AI inference"
+      },
+      {
+        "key": "SUBGRAPH_API_KEY",
+        "required": true,
+        "description": "Access token for blockchain data queries"
+      },
+      {
+        "key": "RPC_URL",
+        "required": true,
+        "description": "Blockchain node endpoint"
+      },
+      {
+        "key": "CHAIN_NAME",
+        "required": true,
+        "description": "Target blockchain (e.g., eth-sepolia)"
+      },
+      {
+        "key": "ERC8004_AGENT_PASSWORD_HASH",
+        "required": true,
+        "description": "Caddy bcrypt password hash for Basic Auth"
+      },
+      {
+        "key": "ERC8004_AGENT_USERNAME",
+        "required": false,
+        "description": "Caddy Basic Auth username",
+        "default": "agent"
+      },
+      {
+        "key": "AGENT_DOMAIN",
+        "required": false,
+        "description": "Public agent domain override; derived at startup when omitted"
+      },
+      {
+        "key": "TRUST_CENTER_URL",
+        "required": false,
+        "description": "Trust Center widget URL override; derived at startup when omitted"
+      },
+      {
+        "key": "ANTHROPIC_MODEL",
+        "required": false,
+        "description": "Chat model selection",
+        "default": "openai/gpt-oss-120b"
+      },
+      {
+        "key": "AI_MODEL",
+        "required": false,
+        "description": "RedPill model used by the code-generation helper",
+        "default": "phala/qwen-2.5-7b-instruct"
+      },
+      {
+        "key": "AI_TEMPERATURE",
+        "required": false,
+        "description": "AI sampling temperature",
+        "default": "0.3"
+      },
+      {
+        "key": "AI_MAX_TOKENS",
+        "required": false,
+        "description": "AI response token limit",
+        "default": "2000"
+      },
+      {
+        "key": "CODE_EXECUTION_TIMEOUT",
+        "required": false,
+        "description": "Code execution timeout in seconds",
+        "default": "30"
+      },
+      {
+        "key": "REDPILL_API_URL",
+        "required": false,
+        "description": "RedPill API base URL",
+        "default": "https://api.redpill.ai"
+      },
+      {
+        "key": "ANTHROPIC_BASE_URL",
+        "required": false,
+        "description": "Anthropic-compatible API base URL",
+        "default": "https://api.redpill.ai"
+      },
+      {
+        "key": "CHAIN_ID",
+        "required": false,
+        "description": "EVM chain ID override",
+        "default": "11155111"
+      },
+      {
+        "key": "IDENTITY_REGISTRY_ADDRESS",
+        "required": false,
+        "description": "ERC-8004 identity registry contract override",
+        "default": "0x8004A818BFB912233c491871b3d84c89A494BD9e"
+      },
+      {
+        "key": "REPUTATION_REGISTRY_ADDRESS",
+        "required": false,
+        "description": "ERC-8004 reputation registry contract override",
+        "default": "0x8004B663056A597Dffe9eCcC1965A193B7388713"
+      },
+      {
+        "key": "SESSION_TIMEOUT_MINUTES",
+        "required": false,
+        "description": "Chat session timeout in minutes",
+        "default": "60"
+      },
+      {
+        "key": "MAX_SESSIONS",
+        "required": false,
+        "description": "Maximum in-memory chat sessions",
+        "default": "100"
+      }
     ],
-    "tags": ["Agent", "TEE", "ERC-8004", "AI"]
+    "tags": [
+      "Agent",
+      "TEE",
+      "ERC-8004",
+      "AI"
+    ]
+  },
+  {
+    "id": "markitdown-mcp",
+    "name": "Markitdown",
+    "description": "Convert various file formats (PDF, Word, Excel, images, audio) to Markdown deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/microsoft/markitdown",
+    "author": "microsoft",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1664,5 +1664,42 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "brightdata-mcp",
+    "name": "Brightdata",
+    "description": "Bright Data's Web MCP server enabling AI agents to search, extract & navigate the web deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/brightdata/brightdata-mcp",
+    "author": "brightdata",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      },
+      {
+        "key": "API_TOKEN",
+        "required": true,
+        "description": "Bright Data API token."
+      },
+      {
+        "key": "WEB_UNLOCKER_ZONE",
+        "required": false,
+        "description": "Optional Bright Data Web Unlocker zone."
+      },
+      {
+        "key": "BROWSER_AUTH",
+        "required": false,
+        "description": "Optional Browser API authentication string."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1760,5 +1760,27 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "microsoftdocs-mcp",
+    "name": "Microsoft Learn",
+    "description": "Enables clients like GitHub Copilot and other AI agents to bring trusted and up-to-date information directly from Microsoft's official documentation deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/microsoftdocs/mcp",
+    "author": "MicrosoftDocs",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1864,5 +1864,27 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "apify-mcp-server",
+    "name": "Apify",
+    "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store ⚡ deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/apify/apify-mcp-server",
+    "author": "apify",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1804,5 +1804,27 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "nuget-mcp",
+    "name": "Microsoft Nuget",
+    "description": "A Model Context Protocol (MCP) server for NuGet deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/NuGet/Home",
+    "author": "NuGet",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1728,5 +1728,37 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "azure-devops-mcp",
+    "name": "Azure DevOps",
+    "description": "Interact with Azure DevOps services like repositories, work items, builds, releases, test plans, and code search deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/microsoft/azure-devops-mcp",
+    "author": "microsoft",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      },
+      {
+        "key": "AZURE_DEVOPS_ORG",
+        "required": true,
+        "description": "Azure DevOps organization name, for example contoso."
+      },
+      {
+        "key": "AZURE_DEVOPS_EXT_PAT",
+        "required": false,
+        "description": "Optional Azure DevOps PAT for non-interactive auth."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1782,5 +1782,27 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "stripe-mcp",
+    "name": "Stripe",
+    "description": "MCP server integrating with Stripe - tools for customers, products, payments, and more deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/stripe/agent-toolkit",
+    "author": "stripe",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1929,5 +1929,27 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "nuxt-mcp",
+    "name": "Nuxt",
+    "description": "MCP server helping models understand your Vite/Nuxt app deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/antfu/nuxt-mcp",
+    "author": "antfu",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -2000,5 +2000,42 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "sentry-mcp",
+    "name": "Getsentry Sentry",
+    "description": "MCP server for Sentry - error monitoring, issue tracking, and debugging for AI assistants deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/getsentry/sentry-mcp",
+    "author": "getsentry",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      },
+      {
+        "key": "SENTRY_ACCESS_TOKEN",
+        "required": true,
+        "description": "Sentry user auth token."
+      },
+      {
+        "key": "SENTRY_HOST",
+        "required": false,
+        "description": "Optional self-hosted Sentry host."
+      },
+      {
+        "key": "SENTRY_DISABLE_SKILLS",
+        "required": false,
+        "description": "Optional comma-separated Sentry skills/tools to disable."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1600,5 +1600,42 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "microsoft-fabric-mcp",
+    "name": "Microsoft Fabric MCP Server",
+    "description": "MCP tools for interacting with Microsoft Fabric deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/microsoft/mcp",
+    "author": "microsoft",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      },
+      {
+        "key": "AZURE_TENANT_ID",
+        "required": false,
+        "description": "Tenant ID used by Microsoft identity libraries."
+      },
+      {
+        "key": "AZURE_CLIENT_ID",
+        "required": false,
+        "description": "Client ID for app/service-principal auth."
+      },
+      {
+        "key": "AZURE_CLIENT_SECRET",
+        "required": false,
+        "description": "Client secret for app/service-principal auth."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1978,5 +1978,27 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "atlassian-mcp-server",
+    "name": "Atlassian",
+    "description": "Atlassian Rovo MCP Server deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/atlassian/atlassian-mcp-server",
+    "author": "atlassian",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1422,5 +1422,32 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "serena-mcp",
+    "name": "Serena",
+    "description": "Semantic code retrieval & editing tools for coding agents deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/oraios/serena",
+    "author": "oraios",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      },
+      {
+        "key": "SERENA_PROJECT",
+        "required": false,
+        "description": "Optional project path to activate after the server starts, typically under /workspace."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1351,5 +1351,27 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "chrome-devtools-mcp",
+    "name": "Chrome DevTools MCP",
+    "description": "MCP server for Chrome DevTools deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/ChromeDevTools/chrome-devtools-mcp",
+    "author": "ChromeDevTools",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1701,5 +1701,32 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "tavily-mcp",
+    "name": "Tavily",
+    "description": "MCP server for advanced web search using Tavily deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/tavily-ai/tavily-mcp",
+    "author": "tavily-ai",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      },
+      {
+        "key": "TAVILY_API_KEY",
+        "required": true,
+        "description": "Tavily API key."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1886,5 +1886,48 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "mongodb-mcp-server",
+    "name": "Mongodb",
+    "description": "MongoDB Model Context Protocol Server deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/mongodb-js/mongodb-mcp-server",
+    "author": "mongodb-js",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      },
+      {
+        "key": "MDB_MCP_CONNECTION_STRING",
+        "required": true,
+        "description": "MongoDB connection string, or configure Atlas API credentials instead."
+      },
+      {
+        "key": "MDB_MCP_API_CLIENT_ID",
+        "required": false,
+        "description": "Optional MongoDB Atlas API client ID."
+      },
+      {
+        "key": "MDB_MCP_API_CLIENT_SECRET",
+        "required": false,
+        "description": "Optional MongoDB Atlas API client secret."
+      },
+      {
+        "key": "MDB_MCP_READ_ONLY",
+        "required": false,
+        "description": "Set to true to prefer read-only operation where supported.",
+        "default": "false"
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1826,5 +1826,43 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "terraform-mcp-server",
+    "name": "Terraform",
+    "description": "Generate more accurate Terraform and automate workflows for HCP Terraform and Terraform Enterprise deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/hashicorp/terraform-mcp-server",
+    "author": "hashicorp",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      },
+      {
+        "key": "TFE_ADDRESS",
+        "required": false,
+        "description": "Optional HCP Terraform or Terraform Enterprise address.",
+        "default": "https://app.terraform.io"
+      },
+      {
+        "key": "TFE_TOKEN",
+        "required": false,
+        "description": "Optional HCP Terraform or Terraform Enterprise token."
+      },
+      {
+        "key": "MCP_TOOLSETS",
+        "required": false,
+        "description": "Optional comma-separated Terraform MCP toolsets."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1481,5 +1481,37 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "firecrawl-mcp-server",
+    "name": "Firecrawl",
+    "description": "Extract web data with Firecrawl deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/firecrawl/firecrawl-mcp-server",
+    "author": "firecrawl",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      },
+      {
+        "key": "FIRECRAWL_API_KEY",
+        "required": true,
+        "description": "Firecrawl API key."
+      },
+      {
+        "key": "FIRECRAWL_API_URL",
+        "required": false,
+        "description": "Optional self-hosted Firecrawl API URL."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/config.json
+++ b/templates/config.json
@@ -1329,5 +1329,27 @@
     "tags": [
       "MCP"
     ]
+  },
+  {
+    "id": "netdata-mcp-server",
+    "name": "Netdata",
+    "description": "Real-time infrastructure monitoring with metrics, logs, alerts, and ML-based anomaly detection deployed on Phala Cloud with a protected MCP endpoint.",
+    "repo": "https://github.com/netdata/netdata",
+    "author": "netdata",
+    "envs": [
+      {
+        "key": "BEARER_TOKEN",
+        "required": true,
+        "description": "Local gateway token required in the X-Phala-MCP-Token request header."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 2,
+      "memory": 4096,
+      "diskSize": 20
+    },
+    "tags": [
+      "MCP"
+    ]
   }
 ]

--- a/templates/prebuilt/apify-mcp-server/README.md
+++ b/templates/prebuilt/apify-mcp-server/README.md
@@ -1,0 +1,66 @@
+# Apify
+
+Deploy a protected Apify template from the GitHub MCP Registry on Phala Cloud.
+
+Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store ⚡. Proxies Apify’s hosted MCP endpoint. Send upstream Authorization: Bearer <APIFY_TOKEN> from the MCP client when needed.
+
+This template proxies the upstream streamable-http endpoint `https://mcp.apify.com/`. Keep upstream OAuth/API authorization in the MCP client request headers and use `X-Phala-MCP-Token` only for the Phala gateway gate.
+
+## Services
+
+- `proxy`: Caddy reverse proxy on public port `18080` that gates access and forwards traffic to the upstream hosted MCP endpoint.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "apify-mcp-server": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/com.apify/apify-mcp-server`
+- Upstream repository: `https://github.com/apify/apify-mcp-server`

--- a/templates/prebuilt/apify-mcp-server/docker-compose.yml
+++ b/templates/prebuilt/apify-mcp-server/docker-compose.yml
@@ -18,8 +18,8 @@ configs:
               header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
           }
           route @valid_auth {
-              reverse_proxy https://mcp.apify.com/ {
-                  header_up Host {upstream_hostport}
+              reverse_proxy https://mcp.apify.com {
+                  header_up Host mcp.apify.com
               }
           }
           route {

--- a/templates/prebuilt/apify-mcp-server/docker-compose.yml
+++ b/templates/prebuilt/apify-mcp-server/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy https://mcp.apify.com/ {
+                  header_up Host {upstream_hostport}
+              }
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }

--- a/templates/prebuilt/atlassian-mcp-server/README.md
+++ b/templates/prebuilt/atlassian-mcp-server/README.md
@@ -1,0 +1,66 @@
+# Atlassian
+
+Deploy a protected Atlassian template from the GitHub MCP Registry on Phala Cloud.
+
+Atlassian Rovo MCP Server. Proxies Atlassian’s hosted Streamable HTTP MCP endpoint. Complete upstream Atlassian auth from the MCP client.
+
+This template proxies the upstream streamable-http endpoint `https://mcp.atlassian.com/v1/mcp`. Keep upstream OAuth/API authorization in the MCP client request headers and use `X-Phala-MCP-Token` only for the Phala gateway gate.
+
+## Services
+
+- `proxy`: Caddy reverse proxy on public port `18080` that gates access and forwards traffic to the upstream hosted MCP endpoint.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "atlassian-mcp-server": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/com.atlassian/atlassian-mcp-server`
+- Upstream repository: `https://github.com/atlassian/atlassian-mcp-server`

--- a/templates/prebuilt/atlassian-mcp-server/docker-compose.yml
+++ b/templates/prebuilt/atlassian-mcp-server/docker-compose.yml
@@ -18,8 +18,9 @@ configs:
               header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
           }
           route @valid_auth {
-              reverse_proxy https://mcp.atlassian.com/v1/mcp {
-                  header_up Host {upstream_hostport}
+              rewrite * /v1/mcp
+              reverse_proxy https://mcp.atlassian.com {
+                  header_up Host mcp.atlassian.com
               }
           }
           route {

--- a/templates/prebuilt/atlassian-mcp-server/docker-compose.yml
+++ b/templates/prebuilt/atlassian-mcp-server/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy https://mcp.atlassian.com/v1/mcp {
+                  header_up Host {upstream_hostport}
+              }
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }

--- a/templates/prebuilt/azure-devops-mcp/README.md
+++ b/templates/prebuilt/azure-devops-mcp/README.md
@@ -1,0 +1,67 @@
+# Azure DevOps
+
+Deploy a protected Azure DevOps template from the GitHub MCP Registry on Phala Cloud.
+
+Interact with Azure DevOps services like repositories, work items, builds, releases, test plans, and code search. Runs Azure DevOps MCP for repositories, work items, builds, releases, test plans, and code search.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+- `AZURE_DEVOPS_ORG` (required): Azure DevOps organization name, for example contoso.
+- `AZURE_DEVOPS_EXT_PAT` (optional): Optional Azure DevOps PAT for non-interactive auth.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "azure-devops-mcp": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/microsoft/azure-devops-mcp`
+- Upstream repository: `https://github.com/microsoft/azure-devops-mcp`

--- a/templates/prebuilt/azure-devops-mcp/docker-compose.yml
+++ b/templates/prebuilt/azure-devops-mcp/docker-compose.yml
@@ -1,0 +1,55 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM node:22-bookworm-slim
+        RUN npm install -g supergateway@3.4.3
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec supergateway --stdio \"npx -y @azure-devops/mcp $AZURE_DEVOPS_ORG\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+    image: azure-devops-mcp:latest
+    pull_policy: build
+    environment:
+      - AZURE_DEVOPS_ORG=${AZURE_DEVOPS_ORG:-}
+      - AZURE_DEVOPS_EXT_PAT=${AZURE_DEVOPS_EXT_PAT:-}
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/templates/prebuilt/azure-devops-mcp/docker-compose.yml
+++ b/templates/prebuilt/azure-devops-mcp/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         RUN npm install -g supergateway@3.4.3
         WORKDIR /workspace
         EXPOSE 8000
-        CMD ["sh", "-lc", "exec supergateway --stdio \"npx -y @azure-devops/mcp $AZURE_DEVOPS_ORG\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+        CMD ["sh", "-lc", "exec supergateway --stdio \"npx -y @azure-devops/mcp $$AZURE_DEVOPS_ORG\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
     image: azure-devops-mcp:latest
     pull_policy: build
     environment:

--- a/templates/prebuilt/azure-mcp/README.md
+++ b/templates/prebuilt/azure-mcp/README.md
@@ -1,0 +1,69 @@
+# Azure MCP Server
+
+Deploy a protected Azure MCP Server template from the GitHub MCP Registry on Phala Cloud.
+
+All Azure MCP tools to create a seamless connection between AI agents and Azure services. Runs Microsoft Azure MCP with the npm package and supports Azure Identity environment variables.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+- `AZURE_TENANT_ID` (optional): Azure tenant ID for service-principal authentication.
+- `AZURE_CLIENT_ID` (optional): Azure client ID for service-principal authentication.
+- `AZURE_CLIENT_SECRET` (optional): Azure client secret for service-principal authentication.
+- `AZURE_MCP_COLLECT_TELEMETRY` (optional): Set to false to disable Azure MCP telemetry.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "azure-mcp": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/com.microsoft/azure`
+- Upstream repository: `https://github.com/microsoft/mcp`

--- a/templates/prebuilt/azure-mcp/docker-compose.yml
+++ b/templates/prebuilt/azure-mcp/docker-compose.yml
@@ -1,0 +1,57 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM node:22-bookworm-slim
+        RUN npm install -g supergateway@3.4.3
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec supergateway --stdio \"npx -y @azure/mcp@3.0.0-beta.6 server start\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+    image: azure-mcp:latest
+    pull_policy: build
+    environment:
+      - AZURE_TENANT_ID=${AZURE_TENANT_ID:-}
+      - AZURE_CLIENT_ID=${AZURE_CLIENT_ID:-}
+      - AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET:-}
+      - AZURE_MCP_COLLECT_TELEMETRY=${AZURE_MCP_COLLECT_TELEMETRY:-}
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/templates/prebuilt/brightdata-mcp/README.md
+++ b/templates/prebuilt/brightdata-mcp/README.md
@@ -1,0 +1,68 @@
+# Brightdata
+
+Deploy a protected Brightdata template from the GitHub MCP Registry on Phala Cloud.
+
+Bright Data's Web MCP server enabling AI agents to search, extract & navigate the web. Provides Bright Data web search, extraction, and browser tools.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+- `API_TOKEN` (required): Bright Data API token.
+- `WEB_UNLOCKER_ZONE` (optional): Optional Bright Data Web Unlocker zone.
+- `BROWSER_AUTH` (optional): Optional Browser API authentication string.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "brightdata-mcp": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/brightdata/brightdata-mcp`
+- Upstream repository: `https://github.com/brightdata/brightdata-mcp`

--- a/templates/prebuilt/brightdata-mcp/docker-compose.yml
+++ b/templates/prebuilt/brightdata-mcp/docker-compose.yml
@@ -1,0 +1,56 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM node:22-bookworm-slim
+        RUN npm install -g supergateway@3.4.3
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec supergateway --stdio \"npx -y @brightdata/mcp@2.9.5\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+    image: brightdata-mcp:latest
+    pull_policy: build
+    environment:
+      - API_TOKEN=${API_TOKEN:-}
+      - WEB_UNLOCKER_ZONE=${WEB_UNLOCKER_ZONE:-}
+      - BROWSER_AUTH=${BROWSER_AUTH:-}
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/templates/prebuilt/chrome-devtools-mcp/README.md
+++ b/templates/prebuilt/chrome-devtools-mcp/README.md
@@ -1,0 +1,65 @@
+# Chrome DevTools MCP
+
+Deploy a protected Chrome DevTools MCP template from the GitHub MCP Registry on Phala Cloud.
+
+MCP server for Chrome DevTools. Runs Chrome DevTools MCP with a browser-capable Playwright base image.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools-mcp": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/ChromeDevTools/chrome-devtools-mcp`
+- Upstream repository: `https://github.com/ChromeDevTools/chrome-devtools-mcp`

--- a/templates/prebuilt/chrome-devtools-mcp/docker-compose.yml
+++ b/templates/prebuilt/chrome-devtools-mcp/docker-compose.yml
@@ -1,0 +1,54 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM mcr.microsoft.com/playwright:v1.57.0-noble
+        USER root
+        RUN npm install -g supergateway@3.4.3
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec supergateway --stdio \"npx -y chrome-devtools-mcp@1.0.1 --no-usage-statistics --headless\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+    image: chrome-devtools-mcp:latest
+    pull_policy: build
+    environment: []
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/templates/prebuilt/dbhub/README.md
+++ b/templates/prebuilt/dbhub/README.md
@@ -1,0 +1,66 @@
+# DBHub
+
+Deploy a protected DBHub template from the GitHub MCP Registry on Phala Cloud.
+
+Minimal, token-efficient Database MCP Server for PostgreSQL, MySQL, SQL Server, SQLite, MariaDB. Runs DBHub in native HTTP mode for PostgreSQL, MySQL, SQL Server, SQLite, or MariaDB.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+- `DBHUB_DSN` (required): Database DSN, for example postgres://user:pass@host:5432/dbname?sslmode=require.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "dbhub": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/bytebase/dbhub`
+- Upstream repository: `https://github.com/bytebase/dbhub`

--- a/templates/prebuilt/dbhub/docker-compose.yml
+++ b/templates/prebuilt/dbhub/docker-compose.yml
@@ -1,0 +1,53 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM node:22-bookworm-slim
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec npx -y @bytebase/dbhub@0.21.1 --transport http --port 8000 --dsn \"$DBHUB_DSN\""]
+    image: dbhub:latest
+    pull_policy: build
+    environment:
+      - DBHUB_DSN=${DBHUB_DSN:-}
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/templates/prebuilt/dbhub/docker-compose.yml
+++ b/templates/prebuilt/dbhub/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         FROM node:22-bookworm-slim
         WORKDIR /workspace
         EXPOSE 8000
-        CMD ["sh", "-lc", "exec npx -y @bytebase/dbhub@0.21.1 --transport http --port 8000 --dsn \"$DBHUB_DSN\""]
+        CMD ["sh", "-lc", "exec npx -y @bytebase/dbhub@0.21.1 --transport http --port 8000 --dsn \"$$DBHUB_DSN\""]
     image: dbhub:latest
     pull_policy: build
     environment:

--- a/templates/prebuilt/desktop-commander-mcp/README.md
+++ b/templates/prebuilt/desktop-commander-mcp/README.md
@@ -1,0 +1,65 @@
+# Desktop Commander
+
+Deploy a protected Desktop Commander template from the GitHub MCP Registry on Phala Cloud.
+
+MCP server for terminal commands, file operations, and process management. Runs Desktop Commander inside the CVM sandbox. File and shell tools operate on the container filesystem and /workspace volume.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "desktop-commander-mcp": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/wonderwhy-er/desktop-commander`
+- Upstream repository: `https://github.com/wonderwhy-er/DesktopCommanderMCP`

--- a/templates/prebuilt/desktop-commander-mcp/docker-compose.yml
+++ b/templates/prebuilt/desktop-commander-mcp/docker-compose.yml
@@ -1,0 +1,58 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM node:22-bookworm-slim
+        RUN npm install -g supergateway@3.4.3
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec supergateway --stdio \"npx -y @wonderwhy-er/desktop-commander@0.2.41\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+    image: desktop-commander-mcp:latest
+    pull_policy: build
+    environment: []
+    volumes:
+      - desktop_commander_workspace:/workspace
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge
+
+volumes:
+  desktop_commander_workspace:

--- a/templates/prebuilt/elasticsearch-mcp/README.md
+++ b/templates/prebuilt/elasticsearch-mcp/README.md
@@ -1,0 +1,70 @@
+# Elasticsearch
+
+Deploy a protected Elasticsearch template from the GitHub MCP Registry on Phala Cloud.
+
+MCP server for connecting to Elasticsearch data and indices. Supports search queries, mappings, ES|QL, and shard information through natural language interactions. Runs Elastic MCP in native streamable HTTP mode.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+- `ES_URL` (required): Elasticsearch cluster URL.
+- `ES_API_KEY` (optional): Elasticsearch API key.
+- `ES_USERNAME` (optional): Elasticsearch username for basic auth.
+- `ES_PASSWORD` (optional): Elasticsearch password for basic auth.
+- `ES_SSL_SKIP_VERIFY` (optional): Set to true to skip Elasticsearch TLS verification.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "elasticsearch-mcp": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/elastic/mcp-server-elasticsearch`
+- Upstream repository: `https://github.com/elastic/mcp-server-elasticsearch`

--- a/templates/prebuilt/elasticsearch-mcp/docker-compose.yml
+++ b/templates/prebuilt/elasticsearch-mcp/docker-compose.yml
@@ -1,0 +1,50 @@
+services:
+  app:
+    image: docker.elastic.co/mcp/elasticsearch:latest
+    command: ["http"]
+    environment:
+      - ES_URL=${ES_URL:-}
+      - ES_API_KEY=${ES_API_KEY:-}
+      - ES_USERNAME=${ES_USERNAME:-}
+      - ES_PASSWORD=${ES_PASSWORD:-}
+      - ES_SSL_SKIP_VERIFY=${ES_SSL_SKIP_VERIFY:-}
+    expose:
+      - "8080"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8080
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/templates/prebuilt/firecrawl-mcp-server/README.md
+++ b/templates/prebuilt/firecrawl-mcp-server/README.md
@@ -1,0 +1,67 @@
+# Firecrawl
+
+Deploy a protected Firecrawl template from the GitHub MCP Registry on Phala Cloud.
+
+Extract web data with Firecrawl. Provides Firecrawl search, scrape, crawl, and extraction tools.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+- `FIRECRAWL_API_KEY` (required): Firecrawl API key.
+- `FIRECRAWL_API_URL` (optional): Optional self-hosted Firecrawl API URL.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "firecrawl-mcp-server": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/firecrawl/firecrawl-mcp-server`
+- Upstream repository: `https://github.com/firecrawl/firecrawl-mcp-server`

--- a/templates/prebuilt/firecrawl-mcp-server/docker-compose.yml
+++ b/templates/prebuilt/firecrawl-mcp-server/docker-compose.yml
@@ -1,0 +1,55 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM node:22-bookworm-slim
+        RUN npm install -g supergateway@3.4.3
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec supergateway --stdio \"npx -y firecrawl-mcp\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+    image: firecrawl-mcp-server:latest
+    pull_policy: build
+    environment:
+      - FIRECRAWL_API_KEY=${FIRECRAWL_API_KEY:-}
+      - FIRECRAWL_API_URL=${FIRECRAWL_API_URL:-}
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/templates/prebuilt/github-mcp-server/README.md
+++ b/templates/prebuilt/github-mcp-server/README.md
@@ -1,0 +1,66 @@
+# GitHub
+
+Deploy a protected GitHub template from the GitHub MCP Registry on Phala Cloud.
+
+Connect AI assistants to GitHub - manage repos, issues, PRs, and workflows through natural language. Builds the official GitHub MCP server binary and exposes it through a protected Streamable HTTP endpoint.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+- `GITHUB_PERSONAL_ACCESS_TOKEN` (required): GitHub fine-grained or classic PAT used by the MCP server.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "github-mcp-server": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/github/github-mcp-server`
+- Upstream repository: `https://github.com/github/github-mcp-server`

--- a/templates/prebuilt/github-mcp-server/docker-compose.yml
+++ b/templates/prebuilt/github-mcp-server/docker-compose.yml
@@ -1,0 +1,57 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM golang:1.25-bookworm AS builder
+        RUN go install github.com/github/github-mcp-server/cmd/github-mcp-server@v1.0.4
+        FROM node:22-bookworm-slim
+        RUN npm install -g supergateway@3.4.3 && npm cache clean --force
+        COPY --from=builder /go/bin/github-mcp-server /usr/local/bin/github-mcp-server
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec supergateway --stdio \"github-mcp-server stdio\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+    image: github-mcp-server:latest
+    pull_policy: build
+    environment:
+      - GITHUB_PERSONAL_ACCESS_TOKEN=${GITHUB_PERSONAL_ACCESS_TOKEN:-}
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/templates/prebuilt/markitdown-mcp/README.md
+++ b/templates/prebuilt/markitdown-mcp/README.md
@@ -1,0 +1,65 @@
+# Markitdown
+
+Deploy a protected Markitdown template from the GitHub MCP Registry on Phala Cloud.
+
+Convert various file formats (PDF, Word, Excel, images, audio) to Markdown. Converts PDFs, Office documents, images, audio, and other files to Markdown inside the CVM.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "markitdown-mcp": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/microsoft/markitdown`
+- Upstream repository: `https://github.com/microsoft/markitdown`

--- a/templates/prebuilt/markitdown-mcp/docker-compose.yml
+++ b/templates/prebuilt/markitdown-mcp/docker-compose.yml
@@ -1,0 +1,56 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM node:22-bookworm-slim
+        RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-venv ca-certificates curl git && rm -rf /var/lib/apt/lists/*
+        RUN npm install -g supergateway@3.4.3 && npm cache clean --force
+        RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+        ENV PATH="/root/.local/bin:${PATH}"
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec supergateway --stdio \"uvx markitdown-mcp\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+    image: markitdown-mcp:latest
+    pull_policy: build
+    environment: []
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/templates/prebuilt/markitdown-mcp/docker-compose.yml
+++ b/templates/prebuilt/markitdown-mcp/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-venv ca-certificates curl git && rm -rf /var/lib/apt/lists/*
         RUN npm install -g supergateway@3.4.3 && npm cache clean --force
         RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-        ENV PATH="/root/.local/bin:${PATH}"
+        ENV PATH="/root/.local/bin:$${PATH}"
         WORKDIR /workspace
         EXPOSE 8000
         CMD ["sh", "-lc", "exec supergateway --stdio \"uvx markitdown-mcp\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]

--- a/templates/prebuilt/microsoft-fabric-mcp/README.md
+++ b/templates/prebuilt/microsoft-fabric-mcp/README.md
@@ -1,0 +1,68 @@
+# Microsoft Fabric MCP Server
+
+Deploy a protected Microsoft Fabric MCP Server template from the GitHub MCP Registry on Phala Cloud.
+
+MCP tools for interacting with Microsoft Fabric. Runs Microsoft Fabric MCP and uses Microsoft identity environment variables when configured.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+- `AZURE_TENANT_ID` (optional): Tenant ID used by Microsoft identity libraries.
+- `AZURE_CLIENT_ID` (optional): Client ID for app/service-principal auth.
+- `AZURE_CLIENT_SECRET` (optional): Client secret for app/service-principal auth.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "microsoft-fabric-mcp": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/com.microsoft/microsoft-fabric`
+- Upstream repository: `https://github.com/microsoft/mcp`

--- a/templates/prebuilt/microsoft-fabric-mcp/docker-compose.yml
+++ b/templates/prebuilt/microsoft-fabric-mcp/docker-compose.yml
@@ -1,0 +1,56 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM node:22-bookworm-slim
+        RUN npm install -g supergateway@3.4.3
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec supergateway --stdio \"npx -y @microsoft/fabric-mcp@1.0.0 server start\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+    image: microsoft-fabric-mcp:latest
+    pull_policy: build
+    environment:
+      - AZURE_TENANT_ID=${AZURE_TENANT_ID:-}
+      - AZURE_CLIENT_ID=${AZURE_CLIENT_ID:-}
+      - AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET:-}
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/templates/prebuilt/microsoftdocs-mcp/README.md
+++ b/templates/prebuilt/microsoftdocs-mcp/README.md
@@ -1,0 +1,66 @@
+# Microsoft Learn
+
+Deploy a protected Microsoft Learn template from the GitHub MCP Registry on Phala Cloud.
+
+Enables clients like GitHub Copilot and other AI agents to bring trusted and up-to-date information directly from Microsoft's official documentation. Proxies the hosted Microsoft Learn MCP endpoint for trusted Microsoft documentation search.
+
+This template proxies the upstream sse endpoint `https://learn.microsoft.com/api/mcp`. Keep upstream OAuth/API authorization in the MCP client request headers and use `X-Phala-MCP-Token` only for the Phala gateway gate.
+
+## Services
+
+- `proxy`: Caddy reverse proxy on public port `18080` that gates access and forwards traffic to the upstream hosted MCP endpoint.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "microsoftdocs-mcp": {
+      "type": "sse",
+      "url": "https://<your-app-domain>/sse",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/sse
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/sse
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/microsoftdocs/mcp`
+- Upstream repository: `https://github.com/microsoftdocs/mcp`

--- a/templates/prebuilt/microsoftdocs-mcp/docker-compose.yml
+++ b/templates/prebuilt/microsoftdocs-mcp/docker-compose.yml
@@ -18,8 +18,9 @@ configs:
               header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
           }
           route @valid_auth {
-              reverse_proxy https://learn.microsoft.com/api/mcp {
-                  header_up Host {upstream_hostport}
+              rewrite * /api/mcp
+              reverse_proxy https://learn.microsoft.com {
+                  header_up Host learn.microsoft.com
               }
           }
           route {

--- a/templates/prebuilt/microsoftdocs-mcp/docker-compose.yml
+++ b/templates/prebuilt/microsoftdocs-mcp/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy https://learn.microsoft.com/api/mcp {
+                  header_up Host {upstream_hostport}
+              }
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }

--- a/templates/prebuilt/mongodb-mcp-server/README.md
+++ b/templates/prebuilt/mongodb-mcp-server/README.md
@@ -1,0 +1,69 @@
+# Mongodb
+
+Deploy a protected Mongodb template from the GitHub MCP Registry on Phala Cloud.
+
+MongoDB Model Context Protocol Server. Runs MongoDB MCP for database and Atlas workflows.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+- `MDB_MCP_CONNECTION_STRING` (required): MongoDB connection string, or configure Atlas API credentials instead.
+- `MDB_MCP_API_CLIENT_ID` (optional): Optional MongoDB Atlas API client ID.
+- `MDB_MCP_API_CLIENT_SECRET` (optional): Optional MongoDB Atlas API client secret.
+- `MDB_MCP_READ_ONLY` (optional): Set to true to prefer read-only operation where supported.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "mongodb-mcp-server": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/mongodb-js/mongodb-mcp-server`
+- Upstream repository: `https://github.com/mongodb-js/mongodb-mcp-server`

--- a/templates/prebuilt/mongodb-mcp-server/docker-compose.yml
+++ b/templates/prebuilt/mongodb-mcp-server/docker-compose.yml
@@ -1,0 +1,57 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM node:22-bookworm-slim
+        RUN npm install -g supergateway@3.4.3
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec supergateway --stdio \"npx -y mongodb-mcp-server@1.10.0\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+    image: mongodb-mcp-server:latest
+    pull_policy: build
+    environment:
+      - MDB_MCP_CONNECTION_STRING=${MDB_MCP_CONNECTION_STRING:-}
+      - MDB_MCP_API_CLIENT_ID=${MDB_MCP_API_CLIENT_ID:-}
+      - MDB_MCP_API_CLIENT_SECRET=${MDB_MCP_API_CLIENT_SECRET:-}
+      - MDB_MCP_READ_ONLY=${MDB_MCP_READ_ONLY:-}
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/templates/prebuilt/netdata-mcp-server/README.md
+++ b/templates/prebuilt/netdata-mcp-server/README.md
@@ -1,0 +1,66 @@
+# Netdata
+
+Deploy a protected Netdata template from the GitHub MCP Registry on Phala Cloud.
+
+Real-time infrastructure monitoring with metrics, logs, alerts, and ML-based anomaly detection. Proxies the hosted Netdata MCP endpoint; pass any upstream Authorization header required by Netdata from the MCP client.
+
+This template proxies the upstream streamable-http endpoint `https://app.netdata.cloud/api/v1/mcp`. Keep upstream OAuth/API authorization in the MCP client request headers and use `X-Phala-MCP-Token` only for the Phala gateway gate.
+
+## Services
+
+- `proxy`: Caddy reverse proxy on public port `18080` that gates access and forwards traffic to the upstream hosted MCP endpoint.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "netdata-mcp-server": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/netdata/mcp-server`
+- Upstream repository: `https://github.com/netdata/netdata`

--- a/templates/prebuilt/netdata-mcp-server/docker-compose.yml
+++ b/templates/prebuilt/netdata-mcp-server/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy https://app.netdata.cloud/api/v1/mcp {
+                  header_up Host {upstream_hostport}
+              }
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }

--- a/templates/prebuilt/netdata-mcp-server/docker-compose.yml
+++ b/templates/prebuilt/netdata-mcp-server/docker-compose.yml
@@ -18,8 +18,9 @@ configs:
               header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
           }
           route @valid_auth {
-              reverse_proxy https://app.netdata.cloud/api/v1/mcp {
-                  header_up Host {upstream_hostport}
+              rewrite * /api/v1/mcp
+              reverse_proxy https://app.netdata.cloud {
+                  header_up Host app.netdata.cloud
               }
           }
           route {

--- a/templates/prebuilt/next-devtools-mcp/README.md
+++ b/templates/prebuilt/next-devtools-mcp/README.md
@@ -1,0 +1,66 @@
+# Vercel Next Dev Tools
+
+Deploy a protected Vercel Next Dev Tools template from the GitHub MCP Registry on Phala Cloud.
+
+Next.js development tools MCP server with stdio transport. Runs Next DevTools MCP. Deploy it alongside or network it to the Next.js app you want to inspect.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+- `NEXT_DEV_SERVER_URL` (optional): Optional URL for the Next.js dev server this MCP should inspect.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "next-devtools-mcp": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/vercel/next-devtools-mcp`
+- Upstream repository: `https://github.com/vercel/next-devtools-mcp`

--- a/templates/prebuilt/next-devtools-mcp/docker-compose.yml
+++ b/templates/prebuilt/next-devtools-mcp/docker-compose.yml
@@ -1,0 +1,54 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM node:22-bookworm-slim
+        RUN npm install -g supergateway@3.4.3
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec supergateway --stdio \"npx -y next-devtools-mcp@0.3.6\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+    image: next-devtools-mcp:latest
+    pull_policy: build
+    environment:
+      - NEXT_DEV_SERVER_URL=${NEXT_DEV_SERVER_URL:-}
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/templates/prebuilt/notion-mcp-server/README.md
+++ b/templates/prebuilt/notion-mcp-server/README.md
@@ -1,0 +1,66 @@
+# Notion
+
+Deploy a protected Notion template from the GitHub MCP Registry on Phala Cloud.
+
+Official MCP server for Notion API. Proxies Notion’s hosted SSE MCP endpoint. Complete Notion OAuth or send upstream authorization from the MCP client as required.
+
+This template proxies the upstream sse endpoint `https://mcp.notion.com/sse`. Keep upstream OAuth/API authorization in the MCP client request headers and use `X-Phala-MCP-Token` only for the Phala gateway gate.
+
+## Services
+
+- `proxy`: Caddy reverse proxy on public port `18080` that gates access and forwards traffic to the upstream hosted MCP endpoint.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "notion-mcp-server": {
+      "type": "sse",
+      "url": "https://<your-app-domain>/sse",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/sse
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/sse
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/makenotion/notion-mcp-server`
+- Upstream repository: `https://github.com/makenotion/notion-mcp-server`

--- a/templates/prebuilt/notion-mcp-server/docker-compose.yml
+++ b/templates/prebuilt/notion-mcp-server/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy https://mcp.notion.com/sse {
+                  header_up Host {upstream_hostport}
+              }
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }

--- a/templates/prebuilt/notion-mcp-server/docker-compose.yml
+++ b/templates/prebuilt/notion-mcp-server/docker-compose.yml
@@ -18,8 +18,9 @@ configs:
               header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
           }
           route @valid_auth {
-              reverse_proxy https://mcp.notion.com/sse {
-                  header_up Host {upstream_hostport}
+              rewrite * /sse
+              reverse_proxy https://mcp.notion.com {
+                  header_up Host mcp.notion.com
               }
           }
           route {

--- a/templates/prebuilt/nuget-mcp/README.md
+++ b/templates/prebuilt/nuget-mcp/README.md
@@ -1,0 +1,65 @@
+# Microsoft Nuget
+
+Deploy a protected Microsoft Nuget template from the GitHub MCP Registry on Phala Cloud.
+
+A Model Context Protocol (MCP) server for NuGet. Runs the official NuGet MCP .NET tool for package search and package metadata workflows.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "nuget-mcp": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/com.microsoft/nuget`
+- Upstream repository: `https://github.com/NuGet/Home`

--- a/templates/prebuilt/nuget-mcp/docker-compose.yml
+++ b/templates/prebuilt/nuget-mcp/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && apt-get update && apt-get install -y --no-install-recommends nodejs && rm -rf /var/lib/apt/lists/*
         RUN npm install -g supergateway@3.4.3 && npm cache clean --force
         RUN dotnet tool install --global NuGet.Mcp.Server --version 1.4.3
-        ENV PATH="/root/.dotnet/tools:${PATH}"
+        ENV PATH="/root/.dotnet/tools:$${PATH}"
         WORKDIR /workspace
         EXPOSE 8000
         CMD ["sh", "-lc", "exec supergateway --stdio \"nuget-mcp-server\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]

--- a/templates/prebuilt/nuget-mcp/docker-compose.yml
+++ b/templates/prebuilt/nuget-mcp/docker-compose.yml
@@ -1,0 +1,56 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM mcr.microsoft.com/dotnet/sdk:10.0-preview-bookworm-slim
+        RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && rm -rf /var/lib/apt/lists/*
+        RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && apt-get update && apt-get install -y --no-install-recommends nodejs && rm -rf /var/lib/apt/lists/*
+        RUN npm install -g supergateway@3.4.3 && npm cache clean --force
+        RUN dotnet tool install --global NuGet.Mcp.Server --version 1.4.3
+        ENV PATH="/root/.dotnet/tools:${PATH}"
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec supergateway --stdio \"nuget-mcp-server\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+    image: nuget-mcp:latest
+    pull_policy: build
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/templates/prebuilt/nuxt-mcp/README.md
+++ b/templates/prebuilt/nuxt-mcp/README.md
@@ -1,0 +1,66 @@
+# Nuxt
+
+Deploy a protected Nuxt template from the GitHub MCP Registry on Phala Cloud.
+
+MCP server helping models understand your Vite/Nuxt app. Proxies Nuxt’s hosted documentation MCP endpoint.
+
+This template proxies the upstream sse endpoint `https://mcp.nuxt.com/sse`. Keep upstream OAuth/API authorization in the MCP client request headers and use `X-Phala-MCP-Token` only for the Phala gateway gate.
+
+## Services
+
+- `proxy`: Caddy reverse proxy on public port `18080` that gates access and forwards traffic to the upstream hosted MCP endpoint.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "nuxt-mcp": {
+      "type": "sse",
+      "url": "https://<your-app-domain>/sse",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/sse
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/sse
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/antfu/nuxt-mcp`
+- Upstream repository: `https://github.com/antfu/nuxt-mcp`

--- a/templates/prebuilt/nuxt-mcp/docker-compose.yml
+++ b/templates/prebuilt/nuxt-mcp/docker-compose.yml
@@ -18,8 +18,9 @@ configs:
               header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
           }
           route @valid_auth {
-              reverse_proxy https://mcp.nuxt.com/sse {
-                  header_up Host {upstream_hostport}
+              rewrite * /sse
+              reverse_proxy https://mcp.nuxt.com {
+                  header_up Host mcp.nuxt.com
               }
           }
           route {

--- a/templates/prebuilt/nuxt-mcp/docker-compose.yml
+++ b/templates/prebuilt/nuxt-mcp/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy https://mcp.nuxt.com/sse {
+                  header_up Host {upstream_hostport}
+              }
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }

--- a/templates/prebuilt/playwright-mcp/README.md
+++ b/templates/prebuilt/playwright-mcp/README.md
@@ -1,0 +1,65 @@
+# Playwright
+
+Deploy a protected Playwright template from the GitHub MCP Registry on Phala Cloud.
+
+Automate web browsers using accessibility trees for testing and data extraction. Runs the Playwright MCP server for browser automation from inside the CVM.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "playwright-mcp": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/microsoft/playwright-mcp`
+- Upstream repository: `https://github.com/microsoft/playwright-mcp`

--- a/templates/prebuilt/playwright-mcp/docker-compose.yml
+++ b/templates/prebuilt/playwright-mcp/docker-compose.yml
@@ -1,0 +1,54 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM mcr.microsoft.com/playwright:v1.57.0-noble
+        USER root
+        RUN npm install -g supergateway@3.4.3
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec supergateway --stdio \"npx -y @playwright/mcp\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+    image: playwright-mcp:latest
+    pull_policy: build
+    environment: []
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/templates/prebuilt/sentry-mcp/README.md
+++ b/templates/prebuilt/sentry-mcp/README.md
@@ -1,0 +1,68 @@
+# Getsentry Sentry
+
+Deploy a protected Getsentry Sentry template from the GitHub MCP Registry on Phala Cloud.
+
+MCP server for Sentry - error monitoring, issue tracking, and debugging for AI assistants. Runs Sentry MCP for issue, trace, and debugging workflows.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+- `SENTRY_ACCESS_TOKEN` (required): Sentry user auth token.
+- `SENTRY_HOST` (optional): Optional self-hosted Sentry host.
+- `SENTRY_DISABLE_SKILLS` (optional): Optional comma-separated Sentry skills/tools to disable.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "sentry-mcp": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/getsentry/sentry-mcp`
+- Upstream repository: `https://github.com/getsentry/sentry-mcp`

--- a/templates/prebuilt/sentry-mcp/docker-compose.yml
+++ b/templates/prebuilt/sentry-mcp/docker-compose.yml
@@ -1,0 +1,56 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM node:22-bookworm-slim
+        RUN npm install -g supergateway@3.4.3
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec supergateway --stdio \"npx -y @sentry/mcp-server@0.25.0\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+    image: sentry-mcp:latest
+    pull_policy: build
+    environment:
+      - SENTRY_ACCESS_TOKEN=${SENTRY_ACCESS_TOKEN:-}
+      - SENTRY_HOST=${SENTRY_HOST:-}
+      - SENTRY_DISABLE_SKILLS=${SENTRY_DISABLE_SKILLS:-}
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/templates/prebuilt/serena-mcp/README.md
+++ b/templates/prebuilt/serena-mcp/README.md
@@ -1,0 +1,66 @@
+# Serena
+
+Deploy a protected Serena template from the GitHub MCP Registry on Phala Cloud.
+
+Semantic code retrieval & editing tools for coding agents. Runs Serena for semantic code retrieval and editing. Mount project files into the /workspace volume before using project-scoped tools.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+- `SERENA_PROJECT` (optional): Optional project path to activate after the server starts, typically under /workspace.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "serena-mcp": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/oraios/serena`
+- Upstream repository: `https://github.com/oraios/serena`

--- a/templates/prebuilt/serena-mcp/docker-compose.yml
+++ b/templates/prebuilt/serena-mcp/docker-compose.yml
@@ -1,0 +1,62 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM node:22-bookworm-slim
+        RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-venv ca-certificates curl git && rm -rf /var/lib/apt/lists/*
+        RUN npm install -g supergateway@3.4.3 && npm cache clean --force
+        RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+        ENV PATH="/root/.local/bin:${PATH}"
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec supergateway --stdio \"uvx --from serena-agent serena start-mcp-server --context ide-assistant\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+    image: serena-mcp:latest
+    pull_policy: build
+    environment:
+      - SERENA_PROJECT=${SERENA_PROJECT:-}
+    volumes:
+      - serena_workspace:/workspace
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge
+
+volumes:
+  serena_workspace:

--- a/templates/prebuilt/serena-mcp/docker-compose.yml
+++ b/templates/prebuilt/serena-mcp/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-venv ca-certificates curl git && rm -rf /var/lib/apt/lists/*
         RUN npm install -g supergateway@3.4.3 && npm cache clean --force
         RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-        ENV PATH="/root/.local/bin:${PATH}"
+        ENV PATH="/root/.local/bin:$${PATH}"
         WORKDIR /workspace
         EXPOSE 8000
         CMD ["sh", "-lc", "exec supergateway --stdio \"uvx --from serena-agent serena start-mcp-server --context ide-assistant\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]

--- a/templates/prebuilt/stripe-mcp/README.md
+++ b/templates/prebuilt/stripe-mcp/README.md
@@ -1,0 +1,66 @@
+# Stripe
+
+Deploy a protected Stripe template from the GitHub MCP Registry on Phala Cloud.
+
+MCP server integrating with Stripe - tools for customers, products, payments, and more. Proxies Stripe’s hosted MCP endpoint. Use Stripe OAuth or upstream Authorization according to Stripe MCP docs.
+
+This template proxies the upstream streamable-http endpoint `https://mcp.stripe.com`. Keep upstream OAuth/API authorization in the MCP client request headers and use `X-Phala-MCP-Token` only for the Phala gateway gate.
+
+## Services
+
+- `proxy`: Caddy reverse proxy on public port `18080` that gates access and forwards traffic to the upstream hosted MCP endpoint.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "stripe-mcp": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/com.stripe/mcp`
+- Upstream repository: `https://github.com/stripe/agent-toolkit`

--- a/templates/prebuilt/stripe-mcp/docker-compose.yml
+++ b/templates/prebuilt/stripe-mcp/docker-compose.yml
@@ -19,7 +19,7 @@ configs:
           }
           route @valid_auth {
               reverse_proxy https://mcp.stripe.com {
-                  header_up Host {upstream_hostport}
+                  header_up Host mcp.stripe.com
               }
           }
           route {

--- a/templates/prebuilt/stripe-mcp/docker-compose.yml
+++ b/templates/prebuilt/stripe-mcp/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy https://mcp.stripe.com {
+                  header_up Host {upstream_hostport}
+              }
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }

--- a/templates/prebuilt/tavily-mcp/README.md
+++ b/templates/prebuilt/tavily-mcp/README.md
@@ -1,0 +1,66 @@
+# Tavily
+
+Deploy a protected Tavily template from the GitHub MCP Registry on Phala Cloud.
+
+MCP server for advanced web search using Tavily. Provides Tavily search and extraction tools.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+- `TAVILY_API_KEY` (required): Tavily API key.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "tavily-mcp": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/tavily-ai/tavily-mcp`
+- Upstream repository: `https://github.com/tavily-ai/tavily-mcp`

--- a/templates/prebuilt/tavily-mcp/docker-compose.yml
+++ b/templates/prebuilt/tavily-mcp/docker-compose.yml
@@ -1,0 +1,54 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM node:22-bookworm-slim
+        RUN npm install -g supergateway@3.4.3
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec supergateway --stdio \"npx -y tavily-mcp@0.2.15\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+    image: tavily-mcp:latest
+    pull_policy: build
+    environment:
+      - TAVILY_API_KEY=${TAVILY_API_KEY:-}
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/templates/prebuilt/terraform-mcp-server/README.md
+++ b/templates/prebuilt/terraform-mcp-server/README.md
@@ -1,0 +1,68 @@
+# Terraform
+
+Deploy a protected Terraform template from the GitHub MCP Registry on Phala Cloud.
+
+Generate more accurate Terraform and automate workflows for HCP Terraform and Terraform Enterprise. Runs HashiCorp Terraform MCP in native Streamable HTTP mode.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+- `TFE_ADDRESS` (optional): Optional HCP Terraform or Terraform Enterprise address.
+- `TFE_TOKEN` (optional): Optional HCP Terraform or Terraform Enterprise token.
+- `MCP_TOOLSETS` (optional): Optional comma-separated Terraform MCP toolsets.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "terraform-mcp-server": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/hashicorp/terraform-mcp-server`
+- Upstream repository: `https://github.com/hashicorp/terraform-mcp-server`

--- a/templates/prebuilt/terraform-mcp-server/docker-compose.yml
+++ b/templates/prebuilt/terraform-mcp-server/docker-compose.yml
@@ -1,0 +1,52 @@
+services:
+  app:
+    image: hashicorp/terraform-mcp-server:0.5.0
+    environment:
+      - TFE_ADDRESS=${TFE_ADDRESS:-}
+      - TFE_TOKEN=${TFE_TOKEN:-}
+      - MCP_TOOLSETS=${MCP_TOOLSETS:-}
+      - TRANSPORT_MODE=streamable-http
+      - TRANSPORT_HOST=0.0.0.0
+      - TRANSPORT_PORT=8080
+      - MCP_ENDPOINT=/mcp
+      - MCP_ALLOWED_ORIGINS=*
+    expose:
+      - "8080"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8080
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge

--- a/templates/prebuilt/unity-mcp/README.md
+++ b/templates/prebuilt/unity-mcp/README.md
@@ -1,0 +1,67 @@
+# Unity
+
+Deploy a protected Unity template from the GitHub MCP Registry on Phala Cloud.
+
+Control the Unity Editor from MCP clients via a Unity bridge + local Python server. Runs the Python MCP bridge for Unity. The Unity Editor side still needs the upstream Unity package and reachable bridge settings.
+
+## Services
+
+- `app`: MCP server runtime.
+- `proxy`: Caddy reverse proxy on public port `18080` that enforces the local token.
+
+## Ports
+
+- `18080`: Public HTTP endpoint exposed by Phala Cloud.
+
+## Environment variables
+
+- `BEARER_TOKEN`: Local Phala gateway token checked through the `X-Phala-MCP-Token` request header.
+- `UNITY_HOST` (optional): Optional Unity bridge host if your Unity Editor can reach this CVM.
+- `UNITY_PORT` (optional): Optional Unity bridge port.
+
+Generate a strong local gateway token before deployment:
+
+```bash
+openssl rand -hex 32
+```
+
+## MCP client configuration
+
+Use the Phala Cloud app URL with the MCP endpoint path shown below:
+
+```json
+{
+  "mcpServers": {
+    "unity-mcp": {
+      "type": "streamablehttp",
+      "url": "https://<your-app-domain>/mcp",
+      "headers": {
+        "X-Phala-MCP-Token": "YOUR_BEARER_TOKEN"
+      }
+    }
+  }
+}
+```
+
+For upstream services that require OAuth or API-token authorization, keep those upstream headers in the MCP client configuration alongside `X-Phala-MCP-Token`.
+
+## Verify
+
+Check that the local gate rejects unauthenticated traffic:
+
+```bash
+curl -i https://<your-app-domain>/mcp
+```
+
+Then verify that authenticated requests reach the MCP server or upstream MCP endpoint:
+
+```bash
+curl -i -H "X-Phala-MCP-Token: YOUR_BEARER_TOKEN" https://<your-app-domain>/mcp
+```
+
+A full MCP client performs the protocol initialization over the configured transport. Use the same checks after rotating `BEARER_TOKEN`, changing upstream credentials, or redeploying the template.
+
+## Source
+
+- GitHub MCP Registry: `https://github.com/mcp/coplaydev/unity-mcp`
+- Upstream repository: `https://github.com/CoplayDev/unity-mcp`

--- a/templates/prebuilt/unity-mcp/docker-compose.yml
+++ b/templates/prebuilt/unity-mcp/docker-compose.yml
@@ -7,7 +7,7 @@ services:
         RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-venv ca-certificates curl git && rm -rf /var/lib/apt/lists/*
         RUN npm install -g supergateway@3.4.3 && npm cache clean --force
         RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-        ENV PATH="/root/.local/bin:${PATH}"
+        ENV PATH="/root/.local/bin:$${PATH}"
         WORKDIR /workspace
         EXPOSE 8000
         CMD ["sh", "-lc", "exec supergateway --stdio \"uvx --from mcpforunityserver mcp-for-unity --transport stdio\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]

--- a/templates/prebuilt/unity-mcp/docker-compose.yml
+++ b/templates/prebuilt/unity-mcp/docker-compose.yml
@@ -1,0 +1,58 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM node:22-bookworm-slim
+        RUN apt-get update && apt-get install -y --no-install-recommends python3 python3-venv ca-certificates curl git && rm -rf /var/lib/apt/lists/*
+        RUN npm install -g supergateway@3.4.3 && npm cache clean --force
+        RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+        ENV PATH="/root/.local/bin:${PATH}"
+        WORKDIR /workspace
+        EXPOSE 8000
+        CMD ["sh", "-lc", "exec supergateway --stdio \"uvx --from mcpforunityserver mcp-for-unity --transport stdio\" --outputTransport streamableHttp --port 8000 --streamableHttpPath /mcp --healthEndpoint /healthz --cors"]
+    image: unity-mcp:latest
+    pull_policy: build
+    environment:
+      - UNITY_HOST=${UNITY_HOST:-}
+      - UNITY_PORT=${UNITY_PORT:-}
+    expose:
+      - "8000"
+    restart: unless-stopped
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    ports:
+      - "18080:80"
+    environment:
+      - BEARER_TOKEN=${BEARER_TOKEN}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    restart: unless-stopped
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          @valid_auth {
+              header X-Phala-MCP-Token "{env.BEARER_TOKEN}"
+          }
+          route @valid_auth {
+              reverse_proxy app:8000
+          }
+          route {
+              respond 401 {
+                  body "Unauthorized"
+                  close
+              }
+          }
+      }
+
+networks:
+  internal:
+    driver: bridge


### PR DESCRIPTION
## Summary
- Adds Phala Cloud prebuilt templates for the 27 GitHub MCP Registry entries that were missing from `templates/prebuilt`
- Keeps existing coverage for `context7-mcp`, `figma-mcp`, and `supabase-db`
- Adds one template commit per new MCP server, plus small follow-up commits for config formatting and proxy/runtime safety fixes
- Exposes each new template through a protected MCP endpoint using `BEARER_TOKEN` + `X-Phala-MCP-Token`

## Added templates
- `markitdown-mcp`
- `netdata-mcp-server`
- `chrome-devtools-mcp`
- `playwright-mcp`
- `github-mcp-server`
- `serena-mcp`
- `unity-mcp`
- `firecrawl-mcp-server`
- `desktop-commander-mcp`
- `notion-mcp-server`
- `azure-mcp`
- `microsoft-fabric-mcp`
- `dbhub`
- `brightdata-mcp`
- `tavily-mcp`
- `azure-devops-mcp`
- `microsoftdocs-mcp`
- `stripe-mcp`
- `nuget-mcp`
- `terraform-mcp-server`
- `apify-mcp-server`
- `mongodb-mcp-server`
- `nuxt-mcp`
- `next-devtools-mcp`
- `atlassian-mcp-server`
- `sentry-mcp`
- `elasticsearch-mcp`

## Implementation notes
- Local stdio MCP servers are exposed as Streamable HTTP through `supergateway` behind Caddy.
- Native HTTP MCP servers keep their upstream HTTP transport and run behind Caddy.
- Hosted-only registry entries use Caddy as a Phala-hosted protected proxy to the official hosted MCP endpoint.
- Runtime env references in inline Dockerfiles are escaped so deploy-time secrets stay in runtime env rather than being interpolated into the inline Dockerfile command.

## Validation
- [x] `python templates/validate.py`
- [x] `git diff --check origin/main...HEAD`
- [x] `docker compose -f <template>/docker-compose.yml config` for all 27 new templates
- [x] Static README/config/secret scan for all 27 new templates
