### PR TITLE
Use hashed CVM IDs in SDK schemas

### DIFF
--- a/go/types_apps.go
+++ b/go/types_apps.go
@@ -89,11 +89,11 @@ type AppAttestationResponse = GenericObject
 
 // DeviceAllowlistItem represents an item in the device allowlist.
 type DeviceAllowlistItem struct {
-	DeviceID       string  `json:"device_id"`
-	NodeName       *string `json:"node_name,omitempty"`
-	CVMIDs         []int   `json:"cvm_ids,omitempty"`
-	AllowedOnchain bool    `json:"allowed_onchain"`
-	Status         string  `json:"status"`
+	DeviceID       string   `json:"device_id"`
+	NodeName       *string  `json:"node_name,omitempty"`
+	CVMIDs         []string `json:"cvm_ids,omitempty"`
+	AllowedOnchain bool     `json:"allowed_onchain"`
+	Status         string   `json:"status"`
 }
 
 // DeviceAllowlistResponse is the response for getting app device allowlist.

--- a/go/types_cvms.go
+++ b/go/types_cvms.go
@@ -378,7 +378,7 @@ type CVMVisibility struct {
 
 // IsAllowedResult represents the result of an on-chain allowance check.
 type IsAllowedResult struct {
-	CvmID              int     `json:"cvm_id,omitempty"`
+	CvmID              string  `json:"cvm_id,omitempty"`
 	AppContractAddress string  `json:"app_contract_address"`
 	ComposeHash        string  `json:"compose_hash"`
 	DeviceID           string  `json:"device_id"`
@@ -412,7 +412,7 @@ type AppCvmsBatchIsAllowedResponse struct {
 	AllowedCount  int               `json:"allowed_count"`
 	DeniedCount   int               `json:"denied_count"`
 	ErrorCount    int               `json:"error_count"`
-	SkippedCvmIDs []int             `json:"skipped_cvm_ids"`
+	SkippedCvmIDs []string          `json:"skipped_cvm_ids"`
 }
 
 // OSImage represents an available OS image.

--- a/js/src/actions/apps/check_app_cvms_is_allowed.ts
+++ b/js/src/actions/apps/check_app_cvms_is_allowed.ts
@@ -4,12 +4,12 @@ import { IsAllowedResultSchema } from "../cvms/check_cvm_is_allowed";
 
 export const AppCvmsBatchIsAllowedResponseSchema = z.object({
   is_onchain: z.boolean(),
-  results: z.array(IsAllowedResultSchema.extend({ cvm_id: z.number() })).default([]),
+  results: z.array(IsAllowedResultSchema.extend({ cvm_id: z.string() })).default([]),
   total: z.number().default(0),
   allowed_count: z.number().default(0),
   denied_count: z.number().default(0),
   error_count: z.number().default(0),
-  skipped_cvm_ids: z.array(z.number()).default([]),
+  skipped_cvm_ids: z.array(z.string()).default([]),
 });
 
 export type AppCvmsBatchIsAllowedResponse = z.infer<typeof AppCvmsBatchIsAllowedResponseSchema>;

--- a/js/src/actions/apps/get_app_device_allowlist.ts
+++ b/js/src/actions/apps/get_app_device_allowlist.ts
@@ -5,7 +5,7 @@ import type { ApiVersion } from "../../types/client";
 const DeviceAllowlistItemSchema = z.object({
   device_id: z.string(),
   node_name: z.string().nullable(),
-  cvm_ids: z.array(z.number()),
+  cvm_ids: z.array(z.string()),
   allowed_onchain: z.boolean(),
   status: z.string(),
 });

--- a/js/src/actions/cvms/check_cvm_is_allowed.ts
+++ b/js/src/actions/cvms/check_cvm_is_allowed.ts
@@ -3,7 +3,7 @@ import { defineAction } from "../../utils/define-action";
 import { CvmIdSchema, type CvmIdInput } from "../../types/cvm_id";
 
 export const IsAllowedResultSchema = z.object({
-  cvm_id: z.number().optional(),
+  cvm_id: z.string().optional(),
   app_contract_address: z.string(),
   compose_hash: z.string(),
   device_id: z.string(),

--- a/js/src/actions/cvms/refresh_cvm_instance_id.test.ts
+++ b/js/src/actions/cvms/refresh_cvm_instance_id.test.ts
@@ -52,4 +52,18 @@ describe("refreshCvmInstanceId", () => {
 
     expect(result.success).toBe(true);
   });
+
+  it("accepts skipped results without a resolved CVM ID", async () => {
+    const skippedResponse = {
+      ...mockResponse,
+      cvm_id: null,
+      status: "skipped" as const,
+      reason: "invalid_identifier",
+    };
+    mockPatch.mockResolvedValue(skippedResponse);
+
+    const result = await refreshCvmInstanceId(client, { id: "101" });
+
+    expect(result.cvm_id).toBeNull();
+  });
 });

--- a/js/src/actions/cvms/refresh_cvm_instance_id.test.ts
+++ b/js/src/actions/cvms/refresh_cvm_instance_id.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe("refreshCvmInstanceId", () => {
   const mockResponse = {
-    cvm_id: 101,
+    cvm_id: "cvm_101",
     identifier: "101",
     status: "updated" as const,
     old_instance_id: null,

--- a/js/src/actions/cvms/refresh_cvm_instance_id.ts
+++ b/js/src/actions/cvms/refresh_cvm_instance_id.ts
@@ -3,7 +3,7 @@ import { CvmIdObjectSchema, CvmIdSchema, refineCvmId } from "../../types/cvm_id"
 import { defineAction } from "../../utils/define-action";
 
 export const InstanceIdRefreshResultSchema = z.object({
-  cvm_id: z.number().int(),
+  cvm_id: z.string(),
   identifier: z.string(),
   status: z.enum(["updated", "unchanged", "skipped", "conflict", "error"]),
   old_instance_id: z.string().nullable().optional(),

--- a/js/src/actions/cvms/refresh_cvm_instance_id.ts
+++ b/js/src/actions/cvms/refresh_cvm_instance_id.ts
@@ -3,7 +3,7 @@ import { CvmIdObjectSchema, CvmIdSchema, refineCvmId } from "../../types/cvm_id"
 import { defineAction } from "../../utils/define-action";
 
 export const InstanceIdRefreshResultSchema = z.object({
-  cvm_id: z.string(),
+  cvm_id: z.string().nullable(),
   identifier: z.string(),
   status: z.enum(["updated", "unchanged", "skipped", "conflict", "error"]),
   old_instance_id: z.string().nullable().optional(),

--- a/js/src/actions/cvms/refresh_cvm_instance_ids.test.ts
+++ b/js/src/actions/cvms/refresh_cvm_instance_ids.test.ts
@@ -26,14 +26,14 @@ describe("refreshCvmInstanceIds", () => {
         reason: null,
       },
       {
-        cvm_id: "cvm_102",
+        cvm_id: null,
         identifier: "102",
-        status: "unchanged" as const,
+        status: "skipped" as const,
         old_instance_id: "inst-def",
-        new_instance_id: "inst-def",
+        new_instance_id: null,
         source: "teepod_state" as const,
         verified_with_gateway: false,
-        reason: "already_synced",
+        reason: "not_found",
       },
     ],
   };

--- a/js/src/actions/cvms/refresh_cvm_instance_ids.test.ts
+++ b/js/src/actions/cvms/refresh_cvm_instance_ids.test.ts
@@ -16,7 +16,7 @@ describe("refreshCvmInstanceIds", () => {
     errors: 0,
     items: [
       {
-        cvm_id: 101,
+        cvm_id: "cvm_101",
         identifier: "101",
         status: "updated" as const,
         old_instance_id: null,
@@ -26,7 +26,7 @@ describe("refreshCvmInstanceIds", () => {
         reason: null,
       },
       {
-        cvm_id: 102,
+        cvm_id: "cvm_102",
         identifier: "102",
         status: "unchanged" as const,
         old_instance_id: "inst-def",

--- a/python/src/phala_cloud/models/apps.py
+++ b/python/src/phala_cloud/models/apps.py
@@ -75,7 +75,7 @@ class AppRevisionsResponse(CloudModel):
 class DeviceAllowlistItem(CloudModel):
     device_id: str
     node_name: str | None = None
-    cvm_ids: list[int] = Field(default_factory=list)
+    cvm_ids: list[str] = Field(default_factory=list)
     allowed_onchain: bool
     status: str
 

--- a/python/src/phala_cloud/models/cvms.py
+++ b/python/src/phala_cloud/models/cvms.py
@@ -249,7 +249,7 @@ class CheckCvmIsAllowedRequest(AliasModel):
 
 
 class IsAllowedResult(CloudModel):
-    cvm_id: int | None = None
+    cvm_id: str | None = None
     app_contract_address: str
     compose_hash: str
     device_id: str
@@ -279,4 +279,4 @@ class AppCvmsBatchIsAllowedResponse(CloudModel):
     allowed_count: int = 0
     denied_count: int = 0
     error_count: int = 0
-    skipped_cvm_ids: list[int] = Field(default_factory=list)
+    skipped_cvm_ids: list[str] = Field(default_factory=list)


### PR DESCRIPTION
## Summary
- Change CVM ID fields in SDK schemas from numeric IDs to hashed string IDs.
- Update JS, Python, and Go SDK response types for CVM/app allow checks, device allowlists, and instance refresh results.

## Tests
- bun test src/actions/cvms/refresh_cvm_instance_id.test.ts src/actions/cvms/refresh_cvm_instance_ids.test.ts
- bun run type-check (sdks/js)
- bun run lint (sdks/js)
- bun run fmt (sdks/js)
- go test ./... (sdks/go)
- python -m compileall -q src (sdks/python)