### PR TITLE
feat: add agent-reach template

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -5216,5 +5216,27 @@
     ],
     "defaultResource": { "vCPU": 1, "memory": 2048, "diskSize": 20 },
     "tags": ["RAG", "Web Apps", "AI Agents"]
+  },
+{
+    "id": "agent-reach",
+    "name": "Panniantong/Agent-Reach",
+    "description": "Give your AI agent eyes to see the entire internet. Read & search Twitter, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu — one CLI, zero API fees.",
+    "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/agent-reach",
+    "author": "Panniantong",
+    "icon": "agent-reach.svg",
+    "envs": [
+      {
+        "key": "AGENT_REACH_REF",
+        "required": false,
+        "default": "17624268a059ccfb23eba8a2ba50f9f92c8dc0ca",
+        "description": "Upstream Agent Reach branch, tag, or commit archive ref loaded by the verifier service at container startup."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 1,
+      "memory": 1024,
+      "diskSize": 10
+    },
+    "tags": ["LLM Inference & Model Serving", "Web Data & Search", "AI Agents"]
   }
 ]

--- a/templates/icons/agent-reach.svg
+++ b/templates/icons/agent-reach.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0066FF"/>
+      <stop offset="100%" style="stop-color:#00AAFF"/>
+    </linearGradient>
+    <clipPath id="clip-circle">
+      <circle cx="256" cy="256" r="140"/>
+    </clipPath>
+  </defs>
+  <rect width="512" height="512" fill="#0A0A1A"/>
+  <circle cx="256" cy="256" r="160" fill="none" stroke="url(#grad1)" stroke-width="8" opacity="0.3"/>
+  <circle cx="256" cy="256" r="140" fill="none" stroke="url(#grad1)" stroke-width="3" opacity="0.6"/>
+  <circle cx="220" cy="256" r="24" fill="url(#grad1)"/>
+  <path d="M 230 256 Q 320 180, 420 200" fill="none" stroke="url(#grad1)" stroke-width="6" stroke-linecap="round" opacity="0.9"/>
+  <path d="M 230 256 Q 320 256, 420 256" fill="none" stroke="url(#grad1)" stroke-width="6" stroke-linecap="round" opacity="0.7"/>
+  <path d="M 230 256 Q 320 330, 420 312" fill="none" stroke="url(#grad1)" stroke-width="6" stroke-linecap="round" opacity="0.5"/>
+  <circle cx="420" cy="200" r="8" fill="#00AAFF" opacity="0.9"/>
+  <circle cx="420" cy="256" r="8" fill="#00AAFF" opacity="0.7"/>
+  <circle cx="420" cy="312" r="8" fill="#00AAFF" opacity="0.5"/>
+</svg>

--- a/templates/prebuilt/agent-reach/README.md
+++ b/templates/prebuilt/agent-reach/README.md
@@ -1,0 +1,133 @@
+# Panniantong/Agent-Reach on Phala Cloud
+
+This template runs a CPU-safe Agent Reach verifier behind a public Caddy proxy. The app installs Agent Reach's declared runtime dependencies, loads the real upstream GitHub source archive on `PYTHONPATH`, imports the package and channel registry, exercises deterministic local channel-matching primitives, and exposes JSON endpoints for smoke testing.
+
+The default deployment does not run `agent-reach install`, does not install optional platform CLIs, does not read browser cookies, does not configure proxies, does not call model providers, does not launch browsers, and does not download model weights. It is a verifier for the upstream package and its local scaffolding primitives, not a production internet-scraping agent.
+
+## Metadata
+
+- Template id: `agent-reach`
+- Display name: `Panniantong/Agent-Reach`
+- Category: LLM Gateway & API Proxy
+- Upstream repository: `https://github.com/Panniantong/Agent-Reach`
+- Upstream install guide: `https://github.com/Panniantong/Agent-Reach/blob/main/docs/install.md`
+- Upstream author: `Panniantong`
+- Source archive: `https://github.com/Panniantong/Agent-Reach/archive/17624268a059ccfb23eba8a2ba50f9f92c8dc0ca.zip`
+- Icon source: upstream `docs/assets/logo-1.svg` from `Panniantong/Agent-Reach`, inspected at commit `17624268a059ccfb23eba8a2ba50f9f92c8dc0ca`
+
+## What This Template Runs
+
+Agent Reach is a Python CLI and scaffolding tool that helps an AI agent install and configure upstream internet-access tools such as `twitter-cli`, `rdt-cli`, `yt-dlp`, `gh`, `mcporter`, and platform-specific MCP services. Its upstream documentation is oriented around installing tools on a user-controlled machine, then asking the agent to call those tools directly.
+
+This Phala Cloud template intentionally avoids that full installer path by default. Instead, the verifier:
+
+- installs the runtime dependencies listed in Agent Reach's `pyproject.toml`;
+- downloads and imports Agent Reach from the upstream GitHub archive;
+- imports `agent_reach`, `AgentReach`, the channel registry, and channel base classes;
+- classifies sample URLs through local `can_handle()` channel methods;
+- checks only local Web and RSS channel availability methods;
+- exposes `/healthz`, `/demo`, and `/v1/models` over HTTP.
+
+This keeps startup deterministic on a small CPU-only Phala CVM and avoids credentialed platform access.
+
+## Services
+
+- `app`: internal Python HTTP verifier. It installs runtime dependencies, loads the upstream source archive at startup, and serves JSON on port `8000`.
+- `proxy`: public Caddy reverse proxy. It is the only service with a host port mapping and exposes `8080:80`.
+
+## Environment Variables
+
+No credentials are required.
+
+| Variable | Default | Required | Description |
+| --- | --- | --- | --- |
+| `AGENT_REACH_REF` | `17624268a059ccfb23eba8a2ba50f9f92c8dc0ca` | No | Upstream Agent Reach branch, tag, or commit archive ref loaded by the verifier at container startup. The default is the commit inspected for this template. |
+| `APP_PORT` | `8000` | No | Internal app port. Caddy proxies to this port; the host only exposes `8080:80`. |
+
+Do not add cookies, browser sessions, proxy credentials, GitHub tokens, Groq keys, model-provider keys, or platform account credentials to this default verifier. Add secrets only if you replace the verifier with a real Agent Reach workflow that needs them.
+
+## Exposed Endpoints
+
+The public HTTP API is available through Caddy on port `8080`.
+
+- `GET /healthz`: returns HTTP 200 only when the package import checks and deterministic local demo pass.
+- `GET /demo`: exercises local Agent Reach channel primitives without calling Twitter, Reddit, YouTube, GitHub, Bilibili, XiaoHongShu, Exa, Jina, or other external platform APIs.
+- `GET /v1/models`: returns an OpenAI-shaped model list containing `agent-reach-local-verifier`. It is metadata only; the template does not host or call an LLM.
+- `GET /`: returns service metadata and endpoint names.
+
+Example:
+
+```bash
+curl -fsS http://localhost:8080/healthz | jq
+curl -fsS 'http://localhost:8080/demo?url=https://github.com/Panniantong/Agent-Reach&url=https://example.com/feed.xml' | jq
+curl -fsS http://localhost:8080/v1/models | jq
+```
+
+Expected `/demo` fields include:
+
+```json
+{
+  "ok": true,
+  "cpu_only": true,
+  "credential_free": true,
+  "remote_platform_calls": false,
+  "demo": {
+    "llm_provider_calls": false,
+    "credentials_required": false,
+    "browser_automation": false,
+    "installer_ran": false
+  }
+}
+```
+
+## Deploy On Phala Cloud
+
+1. Create a new Phala Cloud deployment from the `agent-reach` prebuilt template.
+2. Keep the default CPU-only resources for the verifier: 1 vCPU, 1 GB memory, and 10 GB disk.
+3. Optionally set `AGENT_REACH_REF` to another trusted upstream commit or tag.
+4. Deploy the CVM and wait for the first startup to complete.
+5. Open `https://<your-app-domain>/healthz`.
+
+The first startup downloads Python wheels and the upstream Agent Reach source archive. The runtime smoke path itself is local and deterministic.
+
+## Local Verification
+
+Run locally from the `sdks/` directory:
+
+These commands verify the Compose syntax, service health, deterministic demo endpoint, and metadata endpoint.
+
+```bash
+docker compose -f templates/prebuilt/agent-reach/docker-compose.yml config >/dev/null
+docker compose -f templates/prebuilt/agent-reach/docker-compose.yml up -d
+curl -fsS http://localhost:8080/healthz | jq
+curl -fsS http://localhost:8080/demo | jq
+curl -fsS http://localhost:8080/v1/models | jq
+docker compose -f templates/prebuilt/agent-reach/docker-compose.yml down
+```
+
+Template validation commands from the parent worktree:
+
+```bash
+python3 templates/validate.py
+git diff --check origin/main...HEAD
+docker compose -f templates/prebuilt/agent-reach/docker-compose.yml config >/dev/null
+```
+
+## Production Notes
+
+- The upstream Agent Reach installer is designed for a user-controlled agent environment. Running `agent-reach install --env=auto` may install tools, create files under `~/.agent-reach/`, configure `mcporter`, guide users through cookies, or require additional platform-specific setup.
+- Twitter/X, Reddit, XiaoHongShu, Xueqiu, LinkedIn, and similar channels can require cookies, browser login, proxy configuration, account-specific rate limits, or a dedicated secondary account. Do not bake those credentials into Compose or git.
+- Some platforms can block server or datacenter IPs. Use production proxy settings only through deployment-time secret management.
+- If you adapt this template into a real gateway, add authentication before exposing agent or scraping actions publicly.
+- Pin `AGENT_REACH_REF` to a reviewed commit for reproducible deployments.
+- The default template does not use privileged mode, host networking, host IPC, host PID, Docker socket mounts, host bind mounts, named volumes, `env_file`, GPU devices, browser automation services, external databases, or provider credentials.
+
+## Cleanup
+
+For a local test run from `sdks/`, stop and remove the verifier with:
+
+```bash
+docker compose -f templates/prebuilt/agent-reach/docker-compose.yml down
+```
+
+No named volumes are created by this template.

--- a/templates/prebuilt/agent-reach/docker-compose.yml
+++ b/templates/prebuilt/agent-reach/docker-compose.yml
@@ -1,0 +1,410 @@
+services:
+  app:
+    image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+    restart: unless-stopped
+    init: true
+    expose:
+      - "8000"
+    environment:
+      AGENT_REACH_REF: ${AGENT_REACH_REF:-17624268a059ccfb23eba8a2ba50f9f92c8dc0ca}
+      AGENT_REACH_SOURCE_DIR: /opt/agent-reach-source
+      APP_PORT: ${APP_PORT:-8000}
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      PIP_NO_CACHE_DIR: "1"
+      PIP_ROOT_USER_ACTION: ignore
+      PYTHONUNBUFFERED: "1"
+      UV_SYSTEM_PYTHON: "1"
+    configs:
+      - source: agent_reach_demo_app
+        target: /opt/agent-reach-demo/server.py
+    command:
+      - /bin/sh
+      - -lc
+      - |
+        set -eu
+        uv pip install --system --no-cache requests feedparser python-dotenv loguru pyyaml rich yt-dlp
+        python - <<'PY'
+        import os
+        import pathlib
+        import shutil
+        import urllib.request
+        import zipfile
+
+        ref = os.environ["AGENT_REACH_REF"]
+        source_dir = pathlib.Path(os.environ["AGENT_REACH_SOURCE_DIR"])
+        archive_path = pathlib.Path("/tmp/agent-reach.zip")
+        extract_root = pathlib.Path("/tmp/agent-reach-extract")
+        url = f"https://github.com/Panniantong/Agent-Reach/archive/{ref}.zip"
+
+        shutil.rmtree(source_dir, ignore_errors=True)
+        shutil.rmtree(extract_root, ignore_errors=True)
+        extract_root.mkdir(parents=True, exist_ok=True)
+        urllib.request.urlretrieve(url, archive_path)
+        with zipfile.ZipFile(archive_path) as archive:
+            archive.extractall(extract_root)
+        roots = [path for path in extract_root.iterdir() if path.is_dir()]
+        if len(roots) != 1:
+            raise RuntimeError(f"expected one archive root, found {len(roots)}")
+        shutil.move(str(roots[0]), source_dir)
+        PY
+        export PYTHONPATH="$${AGENT_REACH_SOURCE_DIR}$${PYTHONPATH:+:$${PYTHONPATH}}"
+        exec python /opt/agent-reach-demo/server.py
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import os, sys, urllib.request; port = os.environ.get('APP_PORT', '8000'); response = urllib.request.urlopen(f'http://127.0.0.1:{port}/healthz', timeout=5); sys.exit(0 if response.status == 200 else 1)\"",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 300s
+    networks:
+      - internal
+
+  proxy:
+    image: caddy:2.8
+    restart: unless-stopped
+    ports:
+      - "8080:80"
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+    depends_on:
+      app:
+        condition: service_healthy
+    networks:
+      - internal
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+          encode zstd gzip
+          header {
+              X-Content-Type-Options "nosniff"
+              Referrer-Policy "no-referrer"
+              -Server
+          }
+          reverse_proxy app:8000
+      }
+
+  agent_reach_demo_app:
+    content: |
+      import importlib
+      import importlib.metadata
+      import json
+      import os
+      import platform
+      import sys
+      import time
+      from http import HTTPStatus
+      from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+      from urllib.parse import parse_qs, urlparse
+
+
+      STARTED_AT = time.time()
+      PACKAGE_NAME = "agent-reach"
+      MODULE_NAME = "agent_reach"
+      UPSTREAM_REPO = "https://github.com/Panniantong/Agent-Reach"
+      SOURCE_DIR = os.environ.get("AGENT_REACH_SOURCE_DIR", "/opt/agent-reach-source")
+      DEFAULT_URLS = [
+          "https://github.com/Panniantong/Agent-Reach",
+          "https://x.com/Neo_Reidlab",
+          "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+          "https://example.com/feed.xml",
+          "https://example.com/article",
+      ]
+      MAX_URLS = 8
+
+
+      def package_version(name):
+          try:
+              return importlib.metadata.version(name)
+          except Exception as exc:
+              return None
+
+
+      def source_metadata():
+          result = {
+              "source_dir": SOURCE_DIR,
+              "pyproject_version": None,
+              "pyproject_name": None,
+              "pyproject_found": False,
+              "error": None,
+          }
+          try:
+              import tomllib
+
+              pyproject_path = os.path.join(SOURCE_DIR, "pyproject.toml")
+              with open(pyproject_path, "rb") as file:
+                  data = tomllib.load(file)
+              project = data.get("project", {})
+              result["pyproject_found"] = True
+              result["pyproject_name"] = project.get("name")
+              result["pyproject_version"] = project.get("version")
+          except Exception as exc:
+              result["error"] = f"{type(exc).__name__}: {exc}"
+          return result
+
+
+      def import_checks():
+          result = {
+              "package": PACKAGE_NAME,
+              "distribution_version": None,
+              "source": source_metadata(),
+              "module_version": None,
+              "import_ok": False,
+              "symbols": {},
+              "channel_count": 0,
+              "channel_names": [],
+              "error": None,
+          }
+          try:
+              result["distribution_version"] = package_version(PACKAGE_NAME)
+              agent_reach = importlib.import_module(MODULE_NAME)
+              result["module_version"] = getattr(agent_reach, "__version__", None)
+
+              from agent_reach import AgentReach
+              from agent_reach.channels import get_all_channels, get_channel
+              from agent_reach.channels.base import Channel
+
+              result["symbols"] = {
+                  "AgentReach": AgentReach is not None,
+                  "Channel": Channel is not None,
+                  "get_all_channels": callable(get_all_channels),
+                  "get_channel": callable(get_channel),
+              }
+              channels = get_all_channels()
+              result["channel_count"] = len(channels)
+              result["channel_names"] = [ch.name for ch in channels]
+              result["import_ok"] = (
+                  bool(result["source"]["pyproject_version"])
+                  and bool(result["module_version"])
+                  and all(result["symbols"].values())
+                  and result["channel_count"] >= 10
+              )
+          except Exception as exc:
+              result["error"] = f"{type(exc).__name__}: {exc}"
+          return result
+
+
+      IMPORT_STATUS = import_checks()
+
+
+      def normalize_urls(values):
+          urls = []
+          for value in values:
+              for item in value.split(","):
+                  candidate = item.strip()
+                  if candidate:
+                      urls.append(candidate)
+          return urls[:MAX_URLS] or list(DEFAULT_URLS)
+
+
+      def run_local_demo(urls):
+          if not IMPORT_STATUS["import_ok"]:
+              raise RuntimeError(IMPORT_STATUS["error"] or "Agent Reach import check failed")
+
+          from agent_reach import AgentReach
+          from agent_reach.channels import get_all_channels, get_channel
+          from agent_reach.channels.rss import RSSChannel
+          from agent_reach.channels.web import WebChannel
+
+          reach = AgentReach()
+          channels = get_all_channels()
+          classifications = []
+          for url in urls:
+              matches = [ch.name for ch in channels if ch.can_handle(url)]
+              classifications.append(
+                  {
+                      "url": url,
+                      "matching_channels": matches,
+                      "primary_match": next((name for name in matches if name != "web"), "web"),
+                  }
+              )
+
+          web_status, web_message = WebChannel().check(reach.config)
+          rss_status, rss_message = RSSChannel().check(reach.config)
+          twitter_channel = get_channel("twitter")
+
+          return {
+              "ok": True,
+              "demo_type": "deterministic local Agent Reach channel primitives",
+              "input_urls": urls,
+              "classifications": classifications,
+              "local_checks": {
+                  "web": {"status": web_status, "message": web_message},
+                  "rss": {"status": rss_status, "message": rss_message},
+              },
+              "channel_registry": {
+                  "count": len(channels),
+                  "names": [ch.name for ch in channels],
+                  "twitter_backends": twitter_channel.backends if twitter_channel else [],
+              },
+              "agent_class": type(reach).__name__,
+              "llm_provider_calls": False,
+              "hosted_model_calls": False,
+              "model_downloaded": False,
+              "model_loaded": False,
+              "credentials_required": False,
+              "browser_automation": False,
+              "platform_network_calls": False,
+              "installer_ran": False,
+          }
+
+
+      def demo_result(urls):
+          try:
+              return run_local_demo(urls)
+          except Exception as exc:
+              return {
+                  "ok": False,
+                  "error": f"{type(exc).__name__}: {exc}",
+                  "llm_provider_calls": False,
+                  "hosted_model_calls": False,
+                  "model_downloaded": False,
+                  "model_loaded": False,
+                  "credentials_required": False,
+              }
+
+
+      def base_payload():
+          return {
+              "service": "agent-reach-demo",
+              "upstream": UPSTREAM_REPO,
+              "source_ref": os.environ.get("AGENT_REACH_REF", ""),
+              "python": sys.version.split()[0],
+              "platform": platform.platform(),
+              "uptime_seconds": round(time.time() - STARTED_AT, 3),
+              "agent_reach": IMPORT_STATUS,
+          }
+
+
+      def response_body(path, query):
+          if path == "/healthz":
+              demo = demo_result(list(DEFAULT_URLS))
+              ok = IMPORT_STATUS["import_ok"] and demo["ok"]
+              payload = base_payload()
+              payload.update(
+                  {
+                      "ok": ok,
+                      "status": "ready" if ok else "unhealthy",
+                      "demo_ok": demo["ok"],
+                      "cpu_only": True,
+                      "credential_free": True,
+                      "llm_provider_calls": False,
+                      "browser_automation": False,
+                  }
+              )
+              if not demo["ok"]:
+                  payload["demo_error"] = demo.get("error")
+              return HTTPStatus.OK if ok else HTTPStatus.SERVICE_UNAVAILABLE, payload
+
+          if path == "/demo":
+              urls = normalize_urls(query.get("url", []))
+              demo = demo_result(urls)
+              payload = base_payload()
+              payload.update(
+                  {
+                      "ok": IMPORT_STATUS["import_ok"] and demo["ok"],
+                      "cpu_only": True,
+                      "credential_free": True,
+                      "remote_platform_calls": False,
+                      "demo": demo,
+                  }
+              )
+              return HTTPStatus.OK if payload["ok"] else HTTPStatus.INTERNAL_SERVER_ERROR, payload
+
+          if path == "/v1/models":
+              return HTTPStatus.OK, {
+                  "object": "list",
+                  "data": [
+                      {
+                          "id": "agent-reach-local-verifier",
+                          "object": "model",
+                          "created": 1712963143,
+                          "owned_by": "Panniantong",
+                          "description": (
+                              "Metadata endpoint for the Agent Reach local verifier. "
+                              "No LLM is hosted or called by this template."
+                          ),
+                      }
+                  ],
+                  "agent_reach": {
+                      "distribution_version": IMPORT_STATUS["distribution_version"],
+                      "source_version": IMPORT_STATUS["source"]["pyproject_version"],
+                      "module_version": IMPORT_STATUS["module_version"],
+                      "source_ref": os.environ.get("AGENT_REACH_REF", ""),
+                  },
+              }
+
+          if path == "/":
+              payload = base_payload()
+              payload.update(
+                  {
+                      "ok": IMPORT_STATUS["import_ok"],
+                      "endpoints": ["/healthz", "/demo", "/v1/models"],
+                      "description": (
+                          "CPU-safe Agent Reach verifier. It imports local package "
+                          "and channel primitives without running the upstream installer."
+                      ),
+                  }
+              )
+              return HTTPStatus.OK, payload
+
+          return HTTPStatus.NOT_FOUND, {
+              "ok": False,
+              "error": "not_found",
+              "endpoints": ["/healthz", "/demo", "/v1/models"],
+          }
+
+
+      class Handler(BaseHTTPRequestHandler):
+          server_version = "agent-reach-demo"
+
+          def log_message(self, fmt, *args):
+              print(
+                  json.dumps(
+                      {
+                          "ts": time.time(),
+                          "client": self.client_address[0],
+                          "request": self.requestline,
+                          "message": fmt % args,
+                      }
+                  ),
+                  flush=True,
+              )
+
+          def do_GET(self):
+              parsed = urlparse(self.path)
+              path = parsed.path.rstrip("/") or "/"
+              status, payload = response_body(path, parse_qs(parsed.query))
+              body = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+              self.send_response(status)
+              self.send_header("Content-Type", "application/json; charset=utf-8")
+              self.send_header("Cache-Control", "no-store")
+              self.send_header("Content-Length", str(len(body)))
+              self.end_headers()
+              self.wfile.write(body)
+
+
+      if __name__ == "__main__":
+          port = int(os.environ.get("APP_PORT", "8000"))
+          print(
+              json.dumps(
+                  {
+                      "event": "startup",
+                      "port": port,
+                      "agent_reach": IMPORT_STATUS,
+                      "llm_provider_calls": False,
+                      "browser_automation": False,
+                  }
+              ),
+              flush=True,
+          )
+          ThreadingHTTPServer(("0.0.0.0", port), Handler).serve_forever()
+
+networks:
+  internal:
+    driver: bridge


### PR DESCRIPTION
## Summary
- Add a Phala Cloud prebuilt template for `Panniantong/Agent-Reach`.
- Upstream repository: https://github.com/Panniantong/Agent-Reach
- Template files: `templates/prebuilt/agent-reach/docker-compose.yml`, `templates/prebuilt/agent-reach/README.md`, `templates/config.json`
- Icon: `agent-reach.svg`; source documented in the README.

## Environment variables
- See the template README for optional provider/runtime environment variables. No real secrets are included.

## Validation
- `python sdks/templates/validate.py`
- `git -C sdks diff --check origin/main...HEAD`
- `docker compose -f sdks/templates/prebuilt/agent-reach/docker-compose.yml config >/dev/null`
- static audit: README coverage, config ID uniqueness, icon file, forbidden compose directives, host bind mounts, and secret-like literals

## Deployment smoke
- Deployed with `phala deploy --profile hermes-admin-cvm-check --instance-type tdx.small --node-id 12 --wait --no-public-logs --no-public-sysinfo`
- Smoke CVM: `04d9d76d-42d6-4b2a-bf6d-9fb810a21d0a`
- Smoke app: `168984193503f6ef30ecc6f3e05d02b35ce3011d`
- Endpoint probe: `https://168984193503f6ef30ecc6f3e05d02b35ce3011d-8080.dstack-pha-prod7.phala.network/healthz -> 200 1234 0.139548 rc=0`
- Cleanup: temporary smoke CVM deletion requested and verified separately.

cc @Marvin-Cypher for review.
