### PR TITLE
fix(cli): show replica CVMs in cvms list instead of collapsing to one row

### DIFF
--- a/cli/src/commands/cvms/list/command.ts
+++ b/cli/src/commands/cvms/list/command.ts
@@ -79,6 +79,15 @@ export const cvmsListCommandMeta: CommandMeta = {
 			target: "region",
 			group: "basic",
 		},
+		{
+			name: "show-replicas",
+			description:
+				"List every replica CVM (one row per CVM) instead of one row per app",
+			type: "boolean",
+			target: "showReplicas",
+			negatedName: "no-show-replicas",
+			group: "basic",
+		},
 		jsonOption,
 	],
 	examples: [
@@ -99,6 +108,10 @@ export const cvmsListCommandMeta: CommandMeta = {
 			value: "phala cvms ls --status running",
 		},
 		{
+			name: "Show all replica CVMs",
+			value: "phala cvms ls --show-replicas",
+		},
+		{
 			name: "Output as JSON",
 			value: "phala cvms ls --json",
 		},
@@ -116,6 +129,7 @@ export const cvmsListCommandSchema = z.object({
 	kmsType: z.string().optional(),
 	node: z.string().optional(),
 	region: z.string().optional(),
+	showReplicas: z.boolean().default(false),
 	json: z.boolean().default(false),
 });
 

--- a/cli/src/commands/cvms/list/index.ts
+++ b/cli/src/commands/cvms/list/index.ts
@@ -49,6 +49,7 @@ async function runCvmsListCommand(
 			kmsType: input.kmsType,
 			node: input.node,
 			region: input.region,
+			showReplicas: input.showReplicas,
 		});
 
 		if (result.success === false) {
@@ -68,13 +69,22 @@ async function runCvmsListCommand(
 			return 0;
 		}
 
-		const columns = ["APP_ID", "CVM", "STATUS", "UPTIME"] as const;
-		const rows = data.items.map((item) => ({
-			APP_ID: item.appId,
-			CVM: item.cvmName,
-			STATUS: formatStatus(item.status),
-			UPTIME: item.uptime ?? "-",
-		}));
+		const columns = input.showReplicas
+			? (["APP_ID", "CVM", "VM_UUID", "STATUS", "UPTIME", "REPLICAS"] as const)
+			: (["APP_ID", "CVM", "STATUS", "UPTIME", "REPLICAS"] as const);
+		const rows = data.items.map((item) => {
+			const row: Record<string, string> = {
+				APP_ID: item.appId,
+				CVM: item.cvmName,
+				STATUS: formatStatus(item.status),
+				UPTIME: item.uptime ?? "-",
+				REPLICAS: input.showReplicas
+					? `${item.replicaIndex}/${item.replicaCount}`
+					: String(item.replicaCount),
+			};
+			if (input.showReplicas) row.VM_UUID = item.vmUuid;
+			return row;
+		});
 
 		if (rows.length === 0) {
 			logger.info("No CVMs found");
@@ -83,6 +93,14 @@ async function runCvmsListCommand(
 
 		printTable(columns, rows);
 		logger.info(`Page ${data.page}/${data.totalPages} (total ${data.total})`);
+		if (
+			!input.showReplicas &&
+			data.items.some((item) => item.replicaCount > 1)
+		) {
+			logger.info(
+				"Some apps have multiple replicas. Use --show-replicas to list every CVM.",
+			);
+		}
 		return 0;
 	} catch (error) {
 		logger.logDetailedError(error);

--- a/cli/src/lib/apps/list-apps-with-cvm-status.test.ts
+++ b/cli/src/lib/apps/list-apps-with-cvm-status.test.ts
@@ -1,0 +1,96 @@
+import { describe, test, expect } from "bun:test";
+import { collectDisplayCvms } from "./list-apps-with-cvm-status";
+
+const cvm = (vm_uuid: string, name = vm_uuid, status = "running") => ({
+	vm_uuid,
+	name,
+	status,
+});
+
+describe("collectDisplayCvms", () => {
+	test("emits one row per app by default, annotated with replica count", () => {
+		const apps = [
+			{
+				app_id: "app_a",
+				current_cvm: cvm("uuid-a1", "primary"),
+				cvms: [cvm("uuid-a1", "primary"), cvm("uuid-a2", "replica")],
+				cvm_count: 2,
+			},
+		];
+
+		const refs = collectDisplayCvms(apps, false);
+
+		expect(refs).toHaveLength(1);
+		expect(refs[0]).toMatchObject({
+			appId: "app_a",
+			replicaIndex: 1,
+			replicaCount: 2,
+		});
+		// Default row is the current CVM, not an arbitrary replica.
+		expect(refs[0].cvm.vm_uuid).toBe("uuid-a1");
+	});
+
+	test("emits one row per replica when showReplicas is true", () => {
+		const apps = [
+			{
+				app_id: "app_a",
+				current_cvm: cvm("uuid-a1"),
+				cvms: [cvm("uuid-a1"), cvm("uuid-a2"), cvm("uuid-a3")],
+				cvm_count: 3,
+			},
+		];
+
+		const refs = collectDisplayCvms(apps, true);
+
+		expect(refs).toHaveLength(3);
+		expect(refs.map((r) => r.cvm.vm_uuid)).toEqual([
+			"uuid-a1",
+			"uuid-a2",
+			"uuid-a3",
+		]);
+		expect(refs.map((r) => r.replicaIndex)).toEqual([1, 2, 3]);
+		expect(refs.every((r) => r.replicaCount === 3)).toBe(true);
+	});
+
+	test("falls back to current_cvm when cvms[] is empty", () => {
+		const apps = [
+			{
+				app_id: "app_legacy",
+				current_cvm: cvm("uuid-legacy"),
+				cvms: [],
+				cvm_count: 0,
+			},
+		];
+
+		expect(collectDisplayCvms(apps, false)).toHaveLength(1);
+		expect(collectDisplayCvms(apps, true)).toHaveLength(1);
+		expect(collectDisplayCvms(apps, true)[0].cvm.vm_uuid).toBe("uuid-legacy");
+	});
+
+	test("skips apps that have no CVM with a vm_uuid", () => {
+		const apps = [
+			{ app_id: "app_empty", current_cvm: null, cvms: [], cvm_count: 0 },
+			{
+				app_id: "app_bad",
+				current_cvm: { name: "no-uuid" },
+				cvms: [{ vm_uuid: "", name: "blank" }],
+			},
+		];
+
+		expect(collectDisplayCvms(apps, false)).toHaveLength(0);
+		expect(collectDisplayCvms(apps, true)).toHaveLength(0);
+	});
+
+	test("derives replicaCount from cvms length when cvm_count is missing or stale", () => {
+		const apps = [
+			{
+				app_id: "app_a",
+				current_cvm: cvm("uuid-a1"),
+				cvms: [cvm("uuid-a1"), cvm("uuid-a2")],
+				// cvm_count omitted
+			},
+		];
+
+		expect(collectDisplayCvms(apps, false)[0].replicaCount).toBe(2);
+	});
+});

--- a/cli/src/lib/apps/list-apps-with-cvm-status.ts
+++ b/cli/src/lib/apps/list-apps-with-cvm-status.ts
@@ -13,13 +13,98 @@ export interface AppsListWithStatusOptions {
 	readonly kmsType?: string;
 	readonly node?: string;
 	readonly region?: string;
+	// When true, emit one row per replica CVM instead of one row per app.
+	readonly showReplicas?: boolean;
 }
 
 export interface AppCvmRow {
 	readonly appId: string;
 	readonly cvmName: string;
+	readonly vmUuid: string;
 	readonly status: string;
 	readonly uptime?: string | null;
+	// 1-based position of this CVM within its app's replica set.
+	readonly replicaIndex: number;
+	// Total number of CVMs (replicas) belonging to the app.
+	readonly replicaCount: number;
+}
+
+// Structural subset of the app-list payload this module relies on. Kept
+// minimal so the row-selection logic stays pure and unit-testable without
+// depending on a specific API-version schema.
+interface CvmLike {
+	readonly vm_uuid?: string | null;
+	readonly name: string;
+	readonly status?: unknown;
+}
+
+interface AppLike {
+	readonly app_id: string;
+	readonly current_cvm?: CvmLike | null;
+	readonly cvms?: readonly CvmLike[];
+	readonly cvm_count?: number;
+}
+
+export interface DisplayCvmRef {
+	readonly appId: string;
+	readonly cvm: CvmLike;
+	readonly replicaIndex: number;
+	readonly replicaCount: number;
+}
+
+function hasVmUuid(cvm: CvmLike | null | undefined): cvm is CvmLike {
+	return !!cvm && typeof cvm.vm_uuid === "string" && cvm.vm_uuid.length > 0;
+}
+
+/**
+ * Select which CVMs to display for each app.
+ *
+ * The app-list payload already carries every replica CVM in `app.cvms` and a
+ * `app.cvm_count`, but the list view historically rendered only
+ * `app.current_cvm`, silently hiding the other replicas. This resolves the set
+ * of CVMs to show:
+ *   - `showReplicas` off (default): one row per app (the current CVM, falling
+ *     back to the first known CVM), annotated with the true replica count.
+ *   - `showReplicas` on: one row per replica CVM, each with its 1-based index.
+ *
+ * Pure and side-effect free so it can be unit tested directly.
+ */
+export function collectDisplayCvms(
+	apps: readonly AppLike[],
+	showReplicas: boolean,
+): DisplayCvmRef[] {
+	const refs: DisplayCvmRef[] = [];
+	for (const app of apps) {
+		const allCvms = (app.cvms ?? []).filter(hasVmUuid);
+		const fallback = hasVmUuid(app.current_cvm) ? [app.current_cvm] : [];
+		const cvms = allCvms.length > 0 ? allCvms : fallback;
+		if (cvms.length === 0) continue;
+
+		const replicaCount =
+			typeof app.cvm_count === "number" && app.cvm_count > cvms.length
+				? app.cvm_count
+				: cvms.length;
+
+		if (showReplicas) {
+			cvms.forEach((cvm, index) => {
+				refs.push({
+					appId: app.app_id,
+					cvm,
+					replicaIndex: index + 1,
+					replicaCount,
+				});
+			});
+		} else {
+			const primary = hasVmUuid(app.current_cvm) ? app.current_cvm : cvms[0];
+			refs.push({
+				appId: app.app_id,
+				cvm: primary,
+				replicaIndex: 1,
+				replicaCount,
+			});
+		}
+	}
+	return refs;
 }
 
 export interface AppsListWithStatusResult {
@@ -69,20 +154,17 @@ export async function listAppsWithCvmStatus(
 	const appList = appListResult.data;
 	const apps = appList.dstack_apps ?? [];
 
-	// Only include apps which have a current_cvm
-	const appsWithCvm = apps.filter(
-		(app) =>
-			app.current_cvm &&
-			typeof app.current_cvm === "object" &&
-			"vm_uuid" in app.current_cvm &&
-			!!app.current_cvm.vm_uuid,
-	);
+	const refs = collectDisplayCvms(apps, options.showReplicas ?? false);
 
-	const vmUuids = appsWithCvm
-		.map((app) => app.current_cvm?.vm_uuid)
-		.filter(
-			(uuid): uuid is string => typeof uuid === "string" && uuid.length > 0,
-		);
+	const vmUuids = [
+		...new Set(
+			refs
+				.map((ref) => ref.cvm.vm_uuid)
+				.filter(
+					(uuid): uuid is string => typeof uuid === "string" && uuid.length > 0,
+				),
+		),
+	];
 
 	const statusByUuid: Record<
 		string,
@@ -110,25 +192,25 @@ export async function listAppsWithCvmStatus(
 		}
 	}
 
-	const rows: AppCvmRow[] = [];
-	for (const app of appsWithCvm) {
-		const currentCvm = app.current_cvm;
-		if (!currentCvm?.vm_uuid) continue;
-
-		const batch = statusByUuid[currentCvm.vm_uuid];
+	const rows: AppCvmRow[] = refs.map((ref) => {
+		const uuid = ref.cvm.vm_uuid ?? "";
+		const batch = uuid ? statusByUuid[uuid] : undefined;
 		const status = batch
 			? batch.status
-			: typeof currentCvm.status === "string"
-				? currentCvm.status
+			: typeof ref.cvm.status === "string"
+				? ref.cvm.status
 				: "unknown";
 
-		rows.push({
-			appId: app.app_id,
-			cvmName: currentCvm.name,
+		return {
+			appId: ref.appId,
+			cvmName: ref.cvm.name,
+			vmUuid: uuid,
 			status,
 			uptime: batch?.uptime,
-		});
-	}
+			replicaIndex: ref.replicaIndex,
+			replicaCount: ref.replicaCount,
+		};
+	});
 
 	return {
 		success: true,


### PR DESCRIPTION
Hi, and thanks for all the work on the Cloud CLI.

This is a small, focused fix for #242. `phala cvms list` renders only `app.current_cvm`, so an app with `replicas > 1` shows a single row and its other replica CVMs are invisible from the CLI even though they are running with distinct IDs. Operators end up checking the raw API or Terraform state to confirm replicas exist.

The app list payload already returns every replica in `app.cvms` plus `app.cvm_count`, so this needs no extra API calls.

### What changed
- Default view gains a `REPLICAS` column and a one line hint, so a collapsed replica set is no longer silent. Output stays one row per app, so this is backward compatible.
- New `--show-replicas` flag renders one row per replica CVM and adds a `VM_UUID` column so each replica is addressable.
- Row selection is extracted into a pure `collectDisplayCvms` helper with unit tests (default collapse, replica expansion, `current_cvm` fallback for older API versions, count derivation).
- `--json` output is additive: `vmUuid`, `replicaIndex`, `replicaCount`.

### Example
```
# default: collapsed, but no longer silent
$ phala cvms ls
APP_ID  CVM            STATUS   UPTIME  REPLICAS
app_x   demo-replicas  running  4m      2
Some apps have multiple replicas. Use --show-replicas to list every CVM.

# expanded
$ phala cvms ls --show-replicas
APP_ID  CVM            VM_UUID                               STATUS   UPTIME  REPLICAS
app_x   demo-replicas  05053901-1751-4572-8985-423dcb3b21db  running  4m      1/2
app_x   demo-replicas  16d247ca-23f5-4ffa-b590-7f732eddbf51  running  4m      2/2
```

### Scope
I kept this narrow and scoped to the #242 display bug rather than the broader #243 stateful primitives work. I noticed #244 explored a `cvms list --app <id>` shape for the same area. Happy to switch to that approach, fold this into #243, or also surface `instance_id` if you prefer. Just let me know.

### Testing
`bun test` 5/5 pass, `bun run type-check` clean, `biome lint` and `format` clean, `bun run build` succeeds.
