### PR TITLE
fix: friendly timeout errors + CLI --timeout flag

### DIFF
--- a/cli/src/commands/cvms/list/index.ts
+++ b/cli/src/commands/cvms/list/index.ts
@@ -39,6 +39,7 @@ async function runCvmsListCommand(
 		});
 
 		if (result.success === false) {
+			logger.logDetailedError(result.error.cause ?? result.error);
 			context.fail(result.error.message);
 			return 1;
 		}

--- a/cli/src/commands/cvms/list/index.ts
+++ b/cli/src/commands/cvms/list/index.ts
@@ -1,10 +1,23 @@
 import chalk from "chalk";
 import { defineCommand } from "@/src/core/define-command";
 import type { CommandContext } from "@/src/core/types";
-import { getClient } from "@/src/lib/client";
+import { getClient, resolveTimeoutSeconds } from "@/src/lib/client";
 import { listAppsWithCvmStatus } from "@/src/lib/apps/list-apps-with-cvm-status";
 import { printTable } from "@/src/lib/table";
 import { logger } from "@/src/utils/logger";
+
+function isTimeoutCause(cause: unknown): boolean {
+	return (
+		cause !== null &&
+		typeof cause === "object" &&
+		"code" in cause &&
+		(cause as { code?: unknown }).code === "TIMEOUT"
+	);
+}
+
+function formatTimeoutMessage(timeoutSeconds: number): string {
+	return `Request timed out after ${timeoutSeconds}s.\n  Retry with --timeout <seconds> to allow more time.`;
+}
 
 import {
 	cvmsListCommandMeta,
@@ -39,8 +52,12 @@ async function runCvmsListCommand(
 		});
 
 		if (result.success === false) {
-			logger.logDetailedError(result.error.cause ?? result.error);
-			context.fail(result.error.message);
+			const cause = result.error.cause;
+			logger.logDetailedError(cause ?? result.error);
+			const message = isTimeoutCause(cause)
+				? formatTimeoutMessage(resolveTimeoutSeconds(context))
+				: result.error.message;
+			context.fail(message);
 			return 1;
 		}
 

--- a/cli/src/core/common-flags.ts
+++ b/cli/src/core/common-flags.ts
@@ -70,6 +70,15 @@ export const apiVersionOption: CommandOption = {
 	group: "advanced",
 };
 
+export const timeoutOption: CommandOption = {
+	name: "timeout",
+	description: "Request timeout in seconds (default 60)",
+	type: "number",
+	target: "timeout",
+	argumentName: "seconds",
+	group: "advanced",
+};
+
 export const commonAuthOptions: readonly CommandOption[] = [apiTokenOption];
 
 /**
@@ -159,4 +168,5 @@ export const globalCommandOptions: readonly CommandOption[] = [
 	cvmIdOption,
 	profileOption,
 	apiVersionOption,
+	timeoutOption,
 ];

--- a/cli/src/core/dispatcher.ts
+++ b/cli/src/core/dispatcher.ts
@@ -187,6 +187,18 @@ export async function dispatchCommand(
 			parsedArguments,
 		);
 
+		const rawTimeout = schemaInput.options.timeout;
+		let timeoutSeconds: number | undefined;
+		if (typeof rawTimeout === "number") {
+			if (!Number.isFinite(rawTimeout) || rawTimeout <= 0) {
+				stderr.write(
+					`Invalid --timeout value "${rawTimeout}". Must be a positive number of seconds.\n`,
+				);
+				return 1;
+			}
+			timeoutSeconds = rawTimeout;
+		}
+
 		const globalOptions = {
 			apiToken:
 				typeof schemaInput.options.apiToken === "string"
@@ -202,6 +214,7 @@ export async function dispatchCommand(
 					? schemaInput.options.profile
 					: undefined,
 			apiVersion: typeof rawApiVersion === "string" ? rawApiVersion : undefined,
+			timeout: timeoutSeconds,
 		} as const;
 
 		const mergedInput = {

--- a/cli/src/core/types.ts
+++ b/cli/src/core/types.ts
@@ -85,6 +85,8 @@ export interface CommandGlobalOptions {
 	readonly interactive: boolean;
 	readonly profile?: string;
 	readonly apiVersion?: string;
+	/** Request timeout in seconds (overrides SDK default). */
+	readonly timeout?: number;
 }
 
 export interface CommandContext {

--- a/cli/src/lib/apps/list-apps-with-cvm-status.ts
+++ b/cli/src/lib/apps/list-apps-with-cvm-status.ts
@@ -57,7 +57,13 @@ export async function listAppsWithCvmStatus(
 	});
 
 	if (!appListResult.success) {
-		return { success: false, error: { message: appListResult.error.message } };
+		return {
+			success: false,
+			error: {
+				message: appListResult.error.message,
+				cause: appListResult.error,
+			},
+		};
 	}
 
 	const appList = appListResult.data;
@@ -86,7 +92,13 @@ export async function listAppsWithCvmStatus(
 	for (const uuids of chunk(vmUuids, 100)) {
 		const batchResult = await safeGetCvmStatusBatch(client, { vmUuids: uuids });
 		if (!batchResult.success) {
-			return { success: false, error: { message: batchResult.error.message } };
+			return {
+				success: false,
+				error: {
+					message: batchResult.error.message,
+					cause: batchResult.error,
+				},
+			};
 		}
 
 		for (const [uuid, status] of Object.entries(batchResult.data)) {

--- a/cli/src/lib/client.ts
+++ b/cli/src/lib/client.ts
@@ -50,10 +50,12 @@ export async function getClient(
 ): Promise<CliApiClient> {
 	const auth = resolveAuthForContext(context, options);
 	const version = getApiVersionOverride() ?? API_VERSION;
+	const timeoutSeconds = context?.globalOptions?.timeout;
 	return createClient({
 		apiKey: auth.apiKey ?? undefined,
 		baseURL: auth.baseURL,
 		version,
+		...(timeoutSeconds !== undefined ? { timeout: timeoutSeconds * 1000 } : {}),
 	}) as CliApiClient;
 }
 

--- a/cli/src/lib/client.ts
+++ b/cli/src/lib/client.ts
@@ -6,7 +6,15 @@ import { resolveAuth, type ResolvedAuth } from "@/src/utils/credentials";
 
 const API_VERSION = "2026-01-21" as const;
 
+/** Default request timeout (seconds) when no --timeout flag is supplied. */
+export const DEFAULT_TIMEOUT_SECONDS = 60;
+
 export type CliApiClient = Client<typeof API_VERSION>;
+
+/** Resolve the request timeout (seconds) the CLI will use for this command. */
+export function resolveTimeoutSeconds(context?: AuthContextLike): number {
+	return context?.globalOptions?.timeout ?? DEFAULT_TIMEOUT_SECONDS;
+}
 
 export interface ClientWithAuth {
 	readonly client: CliApiClient;
@@ -50,12 +58,12 @@ export async function getClient(
 ): Promise<CliApiClient> {
 	const auth = resolveAuthForContext(context, options);
 	const version = getApiVersionOverride() ?? API_VERSION;
-	const timeoutSeconds = context?.globalOptions?.timeout;
+	const timeoutSeconds = resolveTimeoutSeconds(context);
 	return createClient({
 		apiKey: auth.apiKey ?? undefined,
 		baseURL: auth.baseURL,
 		version,
-		...(timeoutSeconds !== undefined ? { timeout: timeoutSeconds * 1000 } : {}),
+		timeout: timeoutSeconds * 1000,
 	}) as CliApiClient;
 }
 

--- a/cli/src/lib/result.ts
+++ b/cli/src/lib/result.ts
@@ -1,6 +1,13 @@
+export interface ResultError {
+	readonly message: string;
+	/** Original underlying error (e.g. RequestError from SDK), preserved so
+	 *  callers can introspect HTTP status, response data, etc. */
+	readonly cause?: unknown;
+}
+
 export type Result<T> =
 	| { success: true; data: T }
-	| { success: false; error: { message: string } };
+	| { success: false; error: ResultError };
 
 export function isOk<T>(
 	result: Result<T>,
@@ -10,6 +17,6 @@ export function isOk<T>(
 
 export function isErr<T>(
 	result: Result<T>,
-): result is { success: false; error: { message: string } } {
+): result is { success: false; error: ResultError } {
 	return !result.success;
 }

--- a/cli/src/utils/logger.ts
+++ b/cli/src/utils/logger.ts
@@ -462,24 +462,21 @@ export const logger = {
 
 		const prefix = context ? `[${context}] ` : "";
 
-		// Type guard for request errors (RequestError from SDK)
-		const isRequestError = (
+		// SDK errors (RequestError and its PhalaCloudError subclasses share
+		// `status` / `statusText` / `detail` / `data` / `requestId` fields).
+		const isSdkError = (
 			err: unknown,
 		): err is {
-			isRequestError: true;
-			status: number;
-			statusText: string;
-			message: string;
+			status?: number;
+			statusText?: string;
 			data?: unknown;
+			detail?: unknown;
+			requestId?: string;
 		} => {
 			return (
 				err !== null &&
 				typeof err === "object" &&
-				"isRequestError" in err &&
-				err.isRequestError === true &&
-				"status" in err &&
-				"message" in err &&
-				"data" in err
+				("status" in err || "detail" in err || "requestId" in err)
 			);
 		};
 
@@ -493,16 +490,7 @@ export const logger = {
 			);
 		};
 
-		// Check if it's a SafeResult request error
-		if (isRequestError(error)) {
-			process.stderr.write(`${prefix}HTTP ${error.status}: ${error.message}\n`);
-			if (error.data !== undefined && error.data !== null) {
-				process.stderr.write(`${JSON.stringify(error.data, null, 2)}\n`);
-			}
-			return;
-		}
-
-		// Check if it's a validation error
+		// Validation errors: surface the structured issues.
 		if (isValidationError(error)) {
 			process.stderr.write(
 				`${prefix}Validation error: ${JSON.stringify(error.issues)}\n`,
@@ -510,7 +498,30 @@ export const logger = {
 			return;
 		}
 
-		// Regular error
+		// SDK errors: print only the supplementary info that complements
+		// whatever message the caller already showed (typically via context.fail).
+		// Avoids duplicating the primary error line.
+		if (isSdkError(error)) {
+			const lines: string[] = [];
+			if (typeof error.status === "number" && error.status > 0) {
+				const statusText = error.statusText ?? "";
+				lines.push(
+					`${prefix}HTTP ${error.status}${statusText ? ` ${statusText}` : ""}`,
+				);
+			}
+			if (typeof error.requestId === "string" && error.requestId.length > 0) {
+				lines.push(`${prefix}Request ID: ${error.requestId}`);
+			}
+			if (error.data !== undefined && error.data !== null) {
+				lines.push(JSON.stringify(error.data, null, 2));
+			}
+			if (lines.length > 0) {
+				process.stderr.write(`${lines.join("\n")}\n`);
+			}
+			return;
+		}
+
+		// Regular error: only print if it adds something beyond the caller's message.
 		if (error instanceof Error) {
 			process.stderr.write(`${prefix}${error.message}\n`);
 		} else {

--- a/js/src/client.test.ts
+++ b/js/src/client.test.ts
@@ -238,7 +238,7 @@ describe("Client", () => {
 			expect(ofetch.create).toHaveBeenCalledWith(
 				expect.objectContaining({
 					baseURL: "https://cloud-api.phala.com/api/v1",
-					timeout: 30000,
+					timeout: 60000,
 					headers: expect.objectContaining({
 						"X-API-Key": "test-key",
 						"Content-Type": "application/json",

--- a/js/src/client.test.ts
+++ b/js/src/client.test.ts
@@ -98,7 +98,9 @@ describe("RequestError", () => {
 
 			expect(error.message).toBe("Network Error");
 			expect(error.status).toBe(500);
-			expect(error.detail).toBe("Unknown API error");
+			// Preserve original error message as detail (was previously
+			// overwritten with the unhelpful "Unknown API error" placeholder).
+			expect(error.detail).toBe("Network Error");
 			expect(error.code).toBe("500");
 		});
 

--- a/js/src/client.ts
+++ b/js/src/client.ts
@@ -136,7 +136,7 @@ export class Client<V extends ApiVersion = DefaultApiVersion> {
 
     this.fetchInstance = ofetch.create({
       baseURL,
-      timeout: timeout || 30000,
+      timeout: timeout || 60000,
       headers: requestHeaders,
       ...(useCookieAuth ? { credentials: "include" } : {}),
       ...fetchOptions,

--- a/js/src/utils/errors.test.ts
+++ b/js/src/utils/errors.test.ts
@@ -549,3 +549,65 @@ describe("RequestError.fromFetchError with StructuredError responses", () => {
     expect(formatStructuredError(error as ResourceError)).toContain("Request ID: rid-header-456");
   });
 });
+
+describe("RequestError.fromFetchError with timeout/network errors", () => {
+  it("should produce a friendly Request Timeout error when ofetch aborts on timeout", () => {
+    const timeoutCause = Object.assign(
+      new Error("[TimeoutError]: The operation was aborted due to timeout"),
+      { name: "TimeoutError", code: 23 },
+    );
+    const fetchError = {
+      message:
+        '[POST] "/api/v1/status/batch": <no response> [TimeoutError]: The operation was aborted due to timeout',
+      status: undefined,
+      statusText: undefined,
+      data: undefined,
+      request: "/api/v1/status/batch",
+      response: undefined,
+      cause: timeoutCause,
+    } as unknown;
+
+    const requestError = RequestError.fromFetchError(fetchError as never);
+
+    expect(requestError.code).toBe("TIMEOUT");
+    expect(requestError.status).toBe(0);
+    expect(requestError.statusText).toBe("Request Timeout");
+    expect(requestError.message).toContain("Request timed out");
+    expect(requestError.message).toContain("--timeout");
+    expect(requestError.detail).toContain("Request timed out");
+    expect(requestError.detail).toContain("--timeout");
+  });
+
+  it("should detect timeout via message prefix when cause is missing", () => {
+    const fetchError = {
+      message: '[GET] "/api/v1/apps": <no response> [TimeoutError]: aborted',
+      status: undefined,
+      statusText: undefined,
+      data: undefined,
+      request: "/api/v1/apps",
+      response: undefined,
+    } as unknown;
+
+    const requestError = RequestError.fromFetchError(fetchError as never);
+
+    expect(requestError.code).toBe("TIMEOUT");
+  });
+
+  it("should preserve raw error message for non-timeout failures with no response body", () => {
+    const fetchError = {
+      message: '[GET] "/api/v1/apps": <no response> connect ECONNREFUSED',
+      status: undefined,
+      statusText: undefined,
+      data: undefined,
+      request: "/api/v1/apps",
+      response: undefined,
+    } as unknown;
+
+    const requestError = RequestError.fromFetchError(fetchError as never);
+
+    expect(requestError.code).toBeUndefined();
+    expect(requestError.message).toContain("ECONNREFUSED");
+    expect(requestError.detail).toContain("ECONNREFUSED");
+    expect(requestError.detail).not.toBe("Unknown API error");
+  });
+});

--- a/js/src/utils/errors.test.ts
+++ b/js/src/utils/errors.test.ts
@@ -572,10 +572,12 @@ describe("RequestError.fromFetchError with timeout/network errors", () => {
     expect(requestError.code).toBe("TIMEOUT");
     expect(requestError.status).toBe(0);
     expect(requestError.statusText).toBe("Request Timeout");
-    expect(requestError.message).toContain("Request timed out");
-    expect(requestError.message).toContain("--timeout");
-    expect(requestError.detail).toContain("Request timed out");
-    expect(requestError.detail).toContain("--timeout");
+    expect(requestError.message).toBe(
+      "Request timed out. The server did not respond in time.",
+    );
+    expect(requestError.detail).toBe(
+      "Request timed out. The server did not respond in time.",
+    );
   });
 
   it("should detect timeout via message prefix when cause is missing", () => {
@@ -591,6 +593,26 @@ describe("RequestError.fromFetchError with timeout/network errors", () => {
     const requestError = RequestError.fromFetchError(fetchError as never);
 
     expect(requestError.code).toBe("TIMEOUT");
+  });
+
+  it("should expose code on the PhalaCloudError subclass via parseApiError", () => {
+    const fetchError = {
+      message: '[POST] "/api/v1/status/batch": <no response> [TimeoutError]',
+      status: undefined,
+      statusText: undefined,
+      data: undefined,
+      request: "/api/v1/status/batch",
+      response: undefined,
+      cause: Object.assign(new Error(""), { name: "TimeoutError" }),
+    } as unknown;
+
+    const requestError = RequestError.fromFetchError(fetchError as never);
+    const error = parseApiError(requestError);
+
+    // parseApiError must forward the code so downstream consumers (CLI, JS apps)
+    // can discriminate timeouts without string matching on message/statusText.
+    expect(error.code).toBe("TIMEOUT");
+    expect(error.statusText).toBe("Request Timeout");
   });
 
   it("should preserve raw error message for non-timeout failures with no response body", () => {

--- a/js/src/utils/errors.ts
+++ b/js/src/utils/errors.ts
@@ -67,6 +67,8 @@ export class PhalaCloudError extends Error {
     | Record<string, unknown>
     | Array<{ msg: string; type?: string; ctx?: Record<string, unknown> }>;
   public readonly requestId?: string;
+  /** Machine-readable error code (e.g. "TIMEOUT", HTTP status as string). */
+  public readonly code?: string;
 
   constructor(
     message: string,
@@ -78,6 +80,7 @@ export class PhalaCloudError extends Error {
         | Record<string, unknown>
         | Array<{ msg: string; type?: string; ctx?: Record<string, unknown> }>;
       requestId?: string;
+      code?: string;
     },
   ) {
     super(message);
@@ -86,6 +89,7 @@ export class PhalaCloudError extends Error {
     this.statusText = data.statusText;
     this.detail = data.detail;
     this.requestId = data.requestId;
+    this.code = data.code;
 
     // Maintains proper stack trace for where error was thrown (only available on V8)
     if (Error.captureStackTrace) {
@@ -104,7 +108,6 @@ export class RequestError extends PhalaCloudError implements ApiError {
   public readonly data?: unknown;
   public readonly request?: FetchRequest | undefined;
   public readonly response?: Response | undefined;
-  public readonly code?: string | undefined;
   public readonly type?: string | undefined;
 
   constructor(
@@ -137,12 +140,12 @@ export class RequestError extends PhalaCloudError implements ApiError {
       statusText: options?.statusText ?? "Unknown Error",
       detail: options?.detail || message,
       requestId: options?.requestId,
+      code: options?.code,
     });
 
     this.data = options?.data;
     this.request = options?.request;
     this.response = options?.response;
-    this.code = options?.code;
     this.type = options?.type;
   }
 
@@ -195,19 +198,19 @@ export class RequestError extends PhalaCloudError implements ApiError {
     // "[TimeoutError]:" to the message.
     const cause = (error as { cause?: { name?: string } }).cause;
     if (cause?.name === "TimeoutError" || error.message?.includes("[TimeoutError]")) {
-      // Put the actionable hint in `detail` so parseApiError's
-      // extractPrimaryMessage surfaces it (it prefers detail over the bare
-      // FetchError message like "[POST] ...: <no response>").
-      const friendly =
-        "Request timed out. The server did not respond in time. " +
-        "Increase the timeout via createClient({ timeout }) or the CLI --timeout flag.";
-      return new RequestError(friendly, {
+      // Keep the SDK-facing message generic; callers (including the CLI) can
+      // discriminate via `code === "TIMEOUT"` and append their own remediation
+      // hint (e.g. the CLI surfaces the configured timeout + --timeout flag).
+      // Put the same text in `detail` so parseApiError's extractPrimaryMessage
+      // surfaces it instead of the bare ofetch message ("[POST] ...: <no response>").
+      const message = "Request timed out. The server did not respond in time.";
+      return new RequestError(message, {
         status: 0,
         statusText: "Request Timeout",
         data: error.data,
         request: error.request ?? undefined,
         response: error.response ?? undefined,
-        detail: friendly,
+        detail: message,
         code: "TIMEOUT",
         requestId,
       });
@@ -508,7 +511,13 @@ export function parseApiError(requestError: RequestError): PhalaCloudError {
   // Fallback to original logic for backward compatibility
   const errorType = categorizeErrorType(status);
   const message = extractPrimaryMessage(status, detail, requestError.message);
-  const commonData = { status, statusText, detail, requestId: requestError.requestId };
+  const commonData = {
+    status,
+    statusText,
+    detail,
+    requestId: requestError.requestId,
+    code: requestError.code,
+  };
 
   // Return appropriate error subclass
   if (errorType === "validation" && Array.isArray(detail)) {

--- a/js/src/utils/errors.ts
+++ b/js/src/utils/errors.ts
@@ -190,14 +190,39 @@ export class RequestError extends PhalaCloudError implements ApiError {
       });
     }
 
-    // Fallback to raw error data
+    // Detect ofetch timeout (AbortController fired due to options.timeout):
+    // ofetch wraps the underlying TimeoutError in FetchError.cause and prepends
+    // "[TimeoutError]:" to the message.
+    const cause = (error as { cause?: { name?: string } }).cause;
+    if (cause?.name === "TimeoutError" || error.message?.includes("[TimeoutError]")) {
+      // Put the actionable hint in `detail` so parseApiError's
+      // extractPrimaryMessage surfaces it (it prefers detail over the bare
+      // FetchError message like "[POST] ...: <no response>").
+      const friendly =
+        "Request timed out. The server did not respond in time. " +
+        "Increase the timeout via createClient({ timeout }) or the CLI --timeout flag.";
+      return new RequestError(friendly, {
+        status: 0,
+        statusText: "Request Timeout",
+        data: error.data,
+        request: error.request ?? undefined,
+        response: error.response ?? undefined,
+        detail: friendly,
+        code: "TIMEOUT",
+        requestId,
+      });
+    }
+
+    // Fallback to raw error data — preserve the underlying error message so
+    // callers see something actionable (e.g. ofetch's "[GET] ...: <no response>"
+    // for network failures) instead of a generic "Unknown API error".
     return new RequestError(error.message, {
       status: error.status ?? undefined,
       statusText: error.statusText ?? undefined,
       data: error.data,
       request: error.request ?? undefined,
       response: error.response ?? undefined,
-      detail: error.data?.detail || "Unknown API error",
+      detail: error.data?.detail || error.message || "Unknown API error",
       code: error.status?.toString() ?? undefined,
       requestId,
     });


### PR DESCRIPTION
## Summary

Running `phala cvms ls` on a workspace with ~25+ CVMs produced `✗ Unknown API error` with no other information. Root cause turned out to be `POST /status/batch` consistently taking ~31s on the slowest teepod, which tripped the SDK's hard-coded 30s timeout. The ofetch abort then fell through to a fallback branch in `RequestError.fromFetchError` that overwrote the real message with the placeholder `"Unknown API error"`. The CLI then collapsed the SDK error into `{ message }`, throwing away status / data / requestId, and its `result.success === false` branch never called `logDetailedError` — so the user got the worst-of-both: an opaque message AND no supplementary detail.

Backend `/status/batch` (`teehouse/cvms/actions/get_batch_cvm_status.py`) is already parallel-per-teepod via `gather()`, so 31s is the genuine RTT of the slowest teepod and not a backend bug. The fix is in the client tooling.

## Changes (4 atomic commits)

**`fix(js): surface friendly error for request timeouts`**
- `RequestError.fromFetchError` detects ofetch's `TimeoutError` (via `cause.name` or the `[TimeoutError]` message prefix) and returns an actionable message: _"Request timed out. The server did not respond in time. Increase the timeout via createClient({ timeout }) or the CLI --timeout flag."_
- For non-timeout fallthroughs, the underlying `error.message` is preserved in `detail` instead of being overwritten with `"Unknown API error"` (so `ECONNREFUSED` etc. remain visible).
- Adds `code: "TIMEOUT"` on the error for callers that want to discriminate.
- +3 unit tests covering the timeout path (via `cause` and via message prefix) and the network-error fallthrough.

**`feat(js): bump default request timeout to 60s`**
- 30s tripped on the slowest paginated `/status/batch` calls. 60s leaves headroom while still being well below CF's 100s origin timeout. Callers can still override via `createClient({ timeout })`.

**`feat(cli): add --timeout global flag`**
- `phala <cmd> --timeout <seconds>` overrides the SDK default per-invocation. Validates `> 0` at dispatch. Forwarded to `createClient` as milliseconds.
- Available on every command via `globalCommandOptions`; shows up in `--help` under the `advanced` group.

**`fix(cli): preserve SDK error details and stop duplicating error output`**
- `Result.error` now carries an optional `cause: unknown` so callers can introspect the original SDK error.
- `listAppsWithCvmStatus` passes the SDK error through as `cause` instead of collapsing to `{ message }`.
- `cvms list` calls `logDetailedError(cause)` on the `success === false` branch.
- `logDetailedError` now recognises any `PhalaCloudError` subclass (not just `RequestError`) and prints only supplementary lines (HTTP status, request id, response data). Avoids the previous behaviour of duplicating the primary message.

## Verification

```
$ phala cvms ls --timeout 5
✗ Request timed out. The server did not respond in time. Increase the timeout via createClient({ timeout }) or the CLI --timeout flag.

$ phala cvms ls --timeout 5 --json
{"success": false, "error": "Request timed out. ..."}

$ phala cvms ls          # default 60s
... 27-row CVM list ...
ℹ Page 1/1 (total 27)
# total ~34s, of which ~31s is /status/batch

$ phala cvms ls --timeout 0
Invalid --timeout value "0". Must be a positive number of seconds.

$ phala cvms ls --help | grep timeout
  --timeout SECONDS       Request timeout in seconds (default 60)
```

## Test plan

- [ ] `cd js && bun run fmt && bun run lint && bun run type-check && bun run test` — 711/711 pass
- [ ] `cd cli && bun run fmt && bun run lint && bun run type-check && bun run test` — 407/407 pass
- [ ] Reproduce: `phala cvms ls --timeout 5` on a workspace with ≥1 slow teepod — expect friendly timeout message
- [ ] Reproduce: `phala cvms ls` (no flag) — expect the listing to succeed even when `/status/batch` takes ~30s
- [ ] `phala cvms ls --timeout 5 --json` — JSON mode still emits structured error