### PR TITLE
fix: drop minimal app response schema

### DIFF
--- a/js/src/types/app_info_v20251028.ts
+++ b/js/src/types/app_info_v20251028.ts
@@ -47,26 +47,7 @@ export const DstackAppFullResponseV20251028Schema = z.object({
 });
 export type DstackAppFullResponseV20251028 = z.infer<typeof DstackAppFullResponseV20251028Schema>;
 
-export const DstackAppMinimalResponseV20251028Schema = z.object({
-  id: z.null().optional(),
-  app_id: z.string(),
-  name: z.null().optional(),
-  app_provision_type: z.null().optional(),
-  app_icon_url: z.null().optional(),
-  created_at: z.null().optional(),
-  kms_type: z.null().optional(),
-  current_cvm: z.null().optional(),
-  cvms: z.null().optional(),
-  cvm_count: z.null().optional(),
-});
-export type DstackAppMinimalResponseV20251028 = z.infer<
-  typeof DstackAppMinimalResponseV20251028Schema
->;
-
-export const DstackAppWithCvmResponseV20251028Schema = z.union([
-  DstackAppFullResponseV20251028Schema,
-  DstackAppMinimalResponseV20251028Schema,
-]);
+export const DstackAppWithCvmResponseV20251028Schema = DstackAppFullResponseV20251028Schema;
 export type DstackAppWithCvmResponseV20251028 = z.infer<
   typeof DstackAppWithCvmResponseV20251028Schema
 >;

--- a/js/src/types/app_info_v20260121.ts
+++ b/js/src/types/app_info_v20260121.ts
@@ -30,35 +30,12 @@ export const DstackAppFullResponseV20260522Schema = DstackAppFullResponseV202601
 });
 export type DstackAppFullResponseV20260522 = z.infer<typeof DstackAppFullResponseV20260522Schema>;
 
-export const DstackAppMinimalResponseV20260121Schema = z.object({
-  id: z.null().optional(),
-  app_id: z.string(),
-  name: z.null().optional(),
-  app_provision_type: z.null().optional(),
-  app_icon_url: z.null().optional(),
-  created_at: z.null().optional(),
-  kms_type: z.null().optional(),
-  profile: z.null().optional(),
-  current_cvm: z.null().optional(),
-  cvms: z.null().optional(),
-  cvm_count: z.null().optional(),
-});
-export type DstackAppMinimalResponseV20260121 = z.infer<
-  typeof DstackAppMinimalResponseV20260121Schema
->;
-
-export const DstackAppWithCvmResponseV20260121Schema = z.union([
-  DstackAppFullResponseV20260121Schema,
-  DstackAppMinimalResponseV20260121Schema,
-]);
+export const DstackAppWithCvmResponseV20260121Schema = DstackAppFullResponseV20260121Schema;
 export type DstackAppWithCvmResponseV20260121 = z.infer<
   typeof DstackAppWithCvmResponseV20260121Schema
 >;
 
-export const DstackAppWithCvmResponseV20260522Schema = z.union([
-  DstackAppFullResponseV20260522Schema,
-  DstackAppMinimalResponseV20260121Schema,
-]);
+export const DstackAppWithCvmResponseV20260522Schema = DstackAppFullResponseV20260522Schema;
 export type DstackAppWithCvmResponseV20260522 = z.infer<
   typeof DstackAppWithCvmResponseV20260522Schema
 >;


### PR DESCRIPTION
## Context

The Phala Cloud backend changes `GET /apps/{app_id}` to return `404` (App not found) when the app is missing or the caller lacks permission, instead of a `200` with an all-null "minimal" payload.

Backend / frontend PR (monorepo): Phala-Network/phala-cloud-monorepo#1521

## Change

The minimal response variant is now obsolete. Remove `DstackAppMinimalResponse*Schema` and collapse the response unions to the full schema for all versions:

- `DstackAppWithCvmResponseV20251028Schema` → `DstackAppFullResponseV20251028Schema`
- `DstackAppWithCvmResponseV20260121Schema` → `DstackAppFullResponseV20260121Schema`
- `DstackAppWithCvmResponseV20260522Schema` → `DstackAppFullResponseV20260522Schema`

`getAppInfo` now throws on a `404` (as for any non-2xx); `safeGetAppInfo` returns the error as a `SafeResult`.

## Test

`cd js && bun run fmt && bun run lint && bun run type-check && bun run test` — 725 passed, type-check + lint clean.