### PR TITLE
feat: add 9router template

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -4894,5 +4894,83 @@
       "diskSize": 10
     },
     "tags": ["Business Apps", "AI Agents", "Data & Storage"]
+  },
+{
+    "id": "9router",
+    "name": "decolua/9router",
+    "description": "Unlimited FREE AI coding. Connect Claude Code, Codex, Cursor, Cline, Copilot, Antigravity to FREE Claude/GPT/Gemini via 40+ providers. Auto-fallback, RTK -40% tokens, never hit limits.",
+    "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/9router",
+    "author": "decolua",
+    "icon": "9router.svg",
+    "envs": [
+      {
+        "key": "INITIAL_PASSWORD",
+        "required": true,
+        "description": "Initial dashboard login password. Set a long random value before using 9Router with real provider accounts."
+      },
+      {
+        "key": "JWT_SECRET",
+        "required": true,
+        "description": "Long random secret used to sign dashboard session cookies. Generate with openssl rand -hex 32."
+      },
+      {
+        "key": "API_KEY_SECRET",
+        "required": true,
+        "description": "Long random secret used by 9Router to generate and validate endpoint API keys. Generate with openssl rand -hex 32."
+      },
+      {
+        "key": "MACHINE_ID_SALT",
+        "required": true,
+        "description": "Long random salt for stable machine/API-key identity hashing. Generate with openssl rand -hex 32."
+      },
+      {
+        "key": "ROUTER_IMAGE_TAG",
+        "required": false,
+        "default": "latest",
+        "description": "Upstream decolua/9router Docker image tag used by Docker Compose."
+      },
+      {
+        "key": "AUTH_COOKIE_SECURE",
+        "required": false,
+        "default": "false",
+        "description": "Set to true when the dashboard is exposed only through HTTPS."
+      },
+      {
+        "key": "ENABLE_REQUEST_LOGS",
+        "required": false,
+        "default": "false",
+        "description": "Enables upstream request/translator logs. Keep false unless debugging sensitive traffic."
+      },
+      {
+        "key": "BASE_URL",
+        "required": false,
+        "default": "http://localhost:20128",
+        "description": "Server-side base URL used by internal 9Router cloud-sync jobs."
+      },
+      {
+        "key": "CLOUD_URL",
+        "required": false,
+        "default": "https://9router.com",
+        "description": "Server-side cloud-sync endpoint base URL."
+      },
+      {
+        "key": "NEXT_PUBLIC_BASE_URL",
+        "required": false,
+        "default": "http://localhost:20128",
+        "description": "Public/base URL value used by upstream UI compatibility paths."
+      },
+      {
+        "key": "NEXT_PUBLIC_CLOUD_URL",
+        "required": false,
+        "default": "https://9router.com",
+        "description": "Public cloud-sync endpoint base URL used by the upstream UI."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 1,
+      "memory": 2048,
+      "diskSize": 20
+    },
+    "tags": ["LLM Inference & Model Serving", "Infrastructure", "Developer Tools"]
   }
 ]

--- a/templates/icons/9router.svg
+++ b/templates/icons/9router.svg
@@ -1,0 +1,10 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="6" fill="url(#gradient)"/>
+  <text x="16" y="24" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="white" text-anchor="middle">9</text>
+  <defs>
+    <linearGradient id="gradient" x1="0" y1="0" x2="32" y2="32" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#f97815"/>
+      <stop offset="1" stop-color="#c2590a"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/templates/prebuilt/9router/README.md
+++ b/templates/prebuilt/9router/README.md
@@ -1,0 +1,131 @@
+# decolua/9router
+
+Deploy 9Router on Phala Cloud with a CPU-safe smoke verifier.
+
+## Overview
+
+9Router is a self-hosted AI gateway and dashboard for routing coding tools such as Claude Code, Codex, Cursor, Cline, Copilot, Antigravity, OpenClaw, Continue, and OpenCode through a single OpenAI-compatible endpoint. It supports provider/account fallback, model combos, format translation, usage tracking, cloud sync, and RTK token compression for tool output.
+
+This template runs the official upstream Docker image and adds a small front verifier service. The verifier exposes unauthenticated smoke endpoints that prove the upstream gateway is running and can return its local model catalog. The default smoke path does not call model providers, start OAuth/browser-login flows, download model weights, or require GPU access. Real provider routing is configured later through the 9Router dashboard.
+
+## Metadata
+
+- Template id: `9router`
+- Display name: `decolua/9router`
+- Category: LLM Gateway & API Proxy
+- Upstream repository: https://github.com/decolua/9router
+- Upstream Docker docs: https://github.com/decolua/9router/blob/master/DOCKER.md
+- Docker image: `decolua/9router`
+- Icon source: upstream `public/favicon.svg` from https://github.com/decolua/9router/blob/master/public/favicon.svg
+
+## What This Template Runs
+
+- `router`: the official `decolua/9router` container listening internally on port `20128`, with persistent state in the named `9router_data` volume at `/app/data`.
+- `app`: a Node.js verifier and reverse proxy listening publicly on port `8080`.
+
+The template does not use host bind mounts, `env_file`, privileged mode, host networking, host IPC, Docker socket access, GPUs, or external build contexts.
+
+## Environment Variables
+
+The smoke endpoints work without model-provider credentials. The dashboard should still be protected before real use, so set strong values for the required secret variables in Phala Cloud.
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `INITIAL_PASSWORD` | Yes | unset | Initial dashboard login password when no password hash exists. Set a long random value; do not rely on upstream's fallback password. |
+| `JWT_SECRET` | Yes | unset | Long random secret used to sign dashboard session cookies. Generate with `openssl rand -hex 32`. |
+| `API_KEY_SECRET` | Yes | unset | Long random secret used by 9Router when generating and validating endpoint API keys. Generate with `openssl rand -hex 32`. |
+| `MACHINE_ID_SALT` | Yes | unset | Long random salt for stable machine/API-key identity hashing. Generate with `openssl rand -hex 32`. |
+| `ROUTER_IMAGE_TAG` | No | `latest` | Upstream `decolua/9router` Docker image tag. Pin a release tag for production when one is available. |
+| `BASE_URL` | No | `http://localhost:20128` | Server-side base URL used by internal 9Router cloud-sync jobs. Update if you enable cloud sync behind a public domain. |
+| `CLOUD_URL` | No | `https://9router.com` | Server-side cloud-sync endpoint base URL. |
+| `NEXT_PUBLIC_BASE_URL` | No | `http://localhost:20128` | Public/base URL value used by upstream UI compatibility paths. |
+| `NEXT_PUBLIC_CLOUD_URL` | No | `https://9router.com` | Public cloud-sync endpoint base URL used by the upstream UI. |
+| `AUTH_COOKIE_SECURE` | No | `false` | Set to `true` when the dashboard is exposed only through HTTPS. |
+| `ENABLE_REQUEST_LOGS` | No | `false` | Enables upstream request/translator logs. Keep `false` unless debugging because logs can contain sensitive prompts or headers. |
+
+Provider credentials such as OpenAI, Anthropic, Gemini, OpenRouter, GLM, MiniMax, Kiro, GitHub Copilot, Cursor, or Codex tokens are not placed in this compose file. Add providers through the dashboard after deployment.
+
+## Deploy On Phala Cloud
+
+1. Create a new Phala Cloud deployment from the `9router` template.
+2. Set strong values for `INITIAL_PASSWORD`, `JWT_SECRET`, `API_KEY_SECRET`, and `MACHINE_ID_SALT`.
+3. Keep the default CPU resource shape for the smoke deployment. Increase memory if you enable heavy dashboard usage or request logging.
+4. Wait for the service health check to pass.
+5. Open `https://<your-app-domain>/healthz` and `https://<your-app-domain>/demo`.
+6. Open `https://<your-app-domain>/dashboard` and sign in with `INITIAL_PASSWORD` to configure providers, API keys, and model combos.
+
+## Exposed Endpoints
+
+- `GET /healthz`: verifies the upstream 9Router container is reachable and that its local `/v1/models` catalog returns JSON.
+- `GET /demo`: returns the same verifier status plus a deterministic explanation of the checks performed.
+- `GET /v1/models`: returns the upstream OpenAI-compatible model list through the running 9Router process. In the default empty state this is a local/static catalog and does not call providers.
+- `GET /dashboard`: proxies to the 9Router dashboard. Use `INITIAL_PASSWORD` for the first login.
+- Other paths are proxied to the upstream 9Router service. Remote `/v1/*` production calls should use API keys generated in the dashboard.
+
+## Smoke Verification
+
+After deployment:
+
+```bash
+curl -fsS https://<your-app-domain>/healthz
+curl -fsS https://<your-app-domain>/demo
+curl -fsS https://<your-app-domain>/v1/models
+```
+
+Use these commands to verify the 9Router process and template proxy without sending prompts to any external model provider.
+
+Expected health fields include:
+
+```json
+{
+  "ok": true,
+  "status": "ready",
+  "safety": {
+    "official_upstream_image": true,
+    "cpu_only": true,
+    "credentials_required_for_smoke_endpoints": false,
+    "provider_network_calls_performed_by_smoke_endpoints": false,
+    "model_downloads": false
+  }
+}
+```
+
+## Local Verification
+
+Run from the parent monorepo worktree root:
+
+```bash
+docker compose -f templates/prebuilt/9router/docker-compose.yml config >/dev/null
+docker compose -f templates/prebuilt/9router/docker-compose.yml up -d
+curl -fsS http://localhost:8080/healthz
+curl -fsS http://localhost:8080/demo
+curl -fsS http://localhost:8080/v1/models
+docker compose -f templates/prebuilt/9router/docker-compose.yml down
+```
+
+Template validation from the parent monorepo worktree root:
+
+```bash
+python3 templates/validate.py
+git diff --check origin/main...HEAD
+```
+
+## Production Notes
+
+- 9Router stores provider connections, generated endpoint API keys, combos, usage data, and dashboard state under `/app/data` in the `9router_data` named volume.
+- Set `INITIAL_PASSWORD`, `JWT_SECRET`, `API_KEY_SECRET`, and `MACHINE_ID_SALT` before using the dashboard with real provider accounts.
+- Generate 9Router endpoint API keys from the dashboard before exposing `/v1/chat/completions`, `/v1/responses`, or provider-backed routes to clients.
+- OAuth/subscription providers may involve browser authentication and upstream provider terms. Complete those flows intentionally from the dashboard; the smoke verifier does not perform them.
+- Some upstream providers may be free, subscription-backed, or API-key based. 9Router routes to them only after you configure the corresponding provider credentials or OAuth accounts.
+- Keep `ENABLE_REQUEST_LOGS=false` unless actively debugging. Request logs can include sensitive prompts, headers, provider responses, and tool output.
+- Set `AUTH_COOKIE_SECURE=true` when using an HTTPS-only public domain.
+- Pin `ROUTER_IMAGE_TAG` for reproducible production deployments. The template defaults to `latest` to follow the upstream Docker quick start.
+
+## Upstream Attribution
+
+- Upstream project: https://github.com/decolua/9router
+- Author: `decolua`
+- Docker image: `decolua/9router`
+- Architecture notes inspected: https://github.com/decolua/9router/blob/master/docs/ARCHITECTURE.md
+- Docker deployment docs inspected: https://github.com/decolua/9router/blob/master/DOCKER.md
+- Icon: copied from upstream `public/favicon.svg` and saved as `templates/icons/9router.svg`.

--- a/templates/prebuilt/9router/docker-compose.yml
+++ b/templates/prebuilt/9router/docker-compose.yml
@@ -1,0 +1,379 @@
+services:
+  app:
+    image: node:22-alpine
+    restart: unless-stopped
+    init: true
+    ports:
+      - "8080:8080"
+    environment:
+      PORT: "8080"
+      ROUTER_BASE_URL: "http://router:20128"
+      ROUTER_IMAGE_TAG: ${ROUTER_IMAGE_TAG:-latest}
+      NODE_ENV: production
+    configs:
+      - source: verifier_mjs
+        target: /opt/9router-verifier/server.mjs
+    command:
+      - node
+      - /opt/9router-verifier/server.mjs
+    depends_on:
+      router:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "node -e \"fetch('http://127.0.0.1:' + (process.env.PORT || '8080') + '/healthz').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))\"",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
+
+  router:
+    image: decolua/9router:${ROUTER_IMAGE_TAG:-latest}
+    restart: unless-stopped
+    init: true
+    expose:
+      - "20128"
+    environment:
+      DATA_DIR: /app/data
+      PORT: "20128"
+      HOSTNAME: "0.0.0.0"
+      NODE_ENV: production
+      NEXT_TELEMETRY_DISABLED: "1"
+      BASE_URL: ${BASE_URL:-http://localhost:20128}
+      CLOUD_URL: ${CLOUD_URL:-https://9router.com}
+      NEXT_PUBLIC_BASE_URL: ${NEXT_PUBLIC_BASE_URL:-http://localhost:20128}
+      NEXT_PUBLIC_CLOUD_URL: ${NEXT_PUBLIC_CLOUD_URL:-https://9router.com}
+      INITIAL_PASSWORD: ${INITIAL_PASSWORD:-}
+      JWT_SECRET: ${JWT_SECRET:-}
+      API_KEY_SECRET: ${API_KEY_SECRET:-}
+      MACHINE_ID_SALT: ${MACHINE_ID_SALT:-}
+      AUTH_COOKIE_SECURE: ${AUTH_COOKIE_SECURE:-false}
+      ENABLE_REQUEST_LOGS: ${ENABLE_REQUEST_LOGS:-false}
+    volumes:
+      - 9router_data:/app/data
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "node -e \"fetch('http://127.0.0.1:20128/v1/models').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))\"",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 120s
+
+configs:
+  verifier_mjs:
+    content: |
+      import http from "node:http";
+      import https from "node:https";
+      import os from "node:os";
+
+      const STARTED_AT = Date.now();
+      const PORT = Number.parseInt(process.env.PORT || "8080", 10);
+      const ROUTER_BASE_URL = process.env.ROUTER_BASE_URL || "http://router:20128";
+      const UPSTREAM_REPO = "https://github.com/decolua/9router";
+      const TEMPLATE_REPO = "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/9router";
+      const ROUTER_IMAGE = "decolua/9router";
+      const LOCAL_ROUTER_HOST = "localhost:20128";
+      const HOP_BY_HOP_HEADERS = new Set([
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+      ]);
+
+      function routerUrl(path) {
+        const base = new URL(ROUTER_BASE_URL);
+        return new URL(path, base);
+      }
+
+      function transportFor(url) {
+        return url.protocol === "https:" ? https : http;
+      }
+
+      function routerRequest(path, options) {
+        const opts = options || {};
+        const url = routerUrl(path);
+        const headers = Object.assign({}, opts.headers || {});
+        if (opts.useLocalHostHeader) {
+          headers.host = LOCAL_ROUTER_HOST;
+        }
+        return new Promise((resolve) => {
+          const req = transportFor(url).request(
+            {
+              hostname: url.hostname,
+              port: url.port || (url.protocol === "https:" ? 443 : 80),
+              path: url.pathname + url.search,
+              method: opts.method || "GET",
+              headers,
+              timeout: opts.timeoutMs || 8000,
+            },
+            (res) => {
+              const chunks = [];
+              res.on("data", (chunk) => chunks.push(chunk));
+              res.on("end", () => {
+                const body = Buffer.concat(chunks);
+                resolve({
+                  ok: res.statusCode >= 200 && res.statusCode < 300,
+                  status: res.statusCode,
+                  headers: res.headers,
+                  body,
+                });
+              });
+            },
+          );
+          req.on("timeout", () => req.destroy(new Error("router request timed out")));
+          req.on("error", (error) => {
+            resolve({
+              ok: false,
+              status: 0,
+              headers: {},
+              body: Buffer.from(""),
+              error: error.name + ": " + error.message,
+            });
+          });
+          if (opts.body) {
+            req.write(opts.body);
+          }
+          req.end();
+        });
+      }
+
+      async function routerJson(path) {
+        const response = await routerRequest(path, {
+          headers: { accept: "application/json" },
+          useLocalHostHeader: true,
+        });
+        let parsed = null;
+        let parseError = null;
+        const text = response.body.toString("utf8");
+        if (text) {
+          try {
+            parsed = JSON.parse(text);
+          } catch (error) {
+            parseError = error.name + ": " + error.message;
+          }
+        }
+        return Object.assign({}, response, {
+          json: parsed,
+          text: text,
+          parseError: parseError,
+        });
+      }
+
+      function writeJson(res, status, payload) {
+        const body = Buffer.from(JSON.stringify(payload, null, 2) + "\n", "utf8");
+        res.writeHead(status, {
+          "content-type": "application/json; charset=utf-8",
+          "cache-control": "no-store",
+          "content-length": body.length,
+        });
+        res.end(body);
+      }
+
+      function modelSummary(modelsResponse) {
+        const models = Array.isArray(modelsResponse.json && modelsResponse.json.data)
+          ? modelsResponse.json.data
+          : [];
+        return {
+          ok: modelsResponse.ok && Array.isArray(modelsResponse.json && modelsResponse.json.data),
+          status: modelsResponse.status,
+          count: models.length,
+          sample_ids: models
+            .map((model) => model && model.id)
+            .filter((id) => typeof id === "string")
+            .slice(0, 10),
+          parse_error: modelsResponse.parseError,
+          error: modelsResponse.error || null,
+        };
+      }
+
+      function basePayload() {
+        return {
+          service: "9router-phala-verifier",
+          upstream: {
+            repo: UPSTREAM_REPO,
+            docker_image: ROUTER_IMAGE,
+            docker_tag: process.env.ROUTER_IMAGE_TAG || "latest",
+            template: TEMPLATE_REPO,
+            icon_source: "https://github.com/decolua/9router/blob/master/public/favicon.svg",
+          },
+          runtime: {
+            node: process.version,
+            platform: os.platform() + "/" + os.arch(),
+            uptime_seconds: Math.round((Date.now() - STARTED_AT) / 100) / 10,
+          },
+          safety: {
+            official_upstream_image: true,
+            cpu_only: true,
+            credentials_required_for_smoke_endpoints: false,
+            provider_network_calls_performed_by_smoke_endpoints: false,
+            model_downloads: false,
+            gpu_required: false,
+            browser_auth_required_for_smoke_endpoints: false,
+            host_bind_mounts: false,
+            persistent_data: "named Docker volume mounted at /app/data",
+          },
+        };
+      }
+
+      async function healthPayload() {
+        const init = await routerRequest("/api/init", {
+          headers: { accept: "text/plain" },
+          useLocalHostHeader: true,
+        });
+        const models = await routerJson("/v1/models");
+        const summary = modelSummary(models);
+        const ok = init.ok && summary.ok;
+        const payload = basePayload();
+        payload.ok = ok;
+        payload.status = ok ? "ready" : "unhealthy";
+        payload.router = {
+          init_status: init.status,
+          models: summary,
+        };
+        payload.endpoints = ["/healthz", "/demo", "/v1/models", "/dashboard"];
+        return payload;
+      }
+
+      async function handleHealth(req, res) {
+        const payload = await healthPayload();
+        writeJson(res, payload.ok ? 200 : 503, payload);
+      }
+
+      async function handleDemo(req, res) {
+        const payload = await healthPayload();
+        payload.demo = {
+          type: "deterministic 9Router gateway smoke verification",
+          checks: [
+            "Starts the official decolua/9router Docker image.",
+            "Verifies the public Next.js init route.",
+            "Reads the local OpenAI-compatible /v1/models catalog through the running 9Router process.",
+            "Does not call /v1/chat/completions, external model providers, OAuth flows, or browser login.",
+          ],
+          gateway_capabilities: [
+            "OpenAI-compatible /v1 endpoint for coding tools.",
+            "Provider routing across subscription, API-key, and free-tier providers.",
+            "Fallback model combos and account fallback.",
+            "RTK token saver for tool output compression.",
+          ],
+        };
+        writeJson(res, payload.ok ? 200 : 503, payload);
+      }
+
+      async function handleModels(req, res) {
+        const response = await routerRequest("/v1/models", {
+          headers: { accept: "application/json" },
+          useLocalHostHeader: true,
+        });
+        const contentType = response.headers["content-type"] || "application/json; charset=utf-8";
+        res.writeHead(response.ok ? response.status : 503, {
+          "content-type": contentType,
+          "cache-control": "no-store",
+        });
+        if (response.ok) {
+          res.end(response.body);
+        } else {
+          res.end(JSON.stringify({
+            error: "router_models_unavailable",
+            status: response.status,
+            message: response.error || response.body.toString("utf8"),
+          }) + "\n");
+        }
+      }
+
+      function proxyRequest(req, res) {
+        const url = routerUrl(req.url || "/");
+        const headers = {};
+        for (const entry of Object.entries(req.headers)) {
+          const key = entry[0].toLowerCase();
+          if (!HOP_BY_HOP_HEADERS.has(key)) {
+            headers[entry[0]] = entry[1];
+          }
+        }
+        headers.host = req.headers.host || "localhost";
+        headers["x-forwarded-host"] = req.headers.host || "";
+        headers["x-forwarded-proto"] = req.headers["x-forwarded-proto"] || "http";
+        headers["x-forwarded-for"] = req.socket.remoteAddress || "";
+
+        const upstream = transportFor(url).request(
+          {
+            hostname: url.hostname,
+            port: url.port || (url.protocol === "https:" ? 443 : 80),
+            path: url.pathname + url.search,
+            method: req.method,
+            headers,
+          },
+          (upstreamRes) => {
+            const responseHeaders = {};
+            for (const entry of Object.entries(upstreamRes.headers)) {
+              const key = entry[0].toLowerCase();
+              if (!HOP_BY_HOP_HEADERS.has(key)) {
+                responseHeaders[entry[0]] = entry[1];
+              }
+            }
+            res.writeHead(upstreamRes.statusCode || 502, responseHeaders);
+            upstreamRes.pipe(res);
+          },
+        );
+        upstream.on("error", (error) => {
+          writeJson(res, 502, {
+            error: "router_proxy_error",
+            message: error.name + ": " + error.message,
+          });
+        });
+        req.pipe(upstream);
+      }
+
+      function normalizePathname(pathname) {
+        let path = pathname || "/";
+        while (path.length > 1 && path.endsWith("/")) {
+          path = path.slice(0, -1);
+        }
+        return path;
+      }
+
+      const server = http.createServer(async (req, res) => {
+        const parsed = new URL(req.url || "/", "http://127.0.0.1");
+        const path = normalizePathname(parsed.pathname);
+        try {
+          if (req.method === "GET" && path === "/healthz") {
+            await handleHealth(req, res);
+            return;
+          }
+          if (req.method === "GET" && path === "/demo") {
+            await handleDemo(req, res);
+            return;
+          }
+          if (req.method === "GET" && path === "/v1/models") {
+            await handleModels(req, res);
+            return;
+          }
+          proxyRequest(req, res);
+        } catch (error) {
+          writeJson(res, 500, {
+            error: "internal_error",
+            message: error.name + ": " + error.message,
+          });
+        }
+      });
+
+      server.listen(PORT, "0.0.0.0", () => {
+        console.log(JSON.stringify({
+          event: "startup",
+          service: "9router-phala-verifier",
+          port: PORT,
+          router_base_url: ROUTER_BASE_URL,
+        }));
+      });
+
+volumes:
+  9router_data:


### PR DESCRIPTION
## Summary
- Add a Phala Cloud prebuilt template for `decolua/9router`.
- Upstream repository: https://github.com/decolua/9router
- Template files: `templates/prebuilt/9router/docker-compose.yml`, `templates/prebuilt/9router/README.md`, `templates/config.json`
- Icon: `9router.svg`; source documented in the README.

## Environment variables
- See the template README for optional provider/runtime environment variables. No real secrets are included.

## Validation
- `python sdks/templates/validate.py`
- `git -C sdks diff --check origin/main...HEAD`
- `docker compose -f sdks/templates/prebuilt/9router/docker-compose.yml config >/dev/null`
- static audit: README coverage, config ID uniqueness, icon file, forbidden compose directives, host bind mounts, and secret-like literals

## Deployment smoke
- Deployed with `phala deploy --profile hermes-admin-cvm-check --instance-type tdx.small --node-id 12 --wait --no-public-logs --no-public-sysinfo`
- Smoke CVM: `be7f0647-47a2-4fcd-9727-af2e6cece1a1`
- Smoke app: `596c6fd109bc085a466d3d28409dae80bf26e42d`
- Endpoint probe: `https://596c6fd109bc085a466d3d28409dae80bf26e42d-8080.dstack-pha-prod7.phala.network/healthz -> 200 1514 0.294275 rc=0`
- Cleanup: temporary smoke CVM deletion requested and verified separately.

cc @Marvin-Cypher for review.
