### PR TITLE
feat(go): add RedeployAppRevision

### DIFF
--- a/go/apps.go
+++ b/go/apps.go
@@ -132,6 +132,28 @@ func (c *Client) GetAppRevisionDetail(ctx context.Context, appID, revisionID str
 	return &result, nil
 }
 
+// RedeployAppRevisionRequest is the request body for redeploying an app
+// revision across a set of CVMs.
+type RedeployAppRevisionRequest struct {
+	// VMUUIDs lists the CVMs that should adopt the new revision. The
+	// backend locks each CVM row, flips compose_hash in place, and
+	// enqueues the per-CVM update task; vm_uuid and name are preserved.
+	VMUUIDs []string `json:"vm_uuids"`
+}
+
+// RedeployAppRevision schedules an async redeploy of the named revision
+// against the given set of CVMs. The endpoint returns 202 on accept;
+// callers should poll GetCVMInfo per CVM and wait for compose_hash to
+// flip to the new revision's value before reporting completion.
+//
+// HTTP 465 from the backend means on-chain KMS compose-hash registration
+// is required; surfaced as a regular *APIError so callers can decide how
+// to present it.
+func (c *Client) RedeployAppRevision(ctx context.Context, appID, revisionID string, req *RedeployAppRevisionRequest) error {
+	path := fmt.Sprintf("/apps/%s/revisions/%s/redeploy", appID, url.PathEscape(revisionID))
+	return c.doJSON(ctx, "POST", path, req, nil)
+}
+
 // GetAppAttestation returns attestation data for an application.
 func (c *Client) GetAppAttestation(ctx context.Context, appID string) (*AppAttestationResponse, error) {
 	var result AppAttestationResponse

--- a/go/apps_test.go
+++ b/go/apps_test.go
@@ -65,3 +65,37 @@ func TestCreateAppInstance(t *testing.T) {
 		t.Errorf("Status = %q, want running", result.Status)
 	}
 }
+
+// TestRedeployAppRevision covers the SDK method used by the Terraform
+// provider's members-mode update path: redeploy a revision across a set
+// of vm_uuids by POSTing /apps/{id}/revisions/{rev}/redeploy.
+func TestRedeployAppRevision(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/apps/app-1/revisions/rev_42/redeploy" {
+			t.Errorf("path = %q, want /apps/app-1/revisions/rev_42/redeploy", r.URL.Path)
+		}
+		var body RedeployAppRevisionRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if len(body.VMUUIDs) != 2 || body.VMUUIDs[0] != "vm-a" || body.VMUUIDs[1] != "vm-b" {
+			t.Errorf("vm_uuids = %v, want [vm-a vm-b]", body.VMUUIDs)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"message":"ok"}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(WithBaseURL(srv.URL), WithAPIKey("test"))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if err := client.RedeployAppRevision(context.Background(), "app-1", "rev_42",
+		&RedeployAppRevisionRequest{VMUUIDs: []string{"vm-a", "vm-b"}}); err != nil {
+		t.Fatalf("RedeployAppRevision: %v", err)
+	}
+}


### PR DESCRIPTION
Adds the SDK method for `POST /apps/{id}/revisions/{rev_id}/redeploy`, which redeploys an app revision across a set of CVMs by `vm_uuid` while preserving each slot's `vm_uuid` and `name`. The Terraform provider's members-mode (MIG) update path (Phala-Network/terraform-provider-phala#4) uses this to fan a new compose revision out to every slot in an app.

HTTP 465 (on-chain KMS compose-hash registration required) surfaces as a regular `*APIError` so callers can present it.

## History

This branch originally also carried a numeric-CVM-id workaround (`CVMInfo.ID` as `json.RawMessage` + `IDString()`), because `POST /apps/{id}/instances` used to return `id` as a raw integer. That is **no longer needed**:

- PR #303 (versioned hashid SDK schemas) + the backend's `build_vm_response()` change make the endpoint return the `cvm_<hashid>` string for API version 2026-01-21.
- So `CVMInfo.ID` stays a plain `string`.

Rebased onto current main; only `RedeployAppRevision` remains. `go build` / `go test ./...` green.

## Test plan

- [x] `TestRedeployAppRevision` — asserts path, method, and that `vm_uuids` round-trips through the JSON body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)