### PR TITLE
feat: add device_ids matrix to node schemas

### DIFF
--- a/go/types_cvms.go
+++ b/go/types_cvms.go
@@ -139,14 +139,15 @@ type CvmGatewayInfo struct {
 
 // NodeRef is a reference to a node.
 type NodeRef struct {
-	ObjectType string  `json:"object_type"`
-	ID         *int    `json:"id,omitempty"`
-	Name       *string `json:"name,omitempty"`
-	Region     *string `json:"region,omitempty"`
-	DeviceID   *string `json:"device_id,omitempty"`
-	PPID       *string `json:"ppid,omitempty"`
-	Status     *string `json:"status,omitempty"`
-	Version    *string `json:"version,omitempty"`
+	ObjectType string          `json:"object_type"`
+	ID         *int            `json:"id,omitempty"`
+	Name       *string         `json:"name,omitempty"`
+	Region     *string         `json:"region,omitempty"`
+	DeviceID   *string         `json:"device_id,omitempty"`
+	DeviceIDs  []DeviceIDEntry `json:"device_ids,omitempty"`
+	PPID       *string         `json:"ppid,omitempty"`
+	Status     *string         `json:"status,omitempty"`
+	Version    *string         `json:"version,omitempty"`
 }
 
 // UserRef is a reference to a user.

--- a/go/types_nodes.go
+++ b/go/types_nodes.go
@@ -38,9 +38,10 @@ type TeepodCapacity struct {
 
 // DeviceIDEntry is one of a node's device_ids and the OS images it covers.
 type DeviceIDEntry struct {
-	DeviceID   string `json:"device_id"`
-	OSImageIDs []int  `json:"os_image_ids"`
-	Enabled    bool   `json:"enabled"`
+	DeviceID         string `json:"device_id"`
+	AlgorithmVersion string `json:"algorithm_version"`
+	OSImageIDs       []int  `json:"os_image_ids"`
+	Enabled          bool   `json:"enabled"`
 }
 
 // AvailableImage represents an available OS image on a node.

--- a/go/types_nodes.go
+++ b/go/types_nodes.go
@@ -30,9 +30,17 @@ type TeepodCapacity struct {
 	SupportOnchainKMS *bool            `json:"support_onchain_kms,omitempty"`
 	FMSPC             *string          `json:"fmspc,omitempty"`
 	DeviceID          *string          `json:"device_id,omitempty"`
+	DeviceIDs         []DeviceIDEntry  `json:"device_ids,omitempty"`
 	RegionIdentifier  *string          `json:"region_identifier,omitempty"`
 	DefaultKMS        *string          `json:"default_kms,omitempty"`
 	KMSList           []string         `json:"kms_list,omitempty"`
+}
+
+// DeviceIDEntry is one of a node's device_ids and the OS images it covers.
+type DeviceIDEntry struct {
+	DeviceID   string `json:"device_id"`
+	OSImageIDs []int  `json:"os_image_ids"`
+	Enabled    bool   `json:"enabled"`
 }
 
 // AvailableImage represents an available OS image on a node.

--- a/js/src/actions/get_available_nodes.test.ts
+++ b/js/src/actions/get_available_nodes.test.ts
@@ -38,6 +38,7 @@ const mockAvailableNodesData: AvailableNodes = {
       support_onchain_kms: false,
       fmspc: null,
       device_id: null,
+      device_ids: [],
       kms_list: [],
     },
   ],

--- a/js/src/actions/get_available_nodes.ts
+++ b/js/src/actions/get_available_nodes.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { type Client } from "../client";
+import { DeviceIdEntrySchema } from "../types/cvm_info_v20260121";
 import { KmsInfoSchema } from "../types/kms_info";
 import { defineSimpleAction } from "../utils/define-action";
 
@@ -87,6 +88,7 @@ export const TeepodCapacitySchema = z
     support_onchain_kms: z.boolean().optional(),
     fmspc: z.string().nullable().optional(),
     device_id: z.string().nullable().optional(),
+    device_ids: z.array(DeviceIdEntrySchema).default([]),
     region_identifier: z.string().nullable().optional(),
     default_kms: z.string().nullable().optional(),
     kms_list: z.array(z.string()).default([]),

--- a/js/src/types/cvm_info_v20260121.ts
+++ b/js/src/types/cvm_info_v20260121.ts
@@ -86,12 +86,21 @@ export const CvmLogUrlsV20260121Schema = z.object({
 });
 export type CvmLogUrlsV20260121 = z.infer<typeof CvmLogUrlsV20260121Schema>;
 
+export const DeviceIdEntrySchema = z.object({
+  device_id: z.string(),
+  os_image_ids: z.array(z.number().int()).default([]),
+  enabled: z.boolean(),
+});
+export type DeviceIdEntry = z.infer<typeof DeviceIdEntrySchema>;
+
 export const NodeRefSchema = z.object({
   object_type: z.literal("node"),
   id: z.number().int().nullable().optional(),
   name: z.string().nullable().optional(),
   region: z.string().nullable().optional(),
+  // Deprecated: resolved single device_id. Use device_ids for the full matrix.
   device_id: z.string().nullable().optional(),
+  device_ids: z.array(DeviceIdEntrySchema).default([]),
   ppid: z.string().nullable().optional(),
   status: z.string().nullable().optional(),
   version: z.string().nullable().optional(),

--- a/js/src/types/cvm_info_v20260121.ts
+++ b/js/src/types/cvm_info_v20260121.ts
@@ -88,6 +88,7 @@ export type CvmLogUrlsV20260121 = z.infer<typeof CvmLogUrlsV20260121Schema>;
 
 export const DeviceIdEntrySchema = z.object({
   device_id: z.string(),
+  algorithm_version: z.string(),
   os_image_ids: z.array(z.number().int()).default([]),
   enabled: z.boolean(),
 });

--- a/js/src/types/cvm_info_v20260121.ts
+++ b/js/src/types/cvm_info_v20260121.ts
@@ -89,7 +89,6 @@ export type CvmLogUrlsV20260121 = z.infer<typeof CvmLogUrlsV20260121Schema>;
 export const DeviceIdEntrySchema = z.object({
   device_id: z.string(),
   algorithm_version: z.string(),
-  os_image_ids: z.array(z.number().int()).default([]),
   enabled: z.boolean(),
 });
 export type DeviceIdEntry = z.infer<typeof DeviceIdEntrySchema>;

--- a/python/src/phala_cloud/models/__init__.py
+++ b/python/src/phala_cloud/models/__init__.py
@@ -78,6 +78,7 @@ from .nodes import (
     CvmCreateResourceGraphAny,
     CvmCreateResourceGraphV20260121,
     CvmCreateResourceGraphV20260522,
+    DeviceIdEntry,
     GpuAvailability,
 )
 from .os_images import GetOsImagesRequest, GetOsImagesResponse, OSImagePublic
@@ -92,6 +93,7 @@ __all__ = [
     "AppCvmsBatchIsAllowedResponseV20260522",
     "AvailableNodes",
     "BillingPeriod",
+    "DeviceIdEntry",
     "Certificate",
     "CertificateIssuer",
     "CertificateSubject",

--- a/python/src/phala_cloud/models/cvms.py
+++ b/python/src/phala_cloud/models/cvms.py
@@ -6,6 +6,7 @@ from pydantic import Field, computed_field
 
 from .base import AliasModel, CloudModel
 from .kms import KmsInfo
+from .nodes import DeviceIdEntry
 
 BillingPeriod = Literal["skip", "hourly", "monthly"]
 KmsType = Literal["phala", "ethereum", "base", "legacy"]
@@ -83,6 +84,7 @@ class NodeRef(CloudModel):
     name: str | None = None
     region: str | None = None
     device_id: str | None = None
+    device_ids: list[DeviceIdEntry] = Field(default_factory=list)
     ppid: str | None = None
     status: str | None = None
     version: str | None = None

--- a/python/src/phala_cloud/models/nodes.py
+++ b/python/src/phala_cloud/models/nodes.py
@@ -13,6 +13,12 @@ class AvailableOSImage(CloudModel):
     os_image_hash: str | None = None
 
 
+class DeviceIdEntry(CloudModel):
+    device_id: str
+    os_image_ids: list[int] = Field(default_factory=list)
+    enabled: bool
+
+
 class TeepodCapacity(CloudModel):
     teepod_id: int
     name: str
@@ -25,6 +31,7 @@ class TeepodCapacity(CloudModel):
     support_onchain_kms: bool | None = None
     fmspc: str | None = None
     device_id: str | None = None
+    device_ids: list[DeviceIdEntry] = Field(default_factory=list)
     region_identifier: str | None = None
     default_kms: str | None = None
     kms_list: list[str] = Field(default_factory=list)

--- a/python/src/phala_cloud/models/nodes.py
+++ b/python/src/phala_cloud/models/nodes.py
@@ -15,6 +15,7 @@ class AvailableOSImage(CloudModel):
 
 class DeviceIdEntry(CloudModel):
     device_id: str
+    algorithm_version: str
     os_image_ids: list[int] = Field(default_factory=list)
     enabled: bool
 


### PR DESCRIPTION
Additive support for the node multi-device-id model.

A physical node can expose multiple device_ids — one per dstack OS image version, because the PPID-to-device_id derivation changed across OS releases. This adds a `device_ids` field (`DeviceIdEntry`: `device_id`, `os_image_ids`, `enabled`) alongside the existing single `device_id` on `NodeRef` and `TeepodCapacity`, across the JS, Python, and Go SDKs.

- **Backward compatible**: the legacy `device_id` field is preserved (now the resolved single value); `device_ids` is additive and defaults to empty.
- JS: `DeviceIdEntrySchema` + `device_ids` on `NodeRefSchema` / TeepodCapacity. Python: `DeviceIdEntry` model + field on `NodeRef` / `TeepodCapacity`. Go: `DeviceIDEntry` + `DeviceIDs` on `NodeRef` / `TeepodCapacity`.

Validation: JS (725 tests) / Python (54) / Go all green; type-check clean. CLI interface-compat baseline failures are pre-existing in local env and unrelated to this change.