### PR TITLE
Expose request IDs on structured SDK errors

### DIFF
--- a/go/errors.go
+++ b/go/errors.go
@@ -29,6 +29,7 @@ type APIError struct {
 	Detail      any
 	Body        string
 	Headers     http.Header
+	RequestID   string
 	ErrorCode   string
 	Details     []ErrorDetail
 	Suggestions []string
@@ -158,6 +159,10 @@ func (e *APIError) FormatError() string {
 		fmt.Fprintf(&b, "[%s] ", e.ErrorCode)
 	}
 	b.WriteString(e.Message)
+
+	if e.RequestID != "" {
+		fmt.Fprintf(&b, "\nRequest ID: %s", e.RequestID)
+	}
 
 	if len(e.Details) > 0 {
 		b.WriteString("\n\nDetails:")

--- a/go/request.go
+++ b/go/request.go
@@ -47,6 +47,7 @@ func (c *Client) do(ctx context.Context, req *http.Request) (*http.Response, err
 		StatusCode: resp.StatusCode,
 		Body:       string(bodyBytes),
 		Headers:    resp.Header,
+		RequestID:  resp.Header.Get("X-Request-ID"),
 	}
 
 	// Try to parse error message from JSON response.
@@ -63,6 +64,9 @@ func (c *Client) do(ctx context.Context, req *http.Request) (*http.Response, err
 				b, _ := json.Marshal(detail)
 				apiErr.Message = string(b)
 			}
+		}
+		if requestID, ok := parsed["request_id"].(string); ok {
+			apiErr.RequestID = requestID
 		}
 		if code, ok := parsed["error_code"].(string); ok {
 			apiErr.ErrorCode = code

--- a/go/request_compat_test.go
+++ b/go/request_compat_test.go
@@ -63,12 +63,50 @@ func TestProvisionCVMResponse_UnmarshalComposeHashRegistered(t *testing.T) {
 	}
 }
 
+func TestDo_UsesRequestIDHeaderWhenBodyOmitsRequestID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-ID", "rid-header-456")
+		w.WriteHeader(400)
+		_, _ = io.WriteString(w, `{
+			"message":"structured failure",
+			"error_code":"ERR-01-005"
+		}`)
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(WithAPIKey("k"), WithBaseURL(srv.URL))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	req, err := client.newRequest(context.Background(), "GET", "/test", nil)
+	if err != nil {
+		t.Fatalf("newRequest: %v", err)
+	}
+
+	_, err = client.do(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("expected *APIError, got %T", err)
+	}
+	if apiErr.RequestID != "rid-header-456" {
+		t.Fatalf("RequestID = %q, want rid-header-456", apiErr.RequestID)
+	}
+}
+
 func TestDo_PreservesStructuredErrorDetailValues(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-ID", "rid-header-456")
 		w.WriteHeader(465)
 		_, _ = io.WriteString(w, `{
 			"message":"compose hash precondition failed",
+			"request_id":"rid-body-123",
 			"error_code":"ERR-03-006",
 			"details":[
 				{
@@ -105,6 +143,9 @@ func TestDo_PreservesStructuredErrorDetailValues(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *APIError, got %T", err)
 	}
+	if apiErr.RequestID != "rid-body-123" {
+		t.Fatalf("RequestID = %q, want rid-body-123", apiErr.RequestID)
+	}
 	if len(apiErr.Details) != 2 {
 		t.Fatalf("details = %#v", apiErr.Details)
 	}
@@ -123,6 +164,9 @@ func TestDo_PreservesStructuredErrorDetailValues(t *testing.T) {
 	}
 
 	formatted := apiErr.FormatError()
+	if !strings.Contains(formatted, "Request ID: rid-body-123") {
+		t.Fatalf("FormatError() missing request id: %s", formatted)
+	}
 	if !strings.Contains(formatted, `"kms_info":{"chain_id":1}`) {
 		t.Fatalf("FormatError() missing object value: %s", formatted)
 	}

--- a/js/src/utils/errors.test.ts
+++ b/js/src/utils/errors.test.ts
@@ -12,6 +12,7 @@ import {
   getValidationFields,
   formatValidationErrors,
   formatErrorMessage,
+  formatStructuredError,
 } from "./errors";
 
 describe("parseApiError", () => {
@@ -470,6 +471,7 @@ describe("RequestError.fromFetchError with StructuredError responses", () => {
       data: {
         error_code: "ERR-01-005",
         message: "Compose hash registration required on-chain",
+        request_id: "rid-body-123",
         details: [
           { field: "compose_hash", value: "0xhash123", message: null },
           { field: "app_id", value: "0xapp456", message: null },
@@ -506,6 +508,7 @@ describe("RequestError.fromFetchError with StructuredError responses", () => {
 
     const detail = requestError.detail as Record<string, unknown>;
     expect(detail.error_code).toBe("ERR-01-005");
+    expect(detail.request_id).toBe("rid-body-123");
     expect(detail.details).toBeDefined();
     expect(Array.isArray(detail.details)).toBe(true);
   });
@@ -519,12 +522,30 @@ describe("RequestError.fromFetchError with StructuredError responses", () => {
     expect(error).toBeInstanceOf(BusinessError);
     expect(error).toBeInstanceOf(PhalaCloudError);
     expect(error.status).toBe(465);
+    expect(error.requestId).toBe("rid-body-123");
 
     // detail should still contain the StructuredError object
     expect(error.detail).toBeDefined();
     expect(typeof error.detail).toBe("object");
     const detail = error.detail as Record<string, unknown>;
     expect(detail.error_code).toBe("ERR-01-005");
+    expect(detail.request_id).toBe("rid-body-123");
     expect(Array.isArray(detail.details)).toBe(true);
+  });
+
+  it("should use X-Request-ID header when structured body omits request_id", () => {
+    const fetchError = makeStructuredFetchError(465) as Record<string, unknown>;
+    const data = fetchError.data as Record<string, unknown>;
+    delete data.request_id;
+    fetchError.response = {
+      headers: new Headers({ "X-Request-ID": "rid-header-456" }),
+    } as Response;
+
+    const requestError = RequestError.fromFetchError(fetchError as never);
+    const error = parseApiError(requestError);
+
+    expect(error).toBeInstanceOf(ResourceError);
+    expect(error.requestId).toBe("rid-header-456");
+    expect(formatStructuredError(error as ResourceError)).toContain("Request ID: rid-header-456");
   });
 });

--- a/js/src/utils/errors.ts
+++ b/js/src/utils/errors.ts
@@ -28,6 +28,20 @@ export const ApiErrorSchema = z.object({
 
 export type ApiError = z.infer<typeof ApiErrorSchema>;
 
+function extractRequestId(data: unknown): string | undefined {
+  if (!data || typeof data !== "object") {
+    return undefined;
+  }
+  const requestId = (data as Record<string, unknown>).request_id;
+  return typeof requestId === "string" ? requestId : undefined;
+}
+
+function extractRequestIdFromResponse(
+  response: { headers?: { get(name: string): string | null } } | undefined,
+): string | undefined {
+  return response?.headers?.get("X-Request-ID") ?? undefined;
+}
+
 /**
  * Structured validation error item from FastAPI/Pydantic
  */
@@ -52,6 +66,7 @@ export class PhalaCloudError extends Error {
     | string
     | Record<string, unknown>
     | Array<{ msg: string; type?: string; ctx?: Record<string, unknown> }>;
+  public readonly requestId?: string;
 
   constructor(
     message: string,
@@ -62,6 +77,7 @@ export class PhalaCloudError extends Error {
         | string
         | Record<string, unknown>
         | Array<{ msg: string; type?: string; ctx?: Record<string, unknown> }>;
+      requestId?: string;
     },
   ) {
     super(message);
@@ -69,6 +85,7 @@ export class PhalaCloudError extends Error {
     this.status = data.status;
     this.statusText = data.statusText;
     this.detail = data.detail;
+    this.requestId = data.requestId;
 
     // Maintains proper stack trace for where error was thrown (only available on V8)
     if (Error.captureStackTrace) {
@@ -112,12 +129,14 @@ export class RequestError extends PhalaCloudError implements ApiError {
           }>;
       code?: string | undefined;
       type?: string | undefined;
+      requestId?: string | undefined;
     },
   ) {
     super(message, {
       status: options?.status ?? 0,
       statusText: options?.statusText ?? "Unknown Error",
       detail: options?.detail || message,
+      requestId: options?.requestId,
     });
 
     this.data = options?.data;
@@ -131,6 +150,10 @@ export class RequestError extends PhalaCloudError implements ApiError {
    * Create RequestError from FetchError
    */
   static fromFetchError(error: FetchError): RequestError {
+    const bodyRequestId = extractRequestId(error.data);
+    const headerRequestId = extractRequestIdFromResponse(error.response);
+    const requestId = bodyRequestId ?? headerRequestId;
+
     // Try to parse the error response as ApiError
     const parseResult = ApiErrorSchema.safeParse(error.data);
 
@@ -163,6 +186,7 @@ export class RequestError extends PhalaCloudError implements ApiError {
             }>,
         code: parseResult.data.code ?? undefined,
         type: parseResult.data.type ?? undefined,
+        requestId,
       });
     }
 
@@ -175,6 +199,7 @@ export class RequestError extends PhalaCloudError implements ApiError {
       response: error.response ?? undefined,
       detail: error.data?.detail || "Unknown API error",
       code: error.status?.toString() ?? undefined,
+      requestId,
     });
   }
 
@@ -447,6 +472,7 @@ export function parseApiError(requestError: RequestError): PhalaCloudError {
       status,
       statusText,
       detail,
+      requestId: structured.request_id ?? requestError.requestId,
       errorCode: structured.error_code,
       structuredDetails: structured.details,
       suggestions: structured.suggestions,
@@ -457,7 +483,7 @@ export function parseApiError(requestError: RequestError): PhalaCloudError {
   // Fallback to original logic for backward compatibility
   const errorType = categorizeErrorType(status);
   const message = extractPrimaryMessage(status, detail, requestError.message);
-  const commonData = { status, statusText, detail };
+  const commonData = { status, statusText, detail, requestId: requestError.requestId };
 
   // Return appropriate error subclass
   if (errorType === "validation" && Array.isArray(detail)) {
@@ -641,6 +667,7 @@ export interface ErrorLink {
 export interface StructuredErrorResponse {
   error_code: string; // e.g., "ERR-01-001"
   message: string;
+  request_id?: string;
   details?: StructuredErrorDetail[];
   suggestions?: string[];
   links?: ErrorLink[];
@@ -676,6 +703,7 @@ export class ResourceError extends BusinessError {
             input?: unknown;
             [key: string]: unknown;
           }>;
+      requestId?: string;
       errorCode?: string;
       structuredDetails?: StructuredErrorDetail[];
       suggestions?: string[];
@@ -710,6 +738,7 @@ function parseStructuredError(detail: unknown): StructuredErrorResponse | null {
     return {
       error_code: obj.error_code,
       message: obj.message,
+      request_id: typeof obj.request_id === "string" ? obj.request_id : undefined,
       details: obj.details as StructuredErrorDetail[] | undefined,
       suggestions: obj.suggestions as string[] | undefined,
       links: obj.links as ErrorLink[] | undefined,
@@ -770,6 +799,10 @@ export function formatStructuredError(
     parts.push(`Error [${error.errorCode}]: ${error.message}`);
   } else {
     parts.push(error.message);
+  }
+
+  if (error.requestId) {
+    parts.push(`Request ID: ${error.requestId}`);
   }
 
   // Details

--- a/python/src/phala_cloud/client.py
+++ b/python/src/phala_cloud/client.py
@@ -249,12 +249,19 @@ class AsyncPhalaCloud:
         except Exception:
             pass
 
+        request_id = response.headers.get("X-Request-ID")
+        if isinstance(payload, dict):
+            body_request_id = payload.get("request_id")
+            if isinstance(body_request_id, str):
+                request_id = body_request_id
+
         status = response.status_code
         base_kwargs: dict[str, Any] = {
             "status_code": status,
             "message": message,
             "code": code,
             "detail": payload,
+            "request_id": request_id,
         }
 
         # Structured error (has error_code field)
@@ -475,12 +482,19 @@ class PhalaCloud:
         except Exception:
             pass
 
+        request_id = response.headers.get("X-Request-ID")
+        if isinstance(payload, dict):
+            body_request_id = payload.get("request_id")
+            if isinstance(body_request_id, str):
+                request_id = body_request_id
+
         status = response.status_code
         base_kwargs: dict[str, Any] = {
             "status_code": status,
             "message": message,
             "code": code,
             "detail": payload,
+            "request_id": request_id,
         }
 
         # Structured error (has error_code field)

--- a/python/src/phala_cloud/errors.py
+++ b/python/src/phala_cloud/errors.py
@@ -21,10 +21,12 @@ class ApiError(PhalaCloudError):
         message: str,
         code: str | None = None,
         detail: Any | None = None,
+        request_id: str | None = None,
     ) -> None:
         self.status_code = status_code
         self.code = code
         self.detail = detail
+        self.request_id = request_id
         super().__init__(message)
 
 
@@ -59,6 +61,7 @@ class ResourceError(BusinessError):
         message: str,
         code: str | None = None,
         detail: Any | None = None,
+        request_id: str | None = None,
         error_code: str | None = None,
         structured_details: list[dict[str, Any]] | None = None,
         suggestions: list[str] | None = None,
@@ -68,7 +71,13 @@ class ResourceError(BusinessError):
         self.structured_details = structured_details
         self.suggestions = suggestions
         self.links = links
-        super().__init__(status_code=status_code, message=message, code=code, detail=detail)
+        super().__init__(
+            status_code=status_code,
+            message=message,
+            code=code,
+            detail=detail,
+            request_id=request_id,
+        )
 
 
 class ValidationError(PhalaCloudError):

--- a/python/tests/test_465_structured_error.py
+++ b/python/tests/test_465_structured_error.py
@@ -4,7 +4,7 @@ import httpx
 import pytest
 
 from phala_cloud import AsyncPhalaCloud, PhalaCloud
-from phala_cloud.errors import ApiError
+from phala_cloud.errors import ApiError, ResourceError
 
 
 def _make_structured_465_response() -> httpx.Response:
@@ -13,6 +13,7 @@ def _make_structured_465_response() -> httpx.Response:
         json={
             "error_code": "ERR-01-005",
             "message": "Compose hash registration required on-chain",
+            "request_id": "rid-body-123",
             "details": [
                 {"field": "compose_hash", "value": "0xhash123", "message": None},
                 {"field": "app_id", "value": "0xapp456", "message": None},
@@ -123,6 +124,28 @@ class Test465StructuredErrorSync:
             with pytest.raises(ApiError):
                 c.update_cvm_envs({"id": "c1", "encrypted_env": "x"})
 
+    def test_structured_error_exposes_body_request_id(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                400,
+                json={
+                    "error_code": "ERR-01-005",
+                    "message": "Compose hash registration required on-chain",
+                    "request_id": "rid-body-123",
+                },
+                headers={"X-Request-ID": "rid-header-456"},
+            )
+
+        transport = httpx.MockTransport(handler)
+        with httpx.Client(
+            transport=transport, base_url="https://cloud-api.phala.com/api/v1"
+        ) as raw:
+            c = PhalaCloud(http_client=raw)
+            with pytest.raises(ResourceError) as exc_info:
+                c.get("/test")
+
+        assert exc_info.value.request_id == "rid-body-123"
+
 
 class Test465StructuredErrorAsync:
     @pytest.mark.anyio
@@ -201,3 +224,25 @@ class Test465StructuredErrorAsync:
             c = AsyncPhalaCloud(http_client=raw)
             with pytest.raises(ApiError):
                 await c.update_cvm_envs({"id": "c1", "encrypted_env": "x"})
+
+    @pytest.mark.anyio
+    async def test_structured_error_exposes_header_request_id(self) -> None:
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                400,
+                json={
+                    "error_code": "ERR-01-005",
+                    "message": "Compose hash registration required on-chain",
+                },
+                headers={"X-Request-ID": "rid-header-456"},
+            )
+
+        transport = httpx.MockTransport(handler)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="https://cloud-api.phala.com/api/v1"
+        ) as raw:
+            c = AsyncPhalaCloud(http_client=raw)
+            with pytest.raises(ResourceError) as exc_info:
+                await c.get("/test")
+
+        assert exc_info.value.request_id == "rid-header-456"


### PR DESCRIPTION
## Summary
- capture request IDs from structured error bodies and X-Request-ID headers in JS, Python, and Go SDK errors
- expose request ID fields on SDK error types
- include request IDs in JS and Go structured error formatting

## Tests
- cd sdks/js && bun run lint && bun run type-check && bun run test
- cd sdks/python && pdm run ruff check src/phala_cloud/errors.py src/phala_cloud/client.py tests/test_465_structured_error.py
- cd sdks/python && pdm run python -m compileall -q src/phala_cloud tests/test_465_structured_error.py
- cd sdks/python && pdm run pytest
- cd sdks/go && go test ./...
