### PR TITLE
feat(go): add UpdateCVMListed for in-place marketplace visibility

### DIFF
--- a/go/cvms_config.go
+++ b/go/cvms_config.go
@@ -37,6 +37,21 @@ func (c *Client) UpdateCVMVisibility(ctx context.Context, cvmID string, req *Upd
 	return &result, nil
 }
 
+// UpdateListedRequest is the request body for toggling a CVM's public
+// marketplace listing.
+type UpdateListedRequest struct {
+	Listed bool `json:"listed"`
+}
+
+// UpdateCVMListed toggles whether a CVM is publicly listed. It hits the
+// dedicated PATCH /cvms/{id}/listed endpoint, which is a pure metadata update
+// (plain DB write) — no compose change, no redeploy, no attestation change.
+func (c *Client) UpdateCVMListed(ctx context.Context, cvmID string, listed bool) error {
+	return c.doWithRetry(ctx, func() error {
+		return c.doJSON(ctx, "PATCH", cvmPath(cvmID, "listed"), &UpdateListedRequest{Listed: listed}, nil)
+	})
+}
+
 // UpdateOSImageRequest is the request for updating CVM OS image.
 type UpdateOSImageRequest struct {
 	OSImageName string `json:"os_image_name"`

--- a/go/cvms_config_test.go
+++ b/go/cvms_config_test.go
@@ -1,0 +1,43 @@
+package phala
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestUpdateCVMListed covers the dedicated PATCH /cvms/{id}/listed endpoint
+// used by the Terraform provider to toggle marketplace visibility in place
+// (no redeploy, no attestation change).
+func TestUpdateCVMListed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PATCH" {
+			t.Errorf("method = %q, want PATCH", r.Method)
+		}
+		if r.URL.Path != "/cvms/cvm-123/listed" {
+			t.Errorf("path = %q, want /cvms/cvm-123/listed", r.URL.Path)
+		}
+
+		var body UpdateListedRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if !body.Listed {
+			t.Errorf("listed = %v, want true", body.Listed)
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(WithAPIKey("k"), WithBaseURL(srv.URL))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if err := client.UpdateCVMListed(context.Background(), "cvm-123", true); err != nil {
+		t.Fatalf("UpdateCVMListed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Adds `(*Client).UpdateCVMListed(ctx, cvmID, listed)` hitting the dedicated `PATCH /cvms/{id}/listed` endpoint.

`PATCH /cvms/{id}/listed` is a pure metadata update (plain DB write) — no compose change, no redeploy, no attestation change. The unified `PATCH /cvms/{id}` does **not** process the `listed` field, so a dedicated method is required.

## Why
The Terraform provider currently forces a full CVM **replacement** when `phala_app.listed` (marketplace visibility) is toggled. With this method the provider can make it an in-place patch instead.

## Test
`TestUpdateCVMListed` asserts method (`PATCH`), path (`/cvms/{id}/listed`), and body (`{"listed": true}`) against an httptest server. `go build ./...` + `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)