### PR TITLE
feat: add oh-my-pi template

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -5122,5 +5122,47 @@
     "diskSize": 10
   },
   "tags": ["RAG", "AI Agents", "Web Data & Search"]
-}
+},
+{
+    "id": "oh-my-pi",
+    "name": "can1357/oh-my-pi",
+    "description": "⌥ AI Coding agent for the terminal — hash-anchored edits, optimized tool harness, LSP, Python, browser, subagents, and more",
+    "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/oh-my-pi",
+    "author": "can1357",
+    "icon": "oh-my-pi.svg",
+    "envs": [
+      {
+        "key": "OH_MY_PI_VERSION",
+        "required": false,
+        "default": "15.6.0",
+        "description": "Published @oh-my-pi/pi-coding-agent package version installed by the verifier at container startup."
+      },
+      {
+        "key": "ANTHROPIC_API_KEY",
+        "required": false,
+        "description": "Optional Anthropic provider key for later real omp sessions. The default verifier endpoints do not use it."
+      },
+      {
+        "key": "OPENAI_API_KEY",
+        "required": false,
+        "description": "Optional OpenAI provider key for later real omp sessions. The default verifier endpoints do not use it."
+      },
+      {
+        "key": "GEMINI_API_KEY",
+        "required": false,
+        "description": "Optional Google Gemini provider key for later real omp sessions. The default verifier endpoints do not use it."
+      },
+      {
+        "key": "OPENROUTER_API_KEY",
+        "required": false,
+        "description": "Optional OpenRouter provider key for later real omp sessions. The default verifier endpoints do not use it."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 1,
+      "memory": 2048,
+      "diskSize": 20
+    },
+    "tags": ["AI Agents", "Developer Tools", "Automation"]
+  }
 ]

--- a/templates/icons/oh-my-pi.svg
+++ b/templates/icons/oh-my-pi.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 90" width="120" height="90">
+  <!-- Pi symbol with plugin connector -->
+  <!-- Horizontal bar -->
+  <rect x="10" y="8" width="100" height="12" rx="2" fill="#fafafa"/>
+  <!-- Left leg -->
+  <rect x="25" y="20" width="12" height="62" rx="2" fill="#fafafa"/>
+  <!-- Right leg -->
+  <rect x="75" y="20" width="12" height="45" rx="2" fill="#fafafa"/>
+  <!-- Plugin connector -->
+  <rect x="71" y="55" width="20" height="16" rx="3" fill="#f97316"/>
+  <rect x="76" y="59" width="3" height="8" rx="1" fill="#0d0d0d"/>
+  <rect x="82" y="59" width="3" height="8" rx="1" fill="#0d0d0d"/>
+  <!-- Decorative dots -->
+  <circle cx="18" cy="14" r="2" fill="#f97316" opacity="0.8"/>
+  <circle cx="102" cy="14" r="2" fill="#f97316" opacity="0.8"/>
+</svg>

--- a/templates/prebuilt/oh-my-pi/README.md
+++ b/templates/prebuilt/oh-my-pi/README.md
@@ -1,0 +1,124 @@
+# can1357/oh-my-pi on Phala Cloud
+
+## Metadata
+
+- Template id: `oh-my-pi`
+- Display name: `can1357/oh-my-pi`
+- Category: AI Apps & Workflows
+- Deployable template repository: https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/oh-my-pi
+- Upstream repository: https://github.com/can1357/oh-my-pi
+- Upstream package: `@oh-my-pi/pi-coding-agent`
+- Default package version: `15.6.0`
+- Exposed port: `8080`
+- Icon source: `assets/icon.svg` from the upstream `can1357/oh-my-pi` repository, saved as `templates/icons/oh-my-pi.svg`.
+
+## Overview
+
+Oh My Pi (`omp`) is an AI coding agent for terminal workflows. The upstream README describes a Bun-based CLI with hash-anchored edits, an optimized tool harness, LSP and debugger integrations, Python and JavaScript evaluation, browser tooling, subagents, review workflows, and many model providers.
+
+This Phala Cloud template intentionally runs a credential-free local verifier instead of a hosted interactive agent. At startup it installs the real published `@oh-my-pi/pi-coding-agent` package with Bun, starts a small HTTP server, and exposes deterministic endpoints that exercise local package and CLI primitives only.
+
+The default verifier does not call model providers, does not use browser authentication, does not download model weights, does not require GPU access, and does not require API keys.
+
+## What This Template Runs
+
+- `app`: `oven/bun:1.3.14-slim`, matching the upstream package requirement of Bun `>=1.3.14`.
+- A startup command that installs `@oh-my-pi/pi-coding-agent@$OH_MY_PI_VERSION` into a named volume under `/home/bun/oh-my-pi-app`.
+- A Bun HTTP server on port `8080` from the inline compose config.
+- A bundled sample Markdown file used by the `omp read` smoke path.
+
+The verifier commands are run with a sanitized environment that omits provider API keys even if optional provider variables are configured for later production use.
+
+## Deployment Steps
+
+Deploy the `oh-my-pi` prebuilt template on Phala Cloud and expose port `8080`.
+
+For a local smoke run from the `sdks/` submodule:
+
+```bash
+docker compose -f templates/prebuilt/oh-my-pi/docker-compose.yml up -d
+curl -fsS http://localhost:8080/healthz
+curl -fsS http://localhost:8080/demo
+curl -fsS http://localhost:8080/v1/models
+docker compose -f templates/prebuilt/oh-my-pi/docker-compose.yml down
+```
+
+The first startup downloads the pinned npm package and caches it in named volumes. Changing `OH_MY_PI_VERSION` causes the startup command to reinstall that version.
+
+## Environment Variables
+
+No credentials are required for `/healthz`, `/demo`, or `/v1/models`.
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `OH_MY_PI_VERSION` | No | `15.6.0` | Published `@oh-my-pi/pi-coding-agent` version installed by the verifier at container startup. |
+| `PORT` | No | `8080` | HTTP port used inside the container. |
+| `ANTHROPIC_API_KEY` | No | unset | Optional Anthropic provider key for later real `omp` sessions. The verifier endpoints do not pass it to `omp`. |
+| `OPENAI_API_KEY` | No | unset | Optional OpenAI provider key for later real `omp` sessions. The verifier endpoints do not pass it to `omp`. |
+| `GEMINI_API_KEY` | No | unset | Optional Google Gemini provider key for later real `omp` sessions. The verifier endpoints do not pass it to `omp`. |
+| `OPENROUTER_API_KEY` | No | unset | Optional OpenRouter provider key for later real `omp` sessions. The verifier endpoints do not pass it to `omp`. |
+
+The compose file also sets local, non-interactive runtime defaults such as `PI_NO_TITLE=1`, `PI_NO_PTY=1`, `PI_AUTH_NO_BORROW=1`, `PI_FORCE_IMAGE_PROTOCOL=none`, `PI_PYTHON_SKIP_CHECK=1`, `CI=true`, `NO_COLOR=1`, and isolated Bun/cache paths under `/home/bun`.
+
+## Exposed Endpoints
+
+- `GET /healthz`: checks that the package metadata is present, the requested version marker matches, and `omp --version` runs locally.
+- `GET /demo`: runs the health checks plus `omp --smoke-test`, `omp completions bash`, and `omp read /opt/oh-my-pi-demo/sample.md:raw`.
+- `GET /v1/models`: returns an OpenAI-compatible model-list-shaped metadata response with `oh-my-pi/local-verifier`. It is not a hosted model and does not proxy an LLM.
+- `GET /`: same readiness payload as `/healthz`.
+
+Example verification:
+
+```bash
+curl -fsS http://localhost:8080/healthz | jq '.status, .checks.package.installed_version'
+curl -fsS http://localhost:8080/demo | jq '.what_ran, .hosted_model_calls_performed, .credentials_required_for_health'
+curl -fsS http://localhost:8080/v1/models | jq '.data[0].id'
+```
+
+Use `/demo` to verify the local package install and CLI smoke path without provider credentials.
+
+Expected results:
+
+- `/healthz` returns `200 OK` after the package install completes.
+- `.checks.package.name` is `@oh-my-pi/pi-coding-agent`.
+- `.checks.cli_version.version_output` contains the installed `omp` version.
+- `/demo` reports `hosted_model_calls_performed: false`.
+- `/demo` reports `provider_credentials_passed_to_verifier_commands: false`.
+- `/v1/models` includes `oh-my-pi/local-verifier`.
+
+## Template Validation
+
+Run these from the parent monorepo worktree:
+
+```bash
+python3 templates/validate.py
+git diff --check origin/main...HEAD
+docker compose -f templates/prebuilt/oh-my-pi/docker-compose.yml config >/dev/null
+```
+
+## Production Notes
+
+This template is a verifier, not a full hosted `omp` terminal session. Real Oh My Pi usage is interactive and can access a workspace, shell tools, model providers, browser tooling, LSP servers, debugger adapters, subagents, and local session state. Treat a production agent endpoint as a privileged code-execution surface.
+
+Before adapting this verifier into a production service:
+
+- Add authentication and network policy before exposing any endpoint that can run arbitrary agent tasks.
+- Provide model/provider credentials only through Phala Cloud environment settings or a secret manager. Do not hard-code real API keys, tokens, cookies, private keys, OTPs, or passwords in this compose file, README, image layers, or source control.
+- Mount or provision only the workspace data that the agent should be allowed to read and edit.
+- Review upstream provider configuration, auth storage, browser, MCP, LSP, debugger, and shell-tool settings for your threat model.
+- Pin `OH_MY_PI_VERSION` and review upstream release notes before changing it.
+
+## Security Notes
+
+- The compose file uses named volumes only; it has no host bind mounts, `env_file`, external build context, privileged mode, host networking, host IPC, Docker socket mount, GPU devices, or real secrets.
+- The default endpoints run local package and CLI checks only.
+- Optional provider credentials are reported only as configured/not configured booleans and are not passed to the verifier commands.
+- Browser authentication and hosted model calls are deliberately outside the default smoke path.
+
+## Upstream Attribution
+
+- Upstream project: https://github.com/can1357/oh-my-pi
+- Upstream documentation inspected: upstream README install/runtime sections, `docs/models.md`, `docs/environment-variables.md`, `docs/sdk.md`, `Dockerfile`, and `scripts/install.sh`.
+- npm package: https://www.npmjs.com/package/@oh-my-pi/pi-coding-agent
+- Author: Can Boluk / `can1357`
+- Icon: upstream `assets/icon.svg`, copied into this template as `templates/icons/oh-my-pi.svg`.

--- a/templates/prebuilt/oh-my-pi/docker-compose.yml
+++ b/templates/prebuilt/oh-my-pi/docker-compose.yml
@@ -1,0 +1,371 @@
+services:
+  app:
+    image: oven/bun:1.3.14-slim
+    restart: unless-stopped
+    init: true
+    user: "0:0"
+    ports:
+      - "8080:8080"
+    environment:
+      PORT: ${PORT:-8080}
+      OH_MY_PI_VERSION: ${OH_MY_PI_VERSION:-15.6.0}
+      OH_MY_PI_PACKAGE: "@oh-my-pi/pi-coding-agent"
+      OH_MY_PI_APP_DIR: /home/bun/oh-my-pi-app
+      HOME: /home/bun
+      XDG_CONFIG_HOME: /home/bun/.config
+      XDG_CACHE_HOME: /home/bun/.cache
+      PI_CODING_AGENT_DIR: /home/bun/.omp/agent
+      PI_NO_TITLE: "1"
+      PI_NO_PTY: "1"
+      PI_AUTH_NO_BORROW: "1"
+      PI_FORCE_IMAGE_PROTOCOL: "none"
+      PI_PYTHON_SKIP_CHECK: "1"
+      CI: "true"
+      NO_COLOR: "1"
+      TERM: "dumb"
+      BUN_INSTALL_CACHE_DIR: /home/bun/.bun/install/cache
+      BUN_RUNTIME_TRANSPILER_CACHE_PATH: /home/bun/.cache/bun/transpiler
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+    working_dir: /home/bun/oh-my-pi-app
+    command:
+      - /bin/sh
+      - -lc
+      - |
+        set -eu
+        app_dir="$${OH_MY_PI_APP_DIR:-/home/bun/oh-my-pi-app}"
+        requested_version="$${OH_MY_PI_VERSION:-15.6.0}"
+        mkdir -p "$$app_dir" "$$HOME" "$$XDG_CONFIG_HOME" "$$XDG_CACHE_HOME" "$$PI_CODING_AGENT_DIR" "$$BUN_INSTALL_CACHE_DIR" "$$BUN_RUNTIME_TRANSPILER_CACHE_PATH"
+        cd "$$app_dir"
+
+        installed_version="$$(cat .oh-my-pi-version 2>/dev/null || true)"
+        if [ ! -x node_modules/.bin/omp ] || [ "$$installed_version" != "$$requested_version" ]; then
+          rm -rf node_modules bun.lock bun.lockb package.json .oh-my-pi-version
+          printf '%s\n' '{"type":"module","private":true,"dependencies":{}}' > package.json
+          bun add --exact "$${OH_MY_PI_PACKAGE}@$${requested_version}"
+          printf '%s\n' "$$requested_version" > .oh-my-pi-version
+        fi
+
+        export PATH="$$app_dir/node_modules/.bin:$$PATH"
+        exec bun /opt/oh-my-pi-demo/server.js
+    configs:
+      - source: oh_my_pi_demo_server
+        target: /opt/oh-my-pi-demo/server.js
+      - source: oh_my_pi_sample
+        target: /opt/oh-my-pi-demo/sample.md
+    volumes:
+      - oh_my_pi_app:/home/bun/oh-my-pi-app
+      - oh_my_pi_config:/home/bun/.omp
+      - oh_my_pi_bun_cache:/home/bun/.bun/install/cache
+      - oh_my_pi_transpiler_cache:/home/bun/.cache/bun
+    tmpfs:
+      - /tmp
+    healthcheck:
+      test:
+        - CMD
+        - bun
+        - -e
+        - 'fetch("http://127.0.0.1:" + (Bun.env.PORT || "8080") + "/healthz").then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))'
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 240s
+
+volumes:
+  oh_my_pi_app:
+  oh_my_pi_config:
+  oh_my_pi_bun_cache:
+  oh_my_pi_transpiler_cache:
+
+configs:
+  oh_my_pi_sample:
+    content: |
+      # Oh My Pi local verifier sample
+
+      This file is read by `omp read` during the Phala Cloud smoke demo. The
+      verifier uses local package and CLI primitives only; it does not call an
+      LLM provider, open a browser session, or download model weights.
+  oh_my_pi_demo_server:
+    content: |
+      import { spawnSync } from "node:child_process";
+      import fs from "node:fs";
+      import http from "node:http";
+      import os from "node:os";
+      import path from "node:path";
+
+      const STARTED_AT = Date.now();
+      const PORT = Number.parseInt(process.env.PORT || "8080", 10);
+      const PACKAGE_NAME = "@oh-my-pi/pi-coding-agent";
+      const REQUESTED_VERSION = process.env.OH_MY_PI_VERSION || "15.6.0";
+      const APP_DIR = process.env.OH_MY_PI_APP_DIR || "/home/bun/oh-my-pi-app";
+      const PACKAGE_ROOT = path.join(APP_DIR, "node_modules", "@oh-my-pi", "pi-coding-agent");
+      const SAMPLE_PATH = "/opt/oh-my-pi-demo/sample.md";
+      const UPSTREAM = "https://github.com/can1357/oh-my-pi";
+      const ENDPOINTS = ["/healthz", "/demo", "/v1/models"];
+      const PROVIDER_ENV_KEYS = [
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+        "OPENROUTER_API_KEY",
+      ];
+
+      function cleanText(value) {
+        return String(value || "")
+          .replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, "")
+          .trim()
+          .slice(0, 4000);
+      }
+
+      function safeCommandEnv() {
+        const home = process.env.HOME || "/home/bun";
+        return {
+          PATH: path.join(APP_DIR, "node_modules", ".bin") + ":" + (process.env.PATH || "/usr/local/bin:/usr/bin:/bin"),
+          HOME: home,
+          XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME || path.join(home, ".config"),
+          XDG_CACHE_HOME: process.env.XDG_CACHE_HOME || path.join(home, ".cache"),
+          PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR || path.join(home, ".omp", "agent"),
+          PI_NO_TITLE: "1",
+          PI_NO_PTY: "1",
+          PI_AUTH_NO_BORROW: "1",
+          PI_FORCE_IMAGE_PROTOCOL: "none",
+          PI_PYTHON_SKIP_CHECK: "1",
+          BUN_INSTALL_CACHE_DIR: process.env.BUN_INSTALL_CACHE_DIR || path.join(home, ".bun", "install", "cache"),
+          BUN_RUNTIME_TRANSPILER_CACHE_PATH: process.env.BUN_RUNTIME_TRANSPILER_CACHE_PATH || path.join(home, ".cache", "bun", "transpiler"),
+          CI: "true",
+          NO_COLOR: "1",
+          TERM: "dumb",
+        };
+      }
+
+      function runCommand(command, args, timeoutMs) {
+        const started = Date.now();
+        const result = spawnSync(command, args, {
+          cwd: APP_DIR,
+          encoding: "utf8",
+          env: safeCommandEnv(),
+          timeout: timeoutMs,
+          maxBuffer: 1024 * 1024,
+        });
+        const timedOut = Boolean(result.error && result.error.code === "ETIMEDOUT");
+        const exitCode = timedOut ? 124 : result.status;
+        return {
+          ok: exitCode === 0 && !timedOut,
+          command: [command].concat(args).join(" "),
+          exit_code: exitCode,
+          stdout: cleanText(result.stdout),
+          stderr: cleanText(result.stderr),
+          timed_out: timedOut,
+          error: result.error ? result.error.name + ": " + result.error.message : null,
+          duration_ms: Date.now() - started,
+        };
+      }
+
+      function readJson(filePath) {
+        return JSON.parse(fs.readFileSync(filePath, "utf8"));
+      }
+
+      function packageMetadata() {
+        const packageJsonPath = path.join(PACKAGE_ROOT, "package.json");
+        try {
+          const data = readJson(packageJsonPath);
+          return {
+            ok: data.name === PACKAGE_NAME,
+            package_json_path: packageJsonPath,
+            name: data.name,
+            requested_version: REQUESTED_VERSION,
+            installed_version: data.version || null,
+            description: data.description || null,
+            homepage: data.homepage || null,
+            repository: data.repository || null,
+            bin: data.bin || null,
+            engines: data.engines || null,
+          };
+        } catch (error) {
+          return {
+            ok: false,
+            package_json_path: packageJsonPath,
+            requested_version: REQUESTED_VERSION,
+            error: error.name + ": " + error.message,
+          };
+        }
+      }
+
+      function installMetadata() {
+        const appPackagePath = path.join(APP_DIR, "package.json");
+        const markerPath = path.join(APP_DIR, ".oh-my-pi-version");
+        let appPackage = null;
+        let markerVersion = null;
+        let error = null;
+        try {
+          appPackage = readJson(appPackagePath);
+        } catch (exc) {
+          error = exc.name + ": " + exc.message;
+        }
+        try {
+          markerVersion = fs.readFileSync(markerPath, "utf8").trim();
+        } catch {
+          markerVersion = null;
+        }
+        return {
+          ok: Boolean(appPackage && appPackage.dependencies && appPackage.dependencies[PACKAGE_NAME]) && markerVersion === REQUESTED_VERSION,
+          app_dir: APP_DIR,
+          app_package_path: appPackagePath,
+          dependency_spec: appPackage && appPackage.dependencies ? appPackage.dependencies[PACKAGE_NAME] || null : null,
+          marker_version: markerVersion,
+          cli_path: path.join(APP_DIR, "node_modules", ".bin", "omp"),
+          cli_present: fs.existsSync(path.join(APP_DIR, "node_modules", ".bin", "omp")),
+          error,
+        };
+      }
+
+      function providerConfiguration() {
+        const result = {};
+        for (const key of PROVIDER_ENV_KEYS) {
+          result[key.toLowerCase() + "_configured"] = Boolean(process.env[key]);
+        }
+        return result;
+      }
+
+      function inspectHealth() {
+        const pkg = packageMetadata();
+        const install = installMetadata();
+        const version = runCommand("omp", ["--version"], 10000);
+        const versionOutput = version.stdout || version.stderr;
+        return {
+          ok: pkg.ok && install.ok && install.cli_present && version.ok && versionOutput.length > 0,
+          package: pkg,
+          install,
+          cli_version: {
+            ok: version.ok && versionOutput.length > 0,
+            version_output: versionOutput,
+            check: version,
+          },
+        };
+      }
+
+      function inspectDemo() {
+        const health = inspectHealth();
+        const smoke = runCommand("omp", ["--smoke-test"], 20000);
+        const completions = runCommand("omp", ["completions", "bash"], 20000);
+        const readSample = runCommand("omp", ["read", SAMPLE_PATH + ":raw"], 20000);
+        return {
+          ok: health.ok && smoke.ok && completions.ok && completions.stdout.includes("omp") && readSample.ok,
+          health,
+          smoke_test: smoke,
+          completions: {
+            ok: completions.ok && completions.stdout.includes("omp"),
+            command: completions.command,
+            exit_code: completions.exit_code,
+            preview: completions.stdout.slice(0, 1200),
+            stderr: completions.stderr,
+            timed_out: completions.timed_out,
+            duration_ms: completions.duration_ms,
+          },
+          read_sample: readSample,
+        };
+      }
+
+      function basePayload() {
+        return {
+          service: "oh-my-pi-local-verifier",
+          upstream: UPSTREAM,
+          package_name: PACKAGE_NAME,
+          requested_version: REQUESTED_VERSION,
+          endpoints: ENDPOINTS,
+          uptime_seconds: Math.round((Date.now() - STARTED_AT) / 100) / 10,
+          bun: Bun.version,
+          platform: os.platform() + "/" + os.arch(),
+          cpu_only: true,
+          credentials_required_for_health: false,
+          provider_credentials_passed_to_verifier_commands: false,
+          hosted_model_calls_performed: false,
+          browser_auth_performed: false,
+          model_downloaded: false,
+          configured_provider_env: providerConfiguration(),
+        };
+      }
+
+      function modelListPayload() {
+        return {
+          object: "list",
+          data: [
+            {
+              id: "oh-my-pi/local-verifier",
+              object: "model",
+              created: Math.floor(STARTED_AT / 1000),
+              owned_by: "can1357",
+              metadata: {
+                template_id: "oh-my-pi",
+                upstream: UPSTREAM,
+                package_name: PACKAGE_NAME,
+                requested_version: REQUESTED_VERSION,
+                cpu_only: true,
+                not_a_hosted_llm: true,
+                credentials_required: false,
+              },
+            },
+          ],
+        };
+      }
+
+      function writeJson(response, status, payload) {
+        const body = Buffer.from(JSON.stringify(payload, null, 2) + "\n", "utf8");
+        response.writeHead(status, {
+          "Content-Type": "application/json; charset=utf-8",
+          "Content-Length": String(body.length),
+          "Cache-Control": "no-store",
+        });
+        response.end(body);
+      }
+
+      function responseFor(pathname) {
+        if (pathname === "/" || pathname === "/healthz") {
+          const checks = inspectHealth();
+          const payload = basePayload();
+          payload.ok = checks.ok;
+          payload.status = checks.ok ? "ready" : "unhealthy";
+          payload.checks = checks;
+          return [checks.ok ? 200 : 503, payload];
+        }
+
+        if (pathname === "/demo") {
+          const checks = inspectDemo();
+          const payload = basePayload();
+          payload.ok = checks.ok;
+          payload.status = checks.ok ? "ready" : "unhealthy";
+          payload.description = "Installs the real upstream oh-my-pi package and exercises local-only CLI primitives without model provider credentials.";
+          payload.what_ran = [
+            "omp --version",
+            "omp --smoke-test",
+            "omp completions bash",
+            "omp read /opt/oh-my-pi-demo/sample.md:raw",
+          ];
+          payload.verifies = [
+            "The published @oh-my-pi/pi-coding-agent package is installed.",
+            "The omp CLI starts under Bun and reports its version.",
+            "The upstream smoke-test worker path runs locally.",
+            "Completion metadata can be generated from the local command table.",
+            "The read command can inspect a local file without an LLM provider.",
+          ];
+          payload.checks = checks;
+          return [checks.ok ? 200 : 503, payload];
+        }
+
+        if (pathname === "/v1/models") {
+          return [200, modelListPayload()];
+        }
+
+        return [404, { ok: false, error: "not found", endpoints: ENDPOINTS }];
+      }
+
+      const server = http.createServer((request, response) => {
+        const url = new URL(request.url || "/", "http://127.0.0.1");
+        const result = responseFor(url.pathname);
+        writeJson(response, result[0], result[1]);
+      });
+
+      server.listen(PORT, "0.0.0.0", () => {
+        process.stdout.write("oh-my-pi verifier listening on 0.0.0.0:" + String(PORT) + "\n");
+      });


### PR DESCRIPTION
## Summary
- Add a Phala Cloud prebuilt template for `can1357/oh-my-pi`.
- Upstream repository: https://github.com/can1357/oh-my-pi
- Template files: `templates/prebuilt/oh-my-pi/docker-compose.yml`, `templates/prebuilt/oh-my-pi/README.md`, `templates/config.json`
- Icon: `oh-my-pi.svg`; source documented in the README.

## Environment variables
- See the template README for optional provider/runtime environment variables. No real secrets are included.

## Validation
- `python sdks/templates/validate.py`
- `git -C sdks diff --check origin/main...HEAD`
- `docker compose -f sdks/templates/prebuilt/oh-my-pi/docker-compose.yml config >/dev/null`
- static audit: README coverage, config ID uniqueness, icon file, forbidden compose directives, host bind mounts, and secret-like literals

## Deployment smoke
- Deployed with `phala deploy --profile hermes-admin-cvm-check --instance-type tdx.small --node-id 12 --wait --no-public-logs --no-public-sysinfo`
- Smoke CVM: `eecc2244-6c8a-4fc6-9771-402d64282567`
- Smoke app: `722bb4ea873f002b05b6a0461714e4da114311be`
- Endpoint probe: `https://722bb4ea873f002b05b6a0461714e4da114311be-8080.dstack-pha-prod7.phala.network/healthz -> 200 2135 0.612831 rc=0`
- Cleanup: temporary smoke CVM deletion requested and verified separately.

cc @Marvin-Cypher for review.
