### PR TITLE
feat: add promptflow template

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -2870,5 +2870,37 @@
     "Developer Tools",
     "App Builder"
   ]
+},
+{
+  "id": "promptflow",
+  "name": "microsoft/promptflow",
+  "description": "CPU-safe Promptflow HTTP demo that installs the real Python package, verifies imports, and executes a deterministic local DAG flow without provider credentials, model downloads, GPU, or external databases.",
+  "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/promptflow",
+  "author": "microsoft",
+  "icon": "promptflow.svg",
+  "envs": [
+    {
+      "key": "PROMPTFLOW_VERSION",
+      "required": false,
+      "description": "Promptflow Python package version installed at container startup.",
+      "default": "1.18.5"
+    },
+    {
+      "key": "PROMPTFLOW_DEMO_TOPIC",
+      "required": false,
+      "description": "Default topic used by the deterministic local /demo flow when no query parameter is supplied.",
+      "default": "Phala Cloud prompt orchestration"
+    }
+  ],
+  "defaultResource": {
+    "vCPU": 1,
+    "memory": 2048,
+    "diskSize": 10
+  },
+  "tags": [
+    "Agent Frameworks & Orchestration",
+    "Developer Tools",
+    "AI"
+  ]
 }
 ]

--- a/templates/icons/promptflow.svg
+++ b/templates/icons/promptflow.svg
@@ -1,0 +1,47 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_699_15212)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M237 39.0408V461.693C237 469.397 228.655 474.208 221.988 470.346L151.918 429.764C130.306 417.247 117 394.164 117 369.19V148.892C117 123.917 130.306 100.834 151.918 88.3177L237 39.0408Z" fill="url(#paint0_linear_699_15212)"/>
+<path d="M395.075 127.51L237 39V167.541L283.451 192.041L395.075 127.51Z" fill="url(#paint1_linear_699_15212)"/>
+<path d="M395.075 127.51L237 39V167.541L283.451 192.041L395.075 127.51Z" fill="url(#paint2_linear_699_15212)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M255.5 231.426C255.5 217.184 263.073 204.017 275.382 196.854L395 127.248V216.101C395 241.03 381.742 264.078 360.193 276.611L270.528 328.76C263.861 332.637 255.5 327.828 255.5 320.116L255.5 231.426Z" fill="url(#paint3_linear_699_15212)"/>
+</g>
+<defs>
+<linearGradient id="paint0_linear_699_15212" x1="196.286" y1="183.041" x2="270.786" y2="92.5087" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3272ED"/>
+<stop offset="1" stop-color="#AF7BD6"/>
+</linearGradient>
+<linearGradient id="paint1_linear_699_15212" x1="457.98" y1="131.313" x2="260.351" y2="133.014" gradientUnits="userSpaceOnUse">
+<stop stop-color="#DA7ED0"/>
+<stop offset="0.05" stop-color="#B77BD4"/>
+<stop offset="0.11" stop-color="#9079DA"/>
+<stop offset="0.18" stop-color="#6E77DF"/>
+<stop offset="0.25" stop-color="#5175E3"/>
+<stop offset="0.33" stop-color="#3973E7"/>
+<stop offset="0.42" stop-color="#2772E9"/>
+<stop offset="0.54" stop-color="#1A71EB"/>
+<stop offset="0.813361" stop-color="#1371EC"/>
+<stop offset="1" stop-color="#064495"/>
+</linearGradient>
+<linearGradient id="paint2_linear_699_15212" x1="210.18" y1="4.19164" x2="307.181" y2="175.949" gradientUnits="userSpaceOnUse">
+<stop stop-color="#712575"/>
+<stop offset="0.09" stop-color="#9A2884"/>
+<stop offset="0.18" stop-color="#BF2C92"/>
+<stop offset="0.27" stop-color="#DA2E9C"/>
+<stop offset="0.34" stop-color="#EB30A2"/>
+<stop offset="0.4" stop-color="#F131A5"/>
+<stop offset="0.5" stop-color="#EC30A3"/>
+<stop offset="0.61" stop-color="#DF2F9E"/>
+<stop offset="0.72" stop-color="#C92D96"/>
+<stop offset="0.83" stop-color="#AA2A8A"/>
+<stop offset="0.95" stop-color="#83267C"/>
+<stop offset="1" stop-color="#712575"/>
+</linearGradient>
+<linearGradient id="paint3_linear_699_15212" x1="308" y1="260.041" x2="307.043" y2="133.204" gradientUnits="userSpaceOnUse">
+<stop stop-color="#1D5CD6"/>
+<stop offset="1" stop-color="#787BE5"/>
+</linearGradient>
+<clipPath id="clip0_699_15212">
+<rect width="512" height="512" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/templates/prebuilt/promptflow/README.md
+++ b/templates/prebuilt/promptflow/README.md
@@ -1,0 +1,141 @@
+# microsoft/promptflow
+
+Deploy a CPU-safe Promptflow package smoke demo on Phala Cloud.
+
+## Overview
+
+Promptflow is Microsoft's Python framework and tooling suite for building, testing, evaluating, and deploying LLM application flows. This prebuilt template runs a minimal HTTP API that installs the real `promptflow` Python package, verifies that it imports, and executes a deterministic local Promptflow DAG without provider credentials, model downloads, GPU access, Azure/OpenAI calls, or external databases.
+
+The default demo uses two local Python nodes:
+
+- `normalize_topic`: normalizes the input topic.
+- `compose_response`: returns deterministic flow-style output, including a stable hash-derived trace id.
+
+## Metadata
+
+- Template id: `promptflow`
+- Display name: `microsoft/promptflow`
+- Category: LLM Application Platforms & Low-Code Builders
+- Upstream repository: https://github.com/microsoft/promptflow
+- Upstream documentation: https://microsoft.github.io/promptflow/
+- Python package: `promptflow`
+- Icon source: upstream Promptflow docs logo at `scripts/docs/_static/logo.svg`
+- Upstream author: Microsoft, via the `microsoft/promptflow` GitHub repository
+- Phala prebuilt source: https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/promptflow
+
+## Included Services/Endpoints
+
+The compose file starts one public HTTP service:
+
+- `app`: Python 3.11 container based on `ghcr.io/astral-sh/uv:python3.11-bookworm-slim`. On startup it installs `promptflow==$PROMPTFLOW_VERSION`, then serves the demo API on port `8000` inside the container and `8080` publicly.
+
+Endpoints:
+
+- `GET /healthz`: Verifies `promptflow` package metadata and imports `promptflow.core.Flow` and `promptflow.core.tool`.
+- `GET /demo`: Executes the bundled Promptflow standard DAG using only local Python code.
+- `GET /v1/models`: Returns an OpenAI-compatible empty model-list shape with a `demo` explanation field.
+- `GET /`: Same readiness payload as `/healthz`.
+
+## Deployment on Phala Cloud
+
+1. Deploy the `promptflow` prebuilt template on Phala Cloud.
+2. Keep the default CPU-only resource profile for the smoke demo.
+3. Optionally set `PROMPTFLOW_VERSION` to another published Promptflow package version compatible with Python 3.11.
+4. Optionally set `PROMPTFLOW_DEMO_TOPIC` to change the default `/demo` input.
+5. After startup completes, open `https://<your-app-domain>/healthz`.
+
+The first startup downloads Python wheels from PyPI. The default compose file does not require or use API keys, LLM provider credentials, model weights, persistent databases, host bind mounts, host networking, privileged mode, or an `env_file`.
+
+## Configuration/Env Vars
+
+No credentials are required for the bundled smoke demo.
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `PROMPTFLOW_VERSION` | No | `1.18.5` | Promptflow Python package version installed at container startup. |
+| `PROMPTFLOW_DEMO_TOPIC` | No | `Phala Cloud prompt orchestration` | Default topic used by `/demo` when no `topic` query parameter is supplied. |
+
+If you adapt this template to call Azure OpenAI, OpenAI, or another provider, pass those credentials through Phala Cloud secrets or environment variables. Do not hard-code real tokens in the compose file or README examples.
+
+## Verification Commands
+
+Replace `<your-app-domain>` with the Phala Cloud public domain for the deployment:
+
+```bash
+curl -fsS https://<your-app-domain>/healthz
+curl -fsS https://<your-app-domain>/demo
+curl -fsS "https://<your-app-domain>/demo?topic=confidential%20prompt%20flows"
+curl -fsS https://<your-app-domain>/v1/models
+```
+
+Expected `/demo` fields include:
+
+```json
+{
+  "ok": true,
+  "cpu_only": true,
+  "credentials_required": false,
+  "model_downloaded": false,
+  "remote_calls": false,
+  "demo": {
+    "flow": {
+      "kind": "standard_dag",
+      "credential_free": true
+    },
+    "outputs": {
+      "remote_calls": false,
+      "steps": ["normalize_topic", "compose_response"]
+    }
+  }
+}
+```
+
+The `/v1/models` response intentionally has an empty `data` list:
+
+```json
+{
+  "object": "list",
+  "data": [],
+  "demo": {
+    "message": "This Promptflow template does not host an LLM model."
+  }
+}
+```
+
+## Local Testing
+
+Run from the parent monorepo worktree:
+
+```bash
+docker compose -f templates/prebuilt/promptflow/docker-compose.yml config >/dev/null
+docker compose -f templates/prebuilt/promptflow/docker-compose.yml up -d
+curl -fsS http://localhost:8080/healthz
+curl -fsS http://localhost:8080/demo
+curl -fsS "http://localhost:8080/demo?topic=local%20Promptflow%20test"
+curl -fsS http://localhost:8080/v1/models
+docker compose -f templates/prebuilt/promptflow/docker-compose.yml down
+```
+
+Equivalent commands from inside the `sdks/` submodule:
+
+```bash
+python3 templates/validate.py
+docker compose -f templates/prebuilt/promptflow/docker-compose.yml config >/dev/null
+```
+
+## Security/Production Notes
+
+- The demo API is unauthenticated. Add an authenticated reverse proxy or application-level auth before using it for private workflows.
+- The bundled flow is deterministic and local. It does not call Azure, OpenAI, or any external model provider.
+- The compose file does not mount host paths, use `env_file`, request privileged mode, use host networking, mount the Docker socket, or define real credentials.
+- `OTEL_SDK_DISABLED=true` and `PF_TRACING_SKIP_LOCAL_SETUP=true` are set so the smoke path stays local and quiet by default.
+- Promptflow's upstream documentation currently includes a retirement notice: feature development ended on April 20, 2026, and Microsoft states that Prompt Flow will be fully retired on April 20, 2027. Treat this template as a package compatibility and migration smoke demo rather than a recommendation for new production Promptflow workloads.
+- Pin `PROMPTFLOW_VERSION` for reproducible deployments, and review upstream release notes before changing it.
+
+## Upstream Attribution
+
+Promptflow is developed by Microsoft in the `microsoft/promptflow` repository: https://github.com/microsoft/promptflow.
+
+This Phala Cloud prebuilt template preserves upstream attribution in the template metadata and README while routing deployable assets through the Phala prebuilt template path: https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/promptflow.
+
+The icon saved as `promptflow.svg` is the upstream Promptflow docs logo from `scripts/docs/_static/logo.svg` in the Microsoft repository.

--- a/templates/prebuilt/promptflow/docker-compose.yml
+++ b/templates/prebuilt/promptflow/docker-compose.yml
@@ -1,0 +1,340 @@
+services:
+  app:
+    image: ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+    restart: unless-stopped
+    init: true
+    ports:
+      - "8080:8000"
+    environment:
+      APP_PORT: "8000"
+      PROMPTFLOW_VERSION: ${PROMPTFLOW_VERSION:-1.18.5}
+      PROMPTFLOW_DEMO_TOPIC: ${PROMPTFLOW_DEMO_TOPIC:-Phala Cloud prompt orchestration}
+      OTEL_SDK_DISABLED: "true"
+      PF_TRACING_SKIP_LOCAL_SETUP: "true"
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      PYTHONUNBUFFERED: "1"
+      UV_SYSTEM_PYTHON: "1"
+    configs:
+      - source: promptflow_demo_server
+        target: /opt/promptflow-demo/server.py
+      - source: promptflow_demo_dag
+        target: /opt/promptflow-demo/flow/flow.dag.yaml
+      - source: promptflow_demo_normalize
+        target: /opt/promptflow-demo/flow/normalize.py
+      - source: promptflow_demo_compose
+        target: /opt/promptflow-demo/flow/compose.py
+    command:
+      - /bin/sh
+      - -lc
+      - |
+        set -eu
+        uv pip install --system --no-cache "promptflow==$${PROMPTFLOW_VERSION}"
+        exec python /opt/promptflow-demo/server.py
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=5).read()",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 300s
+
+configs:
+  promptflow_demo_server:
+    content: |
+      import importlib
+      import importlib.metadata
+      import json
+      import os
+      import platform
+      import sys
+      import time
+      from http import HTTPStatus
+      from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+      from pathlib import Path
+      from urllib.parse import parse_qs, urlparse
+
+
+      STARTED_AT = time.time()
+      PACKAGE_NAME = "promptflow"
+      UPSTREAM = "https://github.com/microsoft/promptflow"
+      FLOW_SOURCE = Path("/opt/promptflow-demo/flow")
+      DEFAULT_TOPIC = os.environ.get("PROMPTFLOW_DEMO_TOPIC", "Phala Cloud prompt orchestration")
+      MAX_TOPIC_LENGTH = 160
+
+      FLOW_CACHE = None
+      FLOW_LOAD_ERROR = None
+
+
+      def package_metadata():
+          result = {
+              "distribution": PACKAGE_NAME,
+              "distribution_version": None,
+              "module_version": None,
+              "import_ok": False,
+              "checks": {},
+              "error": None,
+          }
+          try:
+              result["distribution_version"] = importlib.metadata.version(PACKAGE_NAME)
+              promptflow = importlib.import_module("promptflow")
+              core = importlib.import_module("promptflow.core")
+              result["module_version"] = getattr(promptflow, "__version__", None)
+              result["checks"] = {
+                  "promptflow_module": bool(promptflow),
+                  "promptflow_core_flow": hasattr(core, "Flow"),
+                  "promptflow_core_tool": hasattr(core, "tool"),
+              }
+              result["import_ok"] = all(result["checks"].values())
+          except Exception as exc:
+              result["error"] = f"{type(exc).__name__}: {exc}"
+          return result
+
+
+      IMPORT_STATUS = package_metadata()
+
+
+      def clean_topic(raw):
+          normalized = " ".join(str(raw or "").split())[:MAX_TOPIC_LENGTH].strip()
+          return normalized or DEFAULT_TOPIC
+
+
+      def base_payload():
+          return {
+              "service": "promptflow-local-demo",
+              "upstream": UPSTREAM,
+              "python": sys.version.split()[0],
+              "platform": platform.platform(),
+              "uptime_seconds": round(time.time() - STARTED_AT, 3),
+              "promptflow": IMPORT_STATUS,
+          }
+
+
+      def load_demo_flow():
+          global FLOW_CACHE, FLOW_LOAD_ERROR
+          if FLOW_CACHE is not None:
+              return FLOW_CACHE
+          try:
+              from promptflow.core import Flow
+
+              FLOW_CACHE = Flow.load(FLOW_SOURCE)
+              FLOW_LOAD_ERROR = None
+              return FLOW_CACHE
+          except Exception as exc:
+              FLOW_LOAD_ERROR = f"{type(exc).__name__}: {exc}"
+              raise
+
+
+      def run_demo(topic):
+          if not IMPORT_STATUS["import_ok"]:
+              raise RuntimeError(IMPORT_STATUS["error"] or "promptflow import check failed")
+
+          flow = load_demo_flow()
+          outputs = flow(topic=topic)
+          return {
+              "input": {"topic": topic},
+              "flow": {
+                  "kind": "standard_dag",
+                  "source": str(FLOW_SOURCE / "flow.dag.yaml"),
+                  "nodes": [
+                      {"name": "normalize_topic", "type": "python"},
+                      {"name": "compose_response", "type": "python"},
+                  ],
+                  "credential_free": True,
+              },
+              "outputs": outputs,
+          }
+
+
+      def response_body(path, query):
+          if path in ("/", "/healthz"):
+              ok = IMPORT_STATUS["import_ok"]
+              payload = base_payload()
+              payload.update(
+                  {
+                      "ok": ok,
+                      "status": "ready" if ok else "import_failed",
+                      "credentials_required": False,
+                      "remote_calls": False,
+                      "flow_source": str(FLOW_SOURCE / "flow.dag.yaml"),
+                  }
+              )
+              if FLOW_LOAD_ERROR:
+                  payload["last_flow_load_error"] = FLOW_LOAD_ERROR
+              return HTTPStatus.OK if ok else HTTPStatus.SERVICE_UNAVAILABLE, payload
+
+          if path == "/demo":
+              topic = clean_topic(query.get("topic", [DEFAULT_TOPIC])[0])
+              payload = base_payload()
+              payload.update(
+                  {
+                      "ok": True,
+                      "cpu_only": True,
+                      "credentials_required": False,
+                      "model_downloaded": False,
+                      "model_loaded": False,
+                      "remote_calls": False,
+                      "demo": None,
+                  }
+              )
+              try:
+                  payload["demo"] = run_demo(topic)
+              except Exception as exc:
+                  payload["ok"] = False
+                  payload["error"] = f"{type(exc).__name__}: {exc}"
+                  return HTTPStatus.INTERNAL_SERVER_ERROR, payload
+              return HTTPStatus.OK, payload
+
+          if path == "/v1/models":
+              return HTTPStatus.OK, {
+                  "object": "list",
+                  "data": [],
+                  "demo": {
+                      "message": (
+                          "This Promptflow template does not host an LLM model. "
+                          "It exposes /demo to execute a deterministic local Promptflow DAG."
+                      ),
+                      "credentials_required": False,
+                      "remote_calls": False,
+                      "model_downloaded": False,
+                      "openai_compatible_shape": True,
+                  },
+              }
+
+          return HTTPStatus.NOT_FOUND, {
+              "error": "not_found",
+              "endpoints": ["/healthz", "/demo", "/v1/models"],
+          }
+
+
+      class Handler(BaseHTTPRequestHandler):
+          server_version = "promptflow-demo"
+
+          def log_message(self, fmt, *args):
+              print(
+                  json.dumps(
+                      {
+                          "ts": time.time(),
+                          "client": self.client_address[0],
+                          "request": self.requestline,
+                          "message": fmt % args,
+                      },
+                      sort_keys=True,
+                  ),
+                  flush=True,
+              )
+
+          def do_GET(self):
+              parsed = urlparse(self.path)
+              path = parsed.path.rstrip("/") or "/"
+              query = parse_qs(parsed.query)
+              status, payload = response_body(path, query)
+              body = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+              self.send_response(status)
+              self.send_header("Content-Type", "application/json; charset=utf-8")
+              self.send_header("Cache-Control", "no-store")
+              self.send_header("Content-Length", str(len(body)))
+              self.end_headers()
+              self.wfile.write(body)
+
+
+      if __name__ == "__main__":
+          port = int(os.environ.get("APP_PORT", "8000"))
+          print(
+              json.dumps(
+                  {
+                      "event": "startup",
+                      "port": port,
+                      "promptflow": IMPORT_STATUS,
+                      "flow_source": str(FLOW_SOURCE / "flow.dag.yaml"),
+                      "remote_calls": False,
+                  },
+                  sort_keys=True,
+              ),
+              flush=True,
+          )
+          ThreadingHTTPServer(("0.0.0.0", port), Handler).serve_forever()
+
+  promptflow_demo_dag:
+    content: |
+      $$schema: https://azuremlschemas.azureedge.net/promptflow/latest/Flow.schema.json
+      inputs:
+        topic:
+          type: string
+          default: Phala Cloud prompt orchestration
+      outputs:
+        normalized_topic:
+          type: string
+          reference: $${normalize_topic.output}
+        response:
+          type: string
+          reference: $${compose_response.output.response}
+        trace_id:
+          type: string
+          reference: $${compose_response.output.trace_id}
+        steps:
+          type: list
+          reference: $${compose_response.output.steps}
+        remote_calls:
+          type: bool
+          reference: $${compose_response.output.remote_calls}
+        credentials_required:
+          type: bool
+          reference: $${compose_response.output.credentials_required}
+        model_downloaded:
+          type: bool
+          reference: $${compose_response.output.model_downloaded}
+      nodes:
+        - name: normalize_topic
+          type: python
+          source:
+            type: code
+            path: normalize.py
+          inputs:
+            topic: $${inputs.topic}
+        - name: compose_response
+          type: python
+          source:
+            type: code
+            path: compose.py
+          inputs:
+            normalized_topic: $${normalize_topic.output}
+
+  promptflow_demo_normalize:
+    content: |
+      from promptflow.core import tool
+
+
+      MAX_TOPIC_LENGTH = 160
+
+
+      @tool
+      def normalize_topic(topic: str) -> str:
+          normalized = " ".join(str(topic or "").split())[:MAX_TOPIC_LENGTH].strip()
+          return normalized or "Promptflow local demo"
+
+  promptflow_demo_compose:
+    content: |
+      import hashlib
+
+      from promptflow.core import tool
+
+
+      @tool
+      def compose_response(normalized_topic: str) -> dict:
+          digest = hashlib.sha256(normalized_topic.encode("utf-8")).hexdigest()[:12]
+          return {
+              "response": (
+                  "Promptflow executed a deterministic local DAG flow for "
+                  f"{normalized_topic}."
+              ),
+              "trace_id": f"pf-demo-{digest}",
+              "steps": ["normalize_topic", "compose_response"],
+              "remote_calls": False,
+              "credentials_required": False,
+              "model_downloaded": False,
+          }


### PR DESCRIPTION
## Summary
- Add a `promptflow` prebuilt template for `microsoft/promptflow`.
- Run a CPU-safe Promptflow HTTP demo that installs the real `promptflow` Python package and executes a deterministic local DAG flow.
- Add upstream Promptflow docs logo as `templates/icons/promptflow.svg`.

## Template Details
- Upstream repo: https://github.com/microsoft/promptflow
- Template files:
  - `templates/prebuilt/promptflow/docker-compose.yml`
  - `templates/prebuilt/promptflow/README.md`
  - `templates/icons/promptflow.svg`
  - `templates/config.json`
- Config repo routing: `https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/promptflow`
- Env vars:
  - `PROMPTFLOW_VERSION` optional, default `1.18.5`
  - `PROMPTFLOW_DEMO_TOPIC` optional, default `Phala Cloud prompt orchestration`
- Icon source: upstream Promptflow docs logo at `scripts/docs/_static/logo.svg`.

## Validation
- `python templates/validate.py` ✅
- `git diff --check origin/main...HEAD` ✅
- `docker compose -f templates/prebuilt/promptflow/docker-compose.yml config >/dev/null` ✅
- Static audit ✅
  - README covers deploy/use/verification/local/security/upstream notes
  - config id is unique
  - icon file exists
  - compose has no host bind mounts, `env_file`, real secrets, external build context, privileged mode, host network, or host IPC
  - public HTTP port is present

## Phala Cloud Smoke Test
- Deploy command: `phala deploy --name auto-template-test-promptflow-0523-181507 --compose templates/prebuilt/promptflow/docker-compose.yml --instance-type tdx.small --wait --no-public-logs --no-public-sysinfo --json`
- CVM UUID: `f416eb9d-5062-4ebc-b208-7205ebddde0b`
- App ID: `ce041e34cde4e5c821f7fb71322bce922c6ee029`
- `phala ps` showed the app container running and healthy.
- Endpoint probes:
  - `GET /healthz` -> HTTP 200, `ok=true`
  - `GET /demo?topic=Phala%20Cloud` -> HTTP 200, `ok=true`
  - `GET /v1/models` -> HTTP 200, OpenAI-compatible list shape
- Cleanup: `phala cvms delete f416eb9d-5062-4ebc-b208-7205ebddde0b --force --json` returned success; follow-up lookup returned `The requested CVM was not found`.

cc @Marvin-Cypher for review.
