### PR TITLE
feat(js): add pre-launch script upgrade-status and upgrade actions

### DIFF
--- a/js/src/actions/cvms/get_prelaunch_script_upgrade_status.test.ts
+++ b/js/src/actions/cvms/get_prelaunch_script_upgrade_status.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createClient } from "../../client";
+import {
+  getPreLaunchScriptUpgradeStatus,
+  type PreLaunchScriptUpgradeStatus,
+} from "./get_prelaunch_script_upgrade_status";
+
+const mockUpgradable: PreLaunchScriptUpgradeStatus = {
+  current_hash: "0e289ab44fa756e02a3e850d60c22ab1cbf90cade311f98f555fad74a1c40d0a",
+  latest_official_hash: "bf12939bc82c9bdd103b6b1226913e6da58ed7cfcfc7c7ae808ac0813715b9a8",
+  is_official: true,
+  is_latest: false,
+  can_upgrade: true,
+};
+
+const mockCustom: PreLaunchScriptUpgradeStatus = {
+  current_hash: "deadbeef".repeat(8),
+  latest_official_hash: "bf12939bc82c9bdd103b6b1226913e6da58ed7cfcfc7c7ae808ac0813715b9a8",
+  is_official: false,
+  is_latest: false,
+  can_upgrade: false,
+};
+
+describe("getPreLaunchScriptUpgradeStatus", () => {
+  let client: ReturnType<typeof createClient>;
+  let mockGet: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    client = createClient({ apiKey: "test-api-key", baseURL: "https://api.test.com" });
+    mockGet = vi.spyOn(client, "get");
+  });
+
+  it("calls the upgrade-status endpoint and parses the response", async () => {
+    mockGet.mockResolvedValue(mockUpgradable);
+
+    const result = await getPreLaunchScriptUpgradeStatus(client, { id: "cvm-1" });
+
+    expect(mockGet).toHaveBeenCalledWith("/cvms/cvm-1/pre-launch-script/upgrade-status");
+    expect(result).toEqual(mockUpgradable);
+  });
+
+  it("passes through can_upgrade=false for custom scripts", async () => {
+    mockGet.mockResolvedValue(mockCustom);
+
+    const result = await getPreLaunchScriptUpgradeStatus(client, { id: "cvm-2" });
+
+    expect(result.is_official).toBe(false);
+    expect(result.can_upgrade).toBe(false);
+  });
+
+  it("accepts a null current_hash (CVM with no recorded hash)", async () => {
+    mockGet.mockResolvedValue({
+      current_hash: null,
+      latest_official_hash: "bf12939bc82c9bdd103b6b1226913e6da58ed7cfcfc7c7ae808ac0813715b9a8",
+      is_official: false,
+      is_latest: false,
+      can_upgrade: false,
+    });
+
+    const result = await getPreLaunchScriptUpgradeStatus(client, { id: "cvm-3" });
+
+    expect(result.current_hash).toBeNull();
+    expect(result.can_upgrade).toBe(false);
+  });
+});

--- a/js/src/actions/cvms/get_prelaunch_script_upgrade_status.ts
+++ b/js/src/actions/cvms/get_prelaunch_script_upgrade_status.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import { CvmIdSchema, type CvmIdInput } from "../../types/cvm_id";
+import { defineAction } from "../../utils/define-action";
+
+/**
+ * Get pre-launch script upgrade status
+ *
+ * Reports whether a CVM is running an unmodified official pre-launch script
+ * and whether a newer official version is available. The frontend uses
+ * `can_upgrade` to decide whether to surface the one-click upgrade banner.
+ *
+ * @example
+ * ```typescript
+ * import { createClient, getPreLaunchScriptUpgradeStatus } from '@phala/cloud'
+ *
+ * const client = createClient({ apiKey: 'your-api-key' })
+ * const status = await getPreLaunchScriptUpgradeStatus(client, { id: 'cvm-123' })
+ *
+ * if (status.can_upgrade) {
+ *   // CVM is on an older official script; offer the upgrade
+ * }
+ * ```
+ */
+
+export const GetPreLaunchScriptUpgradeStatusRequestSchema = CvmIdSchema;
+
+export type GetPreLaunchScriptUpgradeStatusRequest = CvmIdInput;
+
+export const PreLaunchScriptUpgradeStatusSchema = z.object({
+  current_hash: z.string().nullable(),
+  latest_official_hash: z.string(),
+  is_official: z.boolean(),
+  is_latest: z.boolean(),
+  can_upgrade: z.boolean(),
+});
+
+export type PreLaunchScriptUpgradeStatus = z.infer<typeof PreLaunchScriptUpgradeStatusSchema>;
+
+const {
+  action: getPreLaunchScriptUpgradeStatus,
+  safeAction: safeGetPreLaunchScriptUpgradeStatus,
+} = defineAction<GetPreLaunchScriptUpgradeStatusRequest, typeof PreLaunchScriptUpgradeStatusSchema>(
+  PreLaunchScriptUpgradeStatusSchema,
+  async (client, request) => {
+    const { cvmId } = GetPreLaunchScriptUpgradeStatusRequestSchema.parse(request);
+    return await client.get(`/cvms/${cvmId}/pre-launch-script/upgrade-status`);
+  },
+);
+
+export { getPreLaunchScriptUpgradeStatus, safeGetPreLaunchScriptUpgradeStatus };

--- a/js/src/actions/cvms/get_prelaunch_script_upgrade_status.ts
+++ b/js/src/actions/cvms/get_prelaunch_script_upgrade_status.ts
@@ -36,15 +36,13 @@ export const PreLaunchScriptUpgradeStatusSchema = z.object({
 
 export type PreLaunchScriptUpgradeStatus = z.infer<typeof PreLaunchScriptUpgradeStatusSchema>;
 
-const {
-  action: getPreLaunchScriptUpgradeStatus,
-  safeAction: safeGetPreLaunchScriptUpgradeStatus,
-} = defineAction<GetPreLaunchScriptUpgradeStatusRequest, typeof PreLaunchScriptUpgradeStatusSchema>(
-  PreLaunchScriptUpgradeStatusSchema,
-  async (client, request) => {
-    const { cvmId } = GetPreLaunchScriptUpgradeStatusRequestSchema.parse(request);
-    return await client.get(`/cvms/${cvmId}/pre-launch-script/upgrade-status`);
-  },
-);
+const { action: getPreLaunchScriptUpgradeStatus, safeAction: safeGetPreLaunchScriptUpgradeStatus } =
+  defineAction<GetPreLaunchScriptUpgradeStatusRequest, typeof PreLaunchScriptUpgradeStatusSchema>(
+    PreLaunchScriptUpgradeStatusSchema,
+    async (client, request) => {
+      const { cvmId } = GetPreLaunchScriptUpgradeStatusRequestSchema.parse(request);
+      return await client.get(`/cvms/${cvmId}/pre-launch-script/upgrade-status`);
+    },
+  );
 
 export { getPreLaunchScriptUpgradeStatus, safeGetPreLaunchScriptUpgradeStatus };

--- a/js/src/actions/cvms/upgrade_prelaunch_script.test.ts
+++ b/js/src/actions/cvms/upgrade_prelaunch_script.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createClient } from "../../client";
+import { PhalaCloudError } from "../../utils/errors";
+import { upgradePreLaunchScript } from "./upgrade_prelaunch_script";
+
+describe("upgradePreLaunchScript", () => {
+  let client: ReturnType<typeof createClient>;
+  let mockPost: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    client = createClient({ apiKey: "test-api-key", baseURL: "https://api.test.com" });
+    mockPost = vi.spyOn(client, "post");
+  });
+
+  it("POSTs to the upgrade endpoint with no body when there are no Phase-2 headers", async () => {
+    mockPost.mockResolvedValue({
+      status: "in_progress",
+      message: "Pre-launch script update initiated",
+      correlation_id: "corr-1",
+    });
+
+    const result = await upgradePreLaunchScript(client, { id: "cvm-1" });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/cvms/cvm-1/pre-launch-script/upgrade-to-latest-official",
+      undefined,
+      { headers: {} },
+    );
+    expect(result).toEqual({
+      status: "in_progress",
+      message: "Pre-launch script update initiated",
+      correlation_id: "corr-1",
+    });
+  });
+
+  it("forwards compose_hash and transaction_hash via Phase-2 headers", async () => {
+    mockPost.mockResolvedValue({
+      status: "in_progress",
+      message: "ok",
+      correlation_id: "corr-2",
+    });
+
+    await upgradePreLaunchScript(client, {
+      id: "cvm-2",
+      compose_hash: "0xabc",
+      transaction_hash: "0xdef",
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/cvms/cvm-2/pre-launch-script/upgrade-to-latest-official",
+      undefined,
+      {
+        headers: {
+          "X-Compose-Hash": "0xabc",
+          "X-Transaction-Hash": "0xdef",
+        },
+      },
+    );
+  });
+
+  it("maps a 465 StructuredError into precondition_required", async () => {
+    const err = new PhalaCloudError("Compose hash registration required", {
+      status: 465,
+      detail: {
+        message: "Compose hash registration required",
+        details: [
+          { field: "compose_hash", value: "0xhash" },
+          { field: "app_id", value: "app-1" },
+          { field: "device_id", value: "device-1" },
+          {
+            field: "kms_info",
+            value: {
+              id: "kms-1",
+              slug: "kms-1",
+              url: "https://kms.example.com",
+              version: "1.0.0",
+              chain_id: 1,
+              kms_contract_address: "0xkms",
+              gateway_app_id: "0xgateway",
+            },
+          },
+        ],
+      },
+    });
+    mockPost.mockRejectedValue(err);
+
+    const result = await upgradePreLaunchScript(client, { id: "cvm-3" });
+
+    expect(result.status).toBe("precondition_required");
+    if (result.status === "precondition_required") {
+      expect(result.compose_hash).toBe("0xhash");
+      expect(result.app_id).toBe("app-1");
+      expect(result.device_id).toBe("device-1");
+    }
+  });
+
+  it("re-throws non-465 errors", async () => {
+    const err = new PhalaCloudError("Conflict", { status: 409 });
+    mockPost.mockRejectedValue(err);
+
+    await expect(upgradePreLaunchScript(client, { id: "cvm-4" })).rejects.toThrow(err);
+  });
+});

--- a/js/src/actions/cvms/upgrade_prelaunch_script.ts
+++ b/js/src/actions/cvms/upgrade_prelaunch_script.ts
@@ -1,0 +1,142 @@
+import { z } from "zod";
+import { CvmIdObjectSchema, CvmIdSchema, refineCvmId } from "../../types/cvm_id";
+import { KmsInfoSchema } from "../../types/kms_info";
+import { defineAction } from "../../utils/define-action";
+import { PhalaCloudError } from "../../utils/errors";
+
+/**
+ * Upgrade a CVM's pre-launch script to the latest official version.
+ *
+ * Replaces the CVM's current pre-launch script with the latest official
+ * version maintained by Phala and triggers the standard update workflow.
+ * The official script content is held server-side; clients only need to
+ * call this endpoint with the CVM ID.
+ *
+ * For contract-owned KMS (ETHEREUM/BASE), the first call returns
+ * `precondition_required` with a compose hash to register on-chain. After
+ * registration, retry with `compose_hash` and `transaction_hash`.
+ *
+ * @example
+ * ```typescript
+ * import { createClient, upgradePreLaunchScript } from '@phala/cloud'
+ *
+ * const client = createClient({ apiKey: 'your-api-key' })
+ *
+ * // Phase 1: kick off the upgrade
+ * const result = await upgradePreLaunchScript(client, { id: 'cvm-123' })
+ *
+ * if (result.status === 'precondition_required') {
+ *   // Register compose hash on-chain, then retry with the headers
+ *   const txHash = await registerComposeHashOnChain(result.compose_hash, result.kms_info)
+ *   await upgradePreLaunchScript(client, {
+ *     id: 'cvm-123',
+ *     compose_hash: result.compose_hash,
+ *     transaction_hash: txHash,
+ *   })
+ * }
+ * ```
+ */
+
+export const UpgradePreLaunchScriptRequestSchema = refineCvmId(
+  CvmIdObjectSchema.extend({
+    compose_hash: z
+      .string()
+      .optional()
+      .describe("Compose hash for verification (Phase 2, contract-owned KMS only)"),
+    transaction_hash: z
+      .string()
+      .optional()
+      .describe("On-chain transaction hash for verification (Phase 2, contract-owned KMS only)"),
+  }),
+).transform((data) => {
+  const { cvmId } = CvmIdSchema.parse(data);
+  return {
+    cvmId,
+    request: {
+      compose_hash: data.compose_hash,
+      transaction_hash: data.transaction_hash,
+    },
+    _raw: data,
+  };
+});
+
+const UpgradePreLaunchScriptInProgressSchema = z.object({
+  status: z.literal("in_progress"),
+  message: z.string(),
+  correlation_id: z.string(),
+});
+
+const UpgradePreLaunchScriptPreconditionRequiredSchema = z.object({
+  status: z.literal("precondition_required"),
+  message: z.string(),
+  compose_hash: z.string(),
+  app_id: z.string(),
+  device_id: z.string(),
+  kms_info: KmsInfoSchema,
+});
+
+export const UpgradePreLaunchScriptResultSchema = z.union([
+  UpgradePreLaunchScriptInProgressSchema,
+  UpgradePreLaunchScriptPreconditionRequiredSchema,
+]);
+
+export type UpgradePreLaunchScriptRequest = z.input<typeof UpgradePreLaunchScriptRequestSchema>;
+export type UpgradePreLaunchScriptResult = z.infer<typeof UpgradePreLaunchScriptResultSchema>;
+export type UpgradePreLaunchScriptInProgress = z.infer<typeof UpgradePreLaunchScriptInProgressSchema>;
+export type UpgradePreLaunchScriptPreconditionRequired = z.infer<
+  typeof UpgradePreLaunchScriptPreconditionRequiredSchema
+>;
+
+const { action: upgradePreLaunchScript, safeAction: safeUpgradePreLaunchScript } = defineAction<
+  UpgradePreLaunchScriptRequest,
+  typeof UpgradePreLaunchScriptResultSchema
+>(UpgradePreLaunchScriptResultSchema, async (client, request) => {
+  const validated = UpgradePreLaunchScriptRequestSchema.parse(request);
+
+  const headers: Record<string, string> = {};
+  if (validated.request.compose_hash) {
+    headers["X-Compose-Hash"] = validated.request.compose_hash;
+  }
+  if (validated.request.transaction_hash) {
+    headers["X-Transaction-Hash"] = validated.request.transaction_hash;
+  }
+
+  try {
+    const response = await client.post<UpgradePreLaunchScriptInProgress>(
+      `/cvms/${validated.cvmId}/pre-launch-script/upgrade-to-latest-official`,
+      undefined,
+      { headers },
+    );
+    return response;
+  } catch (error) {
+    if (error instanceof PhalaCloudError && error.status === 465) {
+      const detail = error.detail;
+      if (detail && typeof detail === "object") {
+        const detailObj = detail as Record<string, unknown>;
+        const detailsArray = detailObj.details as
+          | Array<{ field: string; value: unknown }>
+          | undefined;
+        if (detailsArray && Array.isArray(detailsArray)) {
+          const fieldMap = new Map(detailsArray.map((d) => [d.field, d.value]));
+          const composeHash = fieldMap.get("compose_hash");
+          const appId = fieldMap.get("app_id");
+          const deviceId = fieldMap.get("device_id");
+          const kmsInfo = fieldMap.get("kms_info");
+          if (composeHash && appId) {
+            return {
+              status: "precondition_required" as const,
+              message: (detailObj.message as string) || "Compose hash verification required",
+              compose_hash: composeHash as string,
+              app_id: appId as string,
+              device_id: (deviceId as string) || "",
+              kms_info: kmsInfo,
+            };
+          }
+        }
+      }
+    }
+    throw error;
+  }
+});
+
+export { upgradePreLaunchScript, safeUpgradePreLaunchScript };

--- a/js/src/actions/cvms/upgrade_prelaunch_script.ts
+++ b/js/src/actions/cvms/upgrade_prelaunch_script.ts
@@ -82,7 +82,9 @@ export const UpgradePreLaunchScriptResultSchema = z.union([
 
 export type UpgradePreLaunchScriptRequest = z.input<typeof UpgradePreLaunchScriptRequestSchema>;
 export type UpgradePreLaunchScriptResult = z.infer<typeof UpgradePreLaunchScriptResultSchema>;
-export type UpgradePreLaunchScriptInProgress = z.infer<typeof UpgradePreLaunchScriptInProgressSchema>;
+export type UpgradePreLaunchScriptInProgress = z.infer<
+  typeof UpgradePreLaunchScriptInProgressSchema
+>;
 export type UpgradePreLaunchScriptPreconditionRequired = z.infer<
   typeof UpgradePreLaunchScriptPreconditionRequiredSchema
 >;

--- a/js/src/actions/index.ts
+++ b/js/src/actions/index.ts
@@ -515,6 +515,26 @@ export {
 } from "./cvms/get_cvm_prelaunch_script";
 
 export {
+  getPreLaunchScriptUpgradeStatus,
+  safeGetPreLaunchScriptUpgradeStatus,
+  GetPreLaunchScriptUpgradeStatusRequestSchema,
+  type GetPreLaunchScriptUpgradeStatusRequest,
+  PreLaunchScriptUpgradeStatusSchema,
+  type PreLaunchScriptUpgradeStatus,
+} from "./cvms/get_prelaunch_script_upgrade_status";
+
+export {
+  upgradePreLaunchScript,
+  safeUpgradePreLaunchScript,
+  UpgradePreLaunchScriptRequestSchema,
+  type UpgradePreLaunchScriptRequest,
+  UpgradePreLaunchScriptResultSchema,
+  type UpgradePreLaunchScriptResult,
+  type UpgradePreLaunchScriptInProgress,
+  type UpgradePreLaunchScriptPreconditionRequired,
+} from "./cvms/upgrade_prelaunch_script";
+
+export {
   getCvmStatusBatch,
   safeGetCvmStatusBatch,
   CvmStatusSchema,

--- a/js/src/create-client.ts
+++ b/js/src/create-client.ts
@@ -96,6 +96,18 @@ import {
   safeGetCvmPreLaunchScript,
   type GetCvmPreLaunchScriptRequest,
 } from "./actions/cvms/get_cvm_prelaunch_script";
+import {
+  getPreLaunchScriptUpgradeStatus,
+  safeGetPreLaunchScriptUpgradeStatus,
+  type GetPreLaunchScriptUpgradeStatusRequest,
+  type PreLaunchScriptUpgradeStatus,
+} from "./actions/cvms/get_prelaunch_script_upgrade_status";
+import {
+  upgradePreLaunchScript,
+  safeUpgradePreLaunchScript,
+  type UpgradePreLaunchScriptRequest,
+  type UpgradePreLaunchScriptResult,
+} from "./actions/cvms/upgrade_prelaunch_script";
 import { getKmsInfo, safeGetKmsInfo, type GetKmsInfoRequest } from "./actions/kms/get_kms_info";
 import {
   getKmsList,
@@ -306,6 +318,10 @@ export function createClient<V extends ApiVersion = DefaultApiVersion>(
     readonly safeUpdatePreLaunchScript: typeof safeUpdatePreLaunchScript;
     readonly getCvmPreLaunchScript: typeof getCvmPreLaunchScript;
     readonly safeGetCvmPreLaunchScript: typeof safeGetCvmPreLaunchScript;
+    readonly getPreLaunchScriptUpgradeStatus: typeof getPreLaunchScriptUpgradeStatus;
+    readonly safeGetPreLaunchScriptUpgradeStatus: typeof safeGetPreLaunchScriptUpgradeStatus;
+    readonly upgradePreLaunchScript: typeof upgradePreLaunchScript;
+    readonly safeUpgradePreLaunchScript: typeof safeUpgradePreLaunchScript;
     readonly startCvm: typeof startCvm;
     readonly safeStartCvm: typeof safeStartCvm;
     readonly stopCvm: typeof stopCvm;
@@ -395,6 +411,10 @@ export function createClient<V extends ApiVersion = DefaultApiVersion>(
     safeUpdatePreLaunchScript,
     getCvmPreLaunchScript,
     safeGetCvmPreLaunchScript,
+    getPreLaunchScriptUpgradeStatus,
+    safeGetPreLaunchScriptUpgradeStatus,
+    upgradePreLaunchScript,
+    safeUpgradePreLaunchScript,
     startCvm,
     safeStartCvm,
     stopCvm,
@@ -802,6 +822,54 @@ export interface Client<V extends ApiVersion = DefaultApiVersion> extends BaseCl
   ): Promise<SafeResult<z.infer<T>>>;
   safeGetCvmPreLaunchScript(
     request: GetCvmPreLaunchScriptRequest,
+    parameters: { schema: false },
+  ): Promise<SafeResult<unknown>>;
+
+  getPreLaunchScriptUpgradeStatus(
+    request: GetPreLaunchScriptUpgradeStatusRequest,
+  ): Promise<PreLaunchScriptUpgradeStatus>;
+  getPreLaunchScriptUpgradeStatus<T extends z.ZodTypeAny>(
+    request: GetPreLaunchScriptUpgradeStatusRequest,
+    parameters: { schema: T },
+  ): Promise<z.infer<T>>;
+  getPreLaunchScriptUpgradeStatus(
+    request: GetPreLaunchScriptUpgradeStatusRequest,
+    parameters: { schema: false },
+  ): Promise<unknown>;
+
+  safeGetPreLaunchScriptUpgradeStatus(
+    request: GetPreLaunchScriptUpgradeStatusRequest,
+  ): Promise<SafeResult<PreLaunchScriptUpgradeStatus>>;
+  safeGetPreLaunchScriptUpgradeStatus<T extends z.ZodTypeAny>(
+    request: GetPreLaunchScriptUpgradeStatusRequest,
+    parameters: { schema: T },
+  ): Promise<SafeResult<z.infer<T>>>;
+  safeGetPreLaunchScriptUpgradeStatus(
+    request: GetPreLaunchScriptUpgradeStatusRequest,
+    parameters: { schema: false },
+  ): Promise<SafeResult<unknown>>;
+
+  upgradePreLaunchScript(
+    request: UpgradePreLaunchScriptRequest,
+  ): Promise<UpgradePreLaunchScriptResult>;
+  upgradePreLaunchScript<T extends z.ZodTypeAny>(
+    request: UpgradePreLaunchScriptRequest,
+    parameters: { schema: T },
+  ): Promise<z.infer<T>>;
+  upgradePreLaunchScript(
+    request: UpgradePreLaunchScriptRequest,
+    parameters: { schema: false },
+  ): Promise<unknown>;
+
+  safeUpgradePreLaunchScript(
+    request: UpgradePreLaunchScriptRequest,
+  ): Promise<SafeResult<UpgradePreLaunchScriptResult>>;
+  safeUpgradePreLaunchScript<T extends z.ZodTypeAny>(
+    request: UpgradePreLaunchScriptRequest,
+    parameters: { schema: T },
+  ): Promise<SafeResult<z.infer<T>>>;
+  safeUpgradePreLaunchScript(
+    request: UpgradePreLaunchScriptRequest,
     parameters: { schema: false },
   ): Promise<SafeResult<unknown>>;
 


### PR DESCRIPTION
## Summary

Adds two SDK actions that back the one-click "use latest official pre-launch script" affordance in the Phala Cloud compose editor (paired backend + UI PR: Phala-Network/phala-cloud-monorepo#TBD).

- `getPreLaunchScriptUpgradeStatus(client, { id })` — `GET /cvms/{id}/pre-launch-script/upgrade-status`. Returns `current_hash`, `latest_official_hash`, plus the booleans `is_official`, `is_latest`, `can_upgrade`. The frontend uses `can_upgrade` to decide whether to show the banner.
- `upgradePreLaunchScript(client, { id, compose_hash?, transaction_hash? })` — `POST /cvms/{id}/pre-launch-script/upgrade-to-latest-official`. Sends no body; the backend substitutes the latest official script content. For contract-owned KMS the same two-phase 465-precondition flow as `updatePreLaunchScript` applies, and the SDK maps the 465 StructuredError into `{ status: "precondition_required", compose_hash, app_id, device_id, kms_info }`.

Both actions are wired into the typed client surface in `create-client.ts` and re-exported from the actions barrel.

## Test plan

- [x] `bun run test src/actions/cvms/get_prelaunch_script_upgrade_status.test.ts src/actions/cvms/upgrade_prelaunch_script.test.ts` — 7 tests pass (endpoint URL/headers, precondition mapping, custom/null hash passthrough)
- [x] `bun run type-check` passes
- [x] `bun run build` succeeds