### PR TITLE
feat: add llama-cpp template

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -285,6 +285,66 @@
     "tags": ["AI Agents", "Data & Storage"]
   },
   {
+    "id": "llama-cpp",
+    "name": "ggerganov/llama.cpp",
+    "description": "C/C++ LLM inference engine; runs on CPU/GPU, deployable anywhere",
+    "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/llama-cpp",
+    "author": "llama.cpp / ggml-org / ggerganov",
+    "icon": "llama-cpp.svg",
+    "envs": [
+      {
+        "key": "MODEL_URL",
+        "required": false,
+        "default": "https://huggingface.co/ggml-org/test-model-stories260K/resolve/main/stories260K-f32.gguf",
+        "description": "Public HTTPS URL for the GGUF model downloaded at startup. Use only model URLs you trust."
+      },
+      {
+        "key": "MODEL_FILE",
+        "required": false,
+        "default": "stories260K-f32.gguf",
+        "description": "Plain file name used for the downloaded model inside the /models volume."
+      },
+      {
+        "key": "LLAMA_ARG_MODEL",
+        "required": false,
+        "default": "",
+        "description": "Optional explicit model path for llama-server. Leave empty to use /models/$MODEL_FILE."
+      },
+      {
+        "key": "LLAMA_ARG_CTX_SIZE",
+        "required": false,
+        "default": "512",
+        "description": "Context size for the demo server."
+      },
+      {
+        "key": "LLAMA_ARG_HOST",
+        "required": false,
+        "default": "0.0.0.0",
+        "description": "Listen address inside the container. Keep 0.0.0.0 on Phala Cloud."
+      },
+      {
+        "key": "LLAMA_ARG_PORT",
+        "required": false,
+        "default": "8080",
+        "description": "Internal llama.cpp server port. Caddy proxies to this port."
+      },
+      {
+        "key": "LLAMA_ARG_THREADS",
+        "required": false,
+        "default": "1",
+        "description": "CPU worker threads. The default is conservative for small CVMs."
+      },
+      {
+        "key": "LLAMA_ARG_N_PREDICT",
+        "required": false,
+        "default": "64",
+        "description": "Default generation limit for llama.cpp requests that do not specify their own limit."
+      }
+    ],
+    "defaultResource": { "vCPU": 1, "memory": 1024, "diskSize": 10 },
+    "tags": ["LLM Inference", "Developer Tools", "TEE & Privacy"]
+  },
+  {
     "id": "anyone-anon-service",
     "name": "Anyone Anon Service",
     "description": "Sets up a Anyone Anon (hidden) service and serves an nginx website from that.",

--- a/templates/icons/llama-cpp.svg
+++ b/templates/icons/llama-cpp.svg
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="Layer_1"
+   version="1.1"
+   viewBox="0 0 250 250"
+   sodipodi:docname="llama1-icon-transparent.svg"
+   width="250"
+   height="250"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     inkscape:zoom="2.48"
+     inkscape:cx="49.596774"
+     inkscape:cy="189.91935"
+     inkscape:window-width="3440"
+     inkscape:window-height="1440"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Layer_1" />
+  <!-- Generator: Adobe Illustrator 29.3.1, SVG Export Plug-In . SVG Version: 2.1.0 Build 151)  -->
+  <defs
+     id="defs1">
+    <style
+       id="style1">
+      .st0 {
+        fill: #ff8236;
+      }
+
+      .st1 {
+        fill: #fff;
+      }
+
+      .st2 {
+        fill: #1b1f20;
+      }
+    </style>
+  </defs>
+  <g
+     id="g7">
+    <g
+       id="g6"
+       transform="translate(-995.51066,-129.70875)">
+      <path
+         class="st0"
+         d="m 1163.3,226.8 -13.5,24 c -17.8,-13.7 -44.2,-15.7 -62,-1 -28.7,23.7 -26.7,78.5 18,78.8 12.5,0 23.1,-5.9 34.5,-9.8 l 6,23.9 c -10.1,4.7 -20.4,9.5 -31.5,11 -101.2,13.8 -95.4,-132.3 -3.9,-139.9 19.2,-1.6 36.1,3.4 52.5,13 z"
+         id="path4" />
+      <path
+         class="st0"
+         d="m 1093.4,203.8 c -15.4,4.6 -29.7,13.1 -40.5,25 -2,-24.2 3.4,-73.1 30.3,-82.7 4,-1.4 17.7,-4.9 17.3,2.2 -0.4,7.1 -9.9,19.3 -12.2,25.9 -4,11.6 -0.3,19.6 5.2,29.7 z"
+         id="path5" />
+      <polygon
+         class="st0"
+         points="1131.4,307.8 1116.4,307.8 1116.4,290.8 1099.4,290.8 1099.4,276.8 1114.9,276.8 1116.4,275.3 1116.4,258.8 1131.4,258.8 1131.4,276.8 1147.4,276.8 1147.4,290.8 1131.4,290.8 "
+         id="polygon5" />
+      <polygon
+         class="st0"
+         points="1186.4,290.8 1186.4,307.8 1171.4,307.8 1171.4,290.8 1155.4,290.8 1155.4,276.8 1171.4,276.8 1171.4,258.8 1186.4,258.8 1186.4,275.3 1187.9,276.8 1203.4,276.8 1203.4,290.8 "
+         id="polygon6" />
+      <path
+         class="st0"
+         d="m 1142.3,156.9 c 2,3 -9.3,15.9 -11.1,19.2 -5.2,9.8 -1.7,15.4 2.2,24.7 -11.3,-1.7 -21.8,-0.3 -33,1 2.5,-21.5 14.6,-52.8 41.9,-44.9 z"
+         id="path6" />
+    </g>
+  </g>
+</svg>

--- a/templates/prebuilt/llama-cpp/README.md
+++ b/templates/prebuilt/llama-cpp/README.md
@@ -1,0 +1,102 @@
+# ggerganov/llama.cpp
+
+Deploy a CPU-safe llama.cpp inference server on Phala Cloud.
+
+This template runs the official `ghcr.io/ggml-org/llama.cpp:server` image and downloads a tiny public GGUF model into a named Docker volume before starting `llama-server`. The service exposes the llama.cpp HTTP API, including OpenAI-compatible endpoints, through a Caddy reverse proxy.
+
+## Upstream
+
+- Project: [ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp)
+- Original queued repository: [ggerganov/llama.cpp](https://github.com/ggerganov/llama.cpp)
+- Runtime image: `ghcr.io/ggml-org/llama.cpp:server`
+- Demo model: [ggml-org/test-model-stories260K](https://huggingface.co/ggml-org/test-model-stories260K)
+
+`llama.cpp` is maintained by ggml-org and originated with Georgi Gerganov (`ggerganov`).
+
+## Services
+
+- `model-init`: Downloads the configured GGUF model into the `llama_models` volume.
+- `llama-server`: Runs the llama.cpp HTTP server on the internal Docker network.
+- `proxy`: Publishes the server through Caddy on port `8080`.
+
+## Environment Variables
+
+All variables are optional for the smoke-test deployment.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `MODEL_URL` | `https://huggingface.co/ggml-org/test-model-stories260K/resolve/main/stories260K-f32.gguf` | Public HTTPS URL for the GGUF model downloaded at startup. Use only model URLs you trust. |
+| `MODEL_FILE` | `stories260K-f32.gguf` | File name used inside the `/models` volume. Use a plain file name, not a path. |
+| `LLAMA_ARG_MODEL` | empty | Optional explicit model path passed to `llama-server`. Leave empty to use `/models/$MODEL_FILE`. |
+| `LLAMA_ARG_CTX_SIZE` | `512` | Context size for the demo server. Increase only when the model and CVM memory can support it. |
+| `LLAMA_ARG_HOST` | `0.0.0.0` | Listen address inside the container. Keep this default on Phala Cloud. |
+| `LLAMA_ARG_PORT` | `8080` | Internal llama.cpp server port. Caddy uses the same value for proxying. |
+| `LLAMA_ARG_THREADS` | `1` | CPU worker threads. The default is conservative for small CVMs. |
+| `LLAMA_ARG_N_PREDICT` | `64` | Default generation limit for llama.cpp requests that do not specify their own limit. |
+
+The defaults are intentionally small so the template can smoke test on a CPU-only deployment. For a real model, set `MODEL_URL`, `MODEL_FILE`, and resource sizing together. If you reuse the same `MODEL_FILE` with a different `MODEL_URL`, clear the `llama_models` volume or use a new file name so the initializer downloads the new model.
+
+## Deploy on Phala Cloud
+
+1. Create a new Phala Cloud deployment from this template.
+2. Keep the default environment variables for the first smoke test.
+3. Deploy the CVM.
+4. Wait for `model-init` to finish and for `llama-server` to become healthy.
+5. Open `https://<your-app-domain>` or send API requests to that domain.
+
+## Verify
+
+Health check:
+
+```bash
+curl -fsS https://<your-app-domain>/health
+```
+
+List the loaded model through the OpenAI-compatible API:
+
+```bash
+curl -fsS https://<your-app-domain>/v1/models
+```
+
+OpenAI-compatible completion request:
+
+```bash
+curl -fsS https://<your-app-domain>/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "local",
+    "prompt": "Once upon a time",
+    "max_tokens": 16,
+    "temperature": 0.2
+  }'
+```
+
+Native llama.cpp completion request:
+
+```bash
+curl -fsS https://<your-app-domain>/completion \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "prompt": "Once upon a time",
+    "n_predict": 16,
+    "temperature": 0.2
+  }'
+```
+
+The default model is a tiny test model for deployment verification, not a useful assistant. Replace it with a production GGUF model for real inference.
+
+## Security Notes
+
+- Do not put API keys, private model URLs, tokens, or credentials in examples, screenshots, or shared template settings.
+- `MODEL_URL` is fetched by the deployment. Only use models from publishers you trust, and review the model license and provenance before production use.
+- The template exposes an unauthenticated HTTP API by default. Add access control at your ingress layer or deploy behind a protected gateway before serving sensitive workloads.
+- Treat prompts and completions as application data. Do not send confidential information to a model or endpoint unless your own threat model allows it.
+- Larger models can exhaust memory or disk on small CVMs. Increase `defaultResource`-equivalent deployment resources when changing the model.
+
+## Persistent Data
+
+- `llama_models`: Named Docker volume mounted at `/models`. It stores the downloaded GGUF model across container restarts.
+
+## Icon Source
+
+The template icon is `llama-cpp.svg`, copied from the upstream llama.cpp repository asset [`media/llama1-icon-transparent.svg`](https://github.com/ggml-org/llama.cpp/blob/master/media/llama1-icon-transparent.svg).

--- a/templates/prebuilt/llama-cpp/docker-compose.yml
+++ b/templates/prebuilt/llama-cpp/docker-compose.yml
@@ -1,0 +1,99 @@
+services:
+  model-init:
+    image: curlimages/curl:8.11.1
+    user: root
+    restart: "no"
+    environment:
+      MODEL_URL: ${MODEL_URL:-https://huggingface.co/ggml-org/test-model-stories260K/resolve/main/stories260K-f32.gguf}
+      MODEL_FILE: ${MODEL_FILE:-stories260K-f32.gguf}
+    volumes:
+      - llama_models:/models
+    entrypoint: ["/bin/sh", "-lc"]
+    command:
+      - |
+        set -eu
+        case "$$MODEL_FILE" in
+          ""|/*|*/*|*..*)
+            echo "MODEL_FILE must be a plain file name inside /models" >&2
+            exit 1
+            ;;
+        esac
+        model_path="/models/$$MODEL_FILE"
+        if [ ! -s "$$model_path" ]; then
+          tmp_path="$${model_path}.tmp"
+          rm -f "$$tmp_path"
+          curl -fL --retry 5 --retry-delay 2 --connect-timeout 20 --output "$$tmp_path" "$$MODEL_URL"
+          mv "$$tmp_path" "$$model_path"
+        fi
+        ls -lh "$$model_path"
+    networks:
+      - internal
+
+  llama-server:
+    image: ghcr.io/ggml-org/llama.cpp:server
+    restart: unless-stopped
+    depends_on:
+      model-init:
+        condition: service_completed_successfully
+    environment:
+      MODEL_FILE: ${MODEL_FILE:-stories260K-f32.gguf}
+      LLAMA_ARG_MODEL: ${LLAMA_ARG_MODEL:-}
+      LLAMA_ARG_CTX_SIZE: ${LLAMA_ARG_CTX_SIZE:-512}
+      LLAMA_ARG_HOST: ${LLAMA_ARG_HOST:-0.0.0.0}
+      LLAMA_ARG_PORT: ${LLAMA_ARG_PORT:-8080}
+      LLAMA_ARG_THREADS: ${LLAMA_ARG_THREADS:-1}
+      LLAMA_ARG_N_PREDICT: ${LLAMA_ARG_N_PREDICT:-64}
+    volumes:
+      - llama_models:/models:ro
+    expose:
+      - "8080"
+    entrypoint: ["/bin/sh", "-lc"]
+    command:
+      - |
+        set -eu
+        model="$${LLAMA_ARG_MODEL:-/models/$$MODEL_FILE}"
+        exec /app/llama-server \
+          --model "$$model" \
+          --host "$$LLAMA_ARG_HOST" \
+          --port "$$LLAMA_ARG_PORT" \
+          --ctx-size "$$LLAMA_ARG_CTX_SIZE" \
+          --threads "$$LLAMA_ARG_THREADS" \
+          --n-predict "$$LLAMA_ARG_N_PREDICT"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:$${LLAMA_ARG_PORT:-8080}/health >/dev/null"]
+      interval: 15s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    restart: unless-stopped
+    depends_on:
+      llama-server:
+        condition: service_healthy
+    ports:
+      - "8080:80"
+    environment:
+      LLAMA_ARG_PORT: ${LLAMA_ARG_PORT:-8080}
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          reverse_proxy llama-server:{env.LLAMA_ARG_PORT}
+      }
+
+networks:
+  internal:
+    driver: bridge
+
+volumes:
+  llama_models:


### PR DESCRIPTION
## Summary
- Add a CPU-safe `llama-cpp` prebuilt template for `ggerganov/llama.cpp` / `ggml-org/llama.cpp`.
- Run the official `ghcr.io/ggml-org/llama.cpp:server` image behind Caddy.
- Download a tiny public GGUF model at startup for real smoke testing on `tdx.small`.

## Upstream repo
- https://github.com/ggerganov/llama.cpp
- Current project home: https://github.com/ggml-org/llama.cpp

## Template files
- `templates/prebuilt/llama-cpp/docker-compose.yml`
- `templates/prebuilt/llama-cpp/README.md`
- `templates/icons/llama-cpp.svg`
- `templates/config.json`

## Environment variables
- `MODEL_URL` (optional): public HTTPS URL for the GGUF model downloaded at startup.
- `MODEL_FILE` (optional): plain filename stored under `/models`.
- `LLAMA_ARG_MODEL` (optional): explicit model path override.
- `LLAMA_ARG_CTX_SIZE` (optional): context size, default `512`.
- `LLAMA_ARG_HOST` (optional): internal bind host, default `0.0.0.0`.
- `LLAMA_ARG_PORT` (optional): internal server port, default `8080`.
- `LLAMA_ARG_THREADS` (optional): CPU threads, default `1`.
- `LLAMA_ARG_N_PREDICT` (optional): default generation limit, default `64`.

## Icon source
- `templates/icons/llama-cpp.svg` is copied from upstream `media/llama1-icon-transparent.svg` in `ggml-org/llama.cpp`.

## Validation
- `python sdks/templates/validate.py` ✅
  - Existing warnings only: unused `mcp-jupyter.svg` and `maybe-finance.png`.
- `git -C sdks diff --check origin/main...HEAD` ✅
- `docker compose -f sdks/templates/prebuilt/llama-cpp/docker-compose.yml config >/dev/null` ✅
- Static audit ✅
  - README has deployment, env, verification, security, and icon-source sections.
  - Config ID is unique.
  - Compose has a proxy/port, no `env_file`, no host bind mount, no external build context, and no literal secrets.
- Runtime image manifest check ✅
  - `ghcr.io/ggml-org/llama.cpp:server` includes `linux/amd64`.
  - `curlimages/curl:8.11.1` includes `linux/amd64`.

## Phala Cloud deployment smoke
- Command: `phala deploy --name auto-template-test-llama-cpp-0521-2303 --compose sdks/templates/prebuilt/llama-cpp/docker-compose.yml --instance-type tdx.small --wait --no-public-logs --no-public-sysinfo --json`
- CVM UUID: `c177ab96-4d0b-47be-8e36-8a2a242682cb`
- App ID: `89f524665483f2a58bcc46b2e0a9870e566319a6`
- `phala ps --cvm-id c177ab96-4d0b-47be-8e36-8a2a242682cb --json` ✅
  - `dstack-model-init-1`: `Exited (0)`
  - `dstack-llama-server-1`: `running`, `healthy`
  - `dstack-proxy-1`: `running`
- HTTP smoke ✅
  - `GET /health` -> HTTP 200, `{"status":"ok"}`
  - `GET /v1/models` -> HTTP 200, listed `stories260K-f32.gguf`
  - `POST /completion` -> HTTP 200, generated text from the tiny demo model

## Cleanup
- Temporary CVM cleanup succeeded.
- `phala cvms get --cvm-id c177ab96-4d0b-47be-8e36-8a2a242682cb --json` returned `The requested CVM was not found` after cleanup.
