### PR TITLE
feat(types): add port_policy to LooseAppCompose

### DIFF
--- a/js/src/types/app_compose.test.ts
+++ b/js/src/types/app_compose.test.ts
@@ -95,4 +95,48 @@ describe("LooseAppComposeSchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it("should accept a valid port_policy", () => {
+    const result = LooseAppComposeSchema.safeParse({
+      docker_compose_file: "version: '3'",
+      port_policy: {
+        ports: [
+          { port: 80, pp: true },
+          { port: 443, pp: false },
+        ],
+        restrict_mode: true,
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.port_policy).toEqual({
+        ports: [
+          { port: 80, pp: true },
+          { port: 443, pp: false },
+        ],
+        restrict_mode: true,
+      });
+    }
+  });
+
+  it("should reject port_policy with out-of-range port", () => {
+    const result = LooseAppComposeSchema.safeParse({
+      docker_compose_file: "version: '3'",
+      port_policy: {
+        ports: [{ port: 70000, pp: true }],
+        restrict_mode: false,
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject port_policy missing restrict_mode", () => {
+    const result = LooseAppComposeSchema.safeParse({
+      docker_compose_file: "version: '3'",
+      port_policy: {
+        ports: [{ port: 80, pp: true }],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/js/src/types/app_compose.ts
+++ b/js/src/types/app_compose.ts
@@ -37,6 +37,17 @@ export const LooseAppComposeSchema = z
     public_logs: z.boolean().optional(),
     public_sysinfo: z.boolean().optional(),
     tproxy_enabled: z.boolean().optional(),
+    port_policy: z
+      .object({
+        ports: z.array(
+          z.object({
+            port: z.number().int().min(1).max(65535),
+            pp: z.boolean(),
+          }),
+        ),
+        restrict_mode: z.boolean(),
+      })
+      .optional(),
     storage_fs: z.enum(["ext4", "zfs"]).optional(),
     pre_launch_script: z.string().optional(),
     env_pubkey: z.string().optional(),


### PR DESCRIPTION
## Summary

- Adds the `AppComposeV2.port_policy` attested field to the JS SDK `LooseAppCompose` zod schema.
- Field shape mirrors the backend protobuf (snake_case): `port_policy.ports[].{port,pp}` and `port_policy.restrict_mode`.
- Phala Cloud frontend is reworking the network-config UI and was previously relying on `.passthrough()` to ship this field, which left it untyped. With this change the SDK gives proper type safety + runtime validation.

## Scope

SDK-only change; no version bump (maintainer handles that). Frontend will bump the SDK version after release.

## Test plan

- [x] `bun run fmt`
- [x] `bun run lint`
- [x] `bun run type-check`
- [x] `bun run test` (692 tests passing, including 3 new tests for `port_policy`: accept-valid, reject-out-of-range-port, reject-missing-restrict_mode)