### PR TITLE
feat: add bolt-diy template

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -2844,5 +2844,31 @@
     "Vector Database",
     "AI Apps"
   ]
+},
+{
+  "id": "bolt-diy",
+  "name": "stackblitz-labs/bolt.diy",
+  "description": "Open-source AI full-stack app builder from stackblitz-labs. This CPU-safe Phala template runs a metadata verifier that checks the real upstream bolt.diy package manifest, AI route, WebContainer runtime, and icon source from public/favicon.svg, then exposes health/demo/model-like endpoints without requiring provider credentials.",
+  "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/bolt-diy",
+  "author": "stackblitz-labs",
+  "icon": "bolt-diy.svg",
+  "envs": [
+    {
+      "key": "BOLT_DIY_REF",
+      "required": false,
+      "default": "2e254ac19a696394030601bc602f54945b12bfc4",
+      "description": "Git branch, tag, or commit from stackblitz-labs/bolt.diy to verify at startup."
+    }
+  ],
+  "defaultResource": {
+    "vCPU": 1,
+    "memory": 1024,
+    "diskSize": 10
+  },
+  "tags": [
+    "AI Agents",
+    "Developer Tools",
+    "App Builder"
+  ]
 }
 ]

--- a/templates/icons/bolt-diy.svg
+++ b/templates/icons/bolt-diy.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+  <rect width="16" height="16" rx="2" fill="#8A5FFF" />
+  <path d="M7.398 9.091h-3.58L10.364 2 8.602 6.909h3.58L5.636 14l1.762-4.909Z" fill="#fff" />
+</svg>

--- a/templates/prebuilt/bolt-diy/README.md
+++ b/templates/prebuilt/bolt-diy/README.md
@@ -1,0 +1,130 @@
+# bolt.diy on Phala Cloud
+
+## Overview
+
+This template deploys a CPU-safe HTTP metadata verifier for [stackblitz-labs/bolt.diy](https://github.com/stackblitz-labs/bolt.diy), the open-source AI full-stack app builder from the bolt.diy community.
+
+The default service does not run the full Remix/Cloudflare bolt.diy application. That upstream app is useful, but the production path is heavier and real chat/build workflows normally need provider configuration. Instead, this template starts a small Node.js service that fetches the real upstream repository files for a pinned ref, verifies the package manifest and key runtime source files, and exposes deterministic JSON endpoints for Phala Cloud smoke testing.
+
+No LLM provider credentials, model downloads, GPU access, privileged mode, host bind mounts, external build contexts, or `env_file` are required for the default smoke path.
+
+## Metadata
+
+- Template id: `bolt-diy`
+- Display name: `stackblitz-labs/bolt.diy`
+- Upstream repository: https://github.com/stackblitz-labs/bolt.diy
+- Upstream documentation: https://stackblitz-labs.github.io/bolt.diy/
+- Upstream author: `stackblitz-labs` and the bolt.diy team
+- Default inspected ref: `2e254ac19a696394030601bc602f54945b12bfc4`
+- Runtime image: `node:22-bookworm-slim`
+- Icon source: upstream `public/favicon.svg` from `stackblitz-labs/bolt.diy`, inspected on the `main` branch where the README and repository tree also expose `public/logo.svg`, `icons/logo.svg`, and related public logo assets.
+
+## What This Template Runs
+
+The `app` service listens on port `8080`. On startup it uses Node's built-in `fetch` to retrieve upstream files from GitHub for `BOLT_DIY_REF`, then checks:
+
+- `package.json` name, module type, Node engine, pnpm package manager, required scripts, and important dependencies.
+- The AI chat route at `app/routes/api.chat.ts`.
+- The LLM runtime directory at `app/lib/.server/llm`.
+- The WebContainer runtime at `app/lib/webcontainer/index.ts`.
+- The action parser runtime at `app/lib/runtime/message-parser.ts`.
+- Public assets such as `favicon.svg` and `logo.svg`.
+
+This is intentionally a verifier and metadata API. It confirms the real upstream source/runtime surface is reachable and shaped as expected, but it does not build bolt.diy, serve the full browser UI, run WebContainers, or call a model provider.
+
+## Deploy
+
+Deploy the `bolt-diy` prebuilt template on Phala Cloud and keep the default resource size for the smoke verifier. The service publishes HTTP on port `8080`.
+
+For a local smoke run from the monorepo root:
+
+```bash
+docker compose -f templates/prebuilt/bolt-diy/docker-compose.yml up -d
+```
+
+After startup, open:
+
+```text
+http://localhost:8080/healthz
+```
+
+The first health check depends on outbound access to GitHub raw/API endpoints because the verifier checks the upstream repository at runtime.
+
+## Usage
+
+Use the public Phala Cloud app URL or local port `8080`:
+
+```bash
+curl -fsS http://localhost:8080/healthz
+curl -fsS http://localhost:8080/demo
+curl -fsS http://localhost:8080/v1/models
+```
+
+Endpoints:
+
+- `GET /healthz`: Returns HTTP 200 when the upstream source checks pass. Returns HTTP 503 with a concrete error if GitHub fetches or checks fail.
+- `GET /demo`: Returns the complete metadata verifier report, including checked files, dependency metadata, and confirmation that no LLM provider calls are made.
+- `GET /v1/models`: Returns an OpenAI-shaped metadata list with `bolt-diy/no-llm-metadata-demo`. This is not a hosted model.
+- `GET /`: Same readiness payload as `/healthz`.
+
+## Environment Variables
+
+The default template requires no credentials.
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `BOLT_DIY_REF` | No | `2e254ac19a696394030601bc602f54945b12bfc4` | Git branch, tag, or commit from `stackblitz-labs/bolt.diy` to verify. Pin a commit for reproducible deployments. Use `stable` or a release tag only when you intentionally want to track upstream movement. |
+
+Provider variables are intentionally not consumed by this metadata verifier. If you replace this verifier with the full upstream bolt.diy app, pass provider credentials only as deployment-time environment variables, using placeholders like:
+
+| Variable | Placeholder | Notes |
+| --- | --- | --- |
+| `OPENAI_API_KEY` | `<your-openai-key>` | Optional for a custom full bolt.diy app using OpenAI. Not read by this template. |
+| `ANTHROPIC_API_KEY` | `<your-anthropic-key>` | Optional for a custom full bolt.diy app using Anthropic. Not read by this template. |
+| `OPEN_ROUTER_API_KEY` | `<your-openrouter-key>` | Optional for a custom full bolt.diy app using OpenRouter. Not read by this template. |
+| `OLLAMA_API_BASE_URL` | `http://<ollama-host>:11434` | Optional for a custom full bolt.diy app that connects to an Ollama endpoint. Not read by this template. |
+
+Do not place real provider values in `docker-compose.yml` or in template files.
+
+## Verification
+
+Run the repository validations from the monorepo root:
+
+```bash
+python3 templates/validate.py
+git diff --check origin/main...HEAD
+docker compose -f templates/prebuilt/bolt-diy/docker-compose.yml config >/dev/null
+```
+
+Local runtime smoke:
+
+```bash
+docker compose -f templates/prebuilt/bolt-diy/docker-compose.yml up -d
+curl -i http://localhost:8080/healthz
+curl -fsS http://localhost:8080/demo
+curl -fsS http://localhost:8080/v1/models
+docker compose -f templates/prebuilt/bolt-diy/docker-compose.yml down
+```
+
+Expected results:
+
+- `GET /healthz` returns `200 OK` after upstream checks complete.
+- The payload includes `"ok": true`, `"credentials_required": false`, `"llm_provider_calls": false`, and `"model_downloaded": false`.
+- `/demo` reports verified source paths such as `app/routes/api.chat.ts`, `app/lib/.server/llm`, and `app/lib/webcontainer/index.ts`.
+- `/v1/models` includes `bolt-diy/no-llm-metadata-demo`.
+
+## Production Notes And Caveats
+
+- This template is a Phala Cloud smoke-testable verifier for bolt.diy, not a production bolt.diy UI deployment.
+- The full upstream app is a Remix/Cloudflare/Wrangler application with a WebContainer browser runtime and many provider integrations. Running it directly may need more CPU/memory, a full build, and carefully managed provider credentials.
+- The default verifier is unauthenticated. It exposes only metadata, but add authentication or a protected reverse proxy before adapting it for private operational data.
+- The verifier performs outbound GitHub source fetches at startup. Pin `BOLT_DIY_REF` to a commit for stable production checks.
+- The compose file uses a public Node image, one HTTP service, no host bind mounts, no `env_file`, no privileged mode, no Docker socket, and no GPU requirements.
+
+## Cleanup
+
+For a local run:
+
+```bash
+docker compose -f templates/prebuilt/bolt-diy/docker-compose.yml down
+```

--- a/templates/prebuilt/bolt-diy/docker-compose.yml
+++ b/templates/prebuilt/bolt-diy/docker-compose.yml
@@ -1,0 +1,393 @@
+services:
+  app:
+    image: node:22-bookworm-slim
+    restart: unless-stopped
+    init: true
+    ports:
+      - "8080:8080"
+    environment:
+      BOLT_DIY_REF: ${BOLT_DIY_REF:-2e254ac19a696394030601bc602f54945b12bfc4}
+      NODE_ENV: production
+      PORT: "8080"
+    configs:
+      - source: bolt_diy_demo_server
+        target: /opt/bolt-diy-demo/server.mjs
+    command:
+      - /bin/sh
+      - -lc
+      - exec node /opt/bolt-diy-demo/server.mjs
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - |
+          fetch('http://127.0.0.1:8080/healthz').then(function (response) { process.exit(response.ok ? 0 : 1); }).catch(function () { process.exit(1); });
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+configs:
+  bolt_diy_demo_server:
+    content: |
+      import http from 'node:http';
+      import { createHash } from 'node:crypto';
+
+      const upstreamRepo = 'https://github.com/stackblitz-labs/bolt.diy';
+      const rawBase = 'https://raw.githubusercontent.com/stackblitz-labs/bolt.diy';
+      const apiBase = 'https://api.github.com/repos/stackblitz-labs/bolt.diy';
+      const ref = process.env.BOLT_DIY_REF || '2e254ac19a696394030601bc602f54945b12bfc4';
+      const port = Number.parseInt(process.env.PORT || '8080', 10);
+      const startedAt = Date.now();
+
+      let upstreamStatus = {
+        ok: false,
+        status: 'starting',
+        upstream: upstreamRepo,
+        ref,
+        credentials_required: false,
+        llm_provider_calls: false,
+        remote_model_calls: false,
+        source_fetch_required: true,
+      };
+
+      function encodePath(path) {
+        return path.split('/').map(encodeURIComponent).join('/');
+      }
+
+      function rawUrl(path) {
+        return rawBase + '/' + encodeURIComponent(ref) + '/' + encodePath(path);
+      }
+
+      function contentsUrl(path) {
+        return apiBase + '/contents/' + encodePath(path) + '?ref=' + encodeURIComponent(ref);
+      }
+
+      function commitUrl() {
+        return apiBase + '/commits/' + encodeURIComponent(ref);
+      }
+
+      function errorMessage(error) {
+        return error && error.stack ? error.stack.split('\n')[0] : String(error);
+      }
+
+      async function fetchText(url) {
+        const response = await fetch(url, {
+          headers: {
+            Accept: 'application/vnd.github+json, text/plain',
+            'User-Agent': 'phala-cloud-bolt-diy-template',
+          },
+          signal: AbortSignal.timeout(20000),
+        });
+
+        if (!response.ok) {
+          throw new Error('GET ' + url + ' failed with HTTP ' + response.status);
+        }
+
+        return response.text();
+      }
+
+      async function fetchJson(url) {
+        return JSON.parse(await fetchText(url));
+      }
+
+      function sha256Prefix(value) {
+        return createHash('sha256').update(value).digest('hex').slice(0, 16);
+      }
+
+      function nodeEngineOk(engine) {
+        const match = String(engine || '').match(/>=\s*(\d+)\.(\d+)\.(\d+)/);
+
+        if (!match) {
+          return null;
+        }
+
+        const required = match.slice(1).map(Number);
+        const current = process.versions.node.split('.').map(Number);
+
+        for (let index = 0; index < required.length; index += 1) {
+          if (current[index] > required[index]) {
+            return true;
+          }
+
+          if (current[index] < required[index]) {
+            return false;
+          }
+        }
+
+        return true;
+      }
+
+      function namedItems(items) {
+        return Array.isArray(items) ? items.map(function (item) { return item.name; }).sort() : [];
+      }
+
+      async function loadUpstreamStatus() {
+        const refreshStartedAt = Date.now();
+        const packageText = await fetchText(rawUrl('package.json'));
+        const readmeText = await fetchText(rawUrl('README.md'));
+        const chatRouteText = await fetchText(rawUrl('app/routes/api.chat.ts'));
+        const messageParserText = await fetchText(rawUrl('app/lib/runtime/message-parser.ts'));
+        const webcontainerText = await fetchText(rawUrl('app/lib/webcontainer/index.ts'));
+        const llmItems = await fetchJson(contentsUrl('app/lib/.server/llm'));
+        const publicItems = await fetchJson(contentsUrl('public'));
+        const commitInfo = await fetchJson(commitUrl()).catch(function () { return null; });
+
+        const manifest = JSON.parse(packageText);
+        const dependencies = manifest.dependencies || {};
+        const scripts = manifest.scripts || {};
+        const llmFileNames = namedItems(llmItems);
+        const publicFileNames = namedItems(publicItems);
+
+        const requiredDependencies = [
+          '@remix-run/cloudflare',
+          '@webcontainer/api',
+          'ai',
+          '@ai-sdk/openai',
+          '@ai-sdk/anthropic',
+          '@modelcontextprotocol/sdk',
+        ];
+        const missingDependencies = requiredDependencies.filter(function (name) {
+          return !dependencies[name];
+        });
+        const requiredScripts = ['dev', 'build', 'dockerstart'];
+        const missingScripts = requiredScripts.filter(function (name) {
+          return !scripts[name];
+        });
+        const providerDependencies = Object.keys(dependencies).filter(function (name) {
+          return name === 'ai' || name.includes('ai-sdk') || name.includes('openrouter') || name.includes('ollama');
+        }).sort();
+        const engineOk = nodeEngineOk(manifest.engines && manifest.engines.node);
+
+        const checks = {
+          package_manifest: {
+            ok: manifest.name === 'bolt' && manifest.private === true && manifest.type === 'module',
+            name: manifest.name,
+            version: manifest.version,
+            license: manifest.license,
+            private: manifest.private === true,
+            module_type: manifest.type,
+            package_sha256_prefix: sha256Prefix(packageText),
+          },
+          package_manager: {
+            ok: String(manifest.packageManager || '').startsWith('pnpm@'),
+            package_manager: manifest.packageManager || null,
+          },
+          node_runtime: {
+            ok: engineOk === true,
+            required: manifest.engines && manifest.engines.node ? manifest.engines.node : null,
+            current: process.version,
+          },
+          npm_scripts: {
+            ok: missingScripts.length === 0,
+            required: requiredScripts,
+            missing: missingScripts,
+          },
+          dependencies: {
+            ok: missingDependencies.length === 0,
+            required: requiredDependencies,
+            missing: missingDependencies,
+            provider_dependency_count: providerDependencies.length,
+          },
+          ai_chat_route: {
+            ok: chatRouteText.includes('streamText') && chatRouteText.includes('MCPService') && chatRouteText.includes('createSummary'),
+            path: 'app/routes/api.chat.ts',
+            sha256_prefix: sha256Prefix(chatRouteText),
+          },
+          llm_runtime_directory: {
+            ok: llmFileNames.includes('stream-text.ts') && llmFileNames.includes('select-context.ts') && llmFileNames.includes('switchable-stream.ts'),
+            path: 'app/lib/.server/llm',
+            files_checked: llmFileNames.filter(function (name) {
+              return ['stream-text.ts', 'select-context.ts', 'switchable-stream.ts'].includes(name);
+            }),
+          },
+          webcontainer_runtime: {
+            ok: webcontainerText.includes('WebContainer.boot') && webcontainerText.includes('@webcontainer/api'),
+            path: 'app/lib/webcontainer/index.ts',
+            dependency: dependencies['@webcontainer/api'] || null,
+            sha256_prefix: sha256Prefix(webcontainerText),
+          },
+          action_parser_runtime: {
+            ok: messageParserText.includes('parse') && messageParserText.includes('BoltAction') && messageParserText.includes('BoltArtifact'),
+            path: 'app/lib/runtime/message-parser.ts',
+            sha256_prefix: sha256Prefix(messageParserText),
+          },
+          public_assets: {
+            ok: publicFileNames.includes('favicon.svg') && publicFileNames.includes('logo.svg'),
+            required: ['favicon.svg', 'logo.svg'],
+            available_subset: publicFileNames.filter(function (name) {
+              return ['favicon.svg', 'logo.svg', 'social_preview_index.jpg'].includes(name);
+            }),
+          },
+          upstream_readme: {
+            ok: readmeText.includes('official open source version') && readmeText.includes('LLM'),
+            sha256_prefix: sha256Prefix(readmeText),
+          },
+        };
+
+        const ok = Object.values(checks).every(function (check) { return check.ok; });
+
+        return {
+          ok,
+          status: ok ? 'ready' : 'failed_checks',
+          service: 'bolt-diy-metadata-demo',
+          upstream: upstreamRepo,
+          upstream_tree: upstreamRepo + '/tree/' + ref,
+          ref,
+          resolved_commit: commitInfo && commitInfo.sha ? commitInfo.sha : null,
+          fetched_at: new Date().toISOString(),
+          fetch_duration_ms: Date.now() - refreshStartedAt,
+          credentials_required: false,
+          llm_provider_calls: false,
+          remote_model_calls: false,
+          model_loaded: false,
+          model_downloaded: false,
+          source_fetch_required: true,
+          package: {
+            name: manifest.name,
+            version: manifest.version,
+            description: manifest.description,
+            package_manager: manifest.packageManager,
+            node_engine: manifest.engines && manifest.engines.node ? manifest.engines.node : null,
+          },
+          provider_dependencies: providerDependencies,
+          checks,
+        };
+      }
+
+      async function refreshStatus() {
+        try {
+          upstreamStatus = await loadUpstreamStatus();
+        } catch (error) {
+          upstreamStatus = {
+            ok: false,
+            status: 'source_fetch_failed',
+            service: 'bolt-diy-metadata-demo',
+            upstream: upstreamRepo,
+            upstream_tree: upstreamRepo + '/tree/' + ref,
+            ref,
+            fetched_at: new Date().toISOString(),
+            credentials_required: false,
+            llm_provider_calls: false,
+            remote_model_calls: false,
+            model_loaded: false,
+            model_downloaded: false,
+            source_fetch_required: true,
+            error: errorMessage(error),
+          };
+        }
+      }
+
+      function basePayload() {
+        return {
+          service: 'bolt-diy-metadata-demo',
+          template_id: 'bolt-diy',
+          upstream: upstreamRepo,
+          ref,
+          node: process.version,
+          uptime_seconds: Math.round((Date.now() - startedAt) / 1000),
+        };
+      }
+
+      function jsonResponse(response, statusCode, payload) {
+        const body = JSON.stringify(payload, null, 2) + '\n';
+        response.writeHead(statusCode, {
+          'Cache-Control': 'no-store',
+          'Content-Type': 'application/json; charset=utf-8',
+          'Content-Length': Buffer.byteLength(body),
+          'X-Content-Type-Options': 'nosniff',
+        });
+        response.end(body);
+      }
+
+      function handleRequest(request, response) {
+        const url = new URL(request.url || '/', 'http://localhost');
+
+        if (request.method !== 'GET') {
+          jsonResponse(response, 405, {
+            ok: false,
+            error: 'method_not_allowed',
+            endpoints: ['/', '/healthz', '/demo', '/v1/models'],
+          });
+          return;
+        }
+
+        if (url.pathname === '/' || url.pathname === '/healthz') {
+          const payload = {
+            ...basePayload(),
+            ...upstreamStatus,
+          };
+          jsonResponse(response, upstreamStatus.ok ? 200 : 503, payload);
+          return;
+        }
+
+        if (url.pathname === '/demo') {
+          const payload = {
+            ...basePayload(),
+            ok: upstreamStatus.ok === true,
+            mode: 'metadata-verifier',
+            credentials_required: false,
+            llm_provider_calls: false,
+            remote_model_calls: false,
+            model_loaded: false,
+            model_downloaded: false,
+            source_fetch_required: true,
+            smoke_path: [
+              'fetch upstream package.json and selected source files',
+              'verify Node, pnpm, Remix, AI SDK, WebContainer, LLM route, and public asset surface',
+              'serve deterministic JSON metadata without calling an LLM provider',
+            ],
+            upstream_status: upstreamStatus,
+          };
+          jsonResponse(response, upstreamStatus.ok ? 200 : 503, payload);
+          return;
+        }
+
+        if (url.pathname === '/v1/models') {
+          const payload = {
+            object: 'list',
+            data: [
+              {
+                id: 'bolt-diy/no-llm-metadata-demo',
+                object: 'model',
+                created: 1704067200,
+                owned_by: 'stackblitz-labs',
+                description: 'Metadata-only smoke endpoint. The default template verifies bolt.diy source/runtime shape and does not host or call an LLM.',
+              },
+            ],
+            credentials_required: false,
+            llm_provider_calls: false,
+            upstream_ready: upstreamStatus.ok === true,
+          };
+          jsonResponse(response, 200, payload);
+          return;
+        }
+
+        jsonResponse(response, 404, {
+          ok: false,
+          error: 'not_found',
+          endpoints: ['/', '/healthz', '/demo', '/v1/models'],
+        });
+      }
+
+      const server = http.createServer(handleRequest);
+
+      server.listen(port, '0.0.0.0', function () {
+        console.log(JSON.stringify({
+          event: 'startup',
+          service: 'bolt-diy-metadata-demo',
+          port,
+          upstream: upstreamRepo,
+          ref,
+        }));
+      });
+
+      refreshStatus().then(function () {
+        console.log(JSON.stringify({
+          event: 'upstream_status',
+          ok: upstreamStatus.ok,
+          status: upstreamStatus.status,
+          ref,
+        }));
+      });


### PR DESCRIPTION
## Summary
- Add the `bolt-diy` prebuilt template for `stackblitz-labs/bolt.diy`.
- Provide a CPU-safe Node.js metadata verifier that checks the real upstream package manifest, AI route, LLM runtime directory, WebContainer runtime, action parser, and public assets.
- Add upstream `public/favicon.svg` as `templates/icons/bolt-diy.svg`.

## Upstream
- Repo: https://github.com/stackblitz-labs/bolt.diy
- Default inspected ref: `2e254ac19a696394030601bc602f54945b12bfc4`
- Deployable template repo path: https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/bolt-diy

## Template files
- `templates/prebuilt/bolt-diy/docker-compose.yml`
- `templates/prebuilt/bolt-diy/README.md`
- `templates/icons/bolt-diy.svg`
- `templates/config.json`

## Env vars
- `BOLT_DIY_REF` optional, defaults to `2e254ac19a696394030601bc602f54945b12bfc4`.
- No provider credentials are required for the default smoke path.

## Validation
- `python templates/validate.py` ✅
- `git diff --check origin/main...HEAD` ✅
- `docker compose -f templates/prebuilt/bolt-diy/docker-compose.yml config >/dev/null` ✅
- Static audit ✅: README deploy/use/verification coverage, unique config id, no host bind mounts, no `env_file`, no literal secrets, no external build context.

## Phala Cloud smoke
- Profile/workspace: `hermes-admin-cvm-check` / `h4x's projects`
- Command: `phala deploy --profile hermes-admin-cvm-check --name auto-template-test-bolt-diy-0523-172020 --compose templates/prebuilt/bolt-diy/docker-compose.yml --instance-type tdx.small --wait --no-public-logs --no-public-sysinfo --json`
- CVM UUID: `86c49102-a960-4f3b-81a5-3f1f55f3ec5e`
- App ID: `6d1ed56178f373403c79cb95a7c111164219d800`
- `phala ps` showed `/dstack-app-1` running and healthy.
- `GET /healthz` returned HTTP 200 with `ok=true`.
- `GET /demo` returned HTTP 200 with `ok=true`.
- `GET /v1/models` returned HTTP 200 with the metadata model list.

## Cleanup
- `phala cvms delete --profile hermes-admin-cvm-check 86c49102-a960-4f3b-81a5-3f1f55f3ec5e --force --json` ✅
- Delete response: `success=true`, `deleted=true`.

cc @Marvin-Cypher for review.