### PR TITLE
fix(js): correct kms_info.chain_id type in app attestation schema

### DIFF
--- a/js/src/actions/apps/get_app_attestation.ts
+++ b/js/src/actions/apps/get_app_attestation.ts
@@ -4,7 +4,7 @@ import { defineAction } from "../../utils/define-action";
 
 const KmsInfoSchema = z.object({
   contract_address: z.string(),
-  chain_id: z.string().nullable(),
+  chain_id: z.number().nullable(),
   version: z.string(),
   url: z.string(),
   gateway_app_id: z.string().nullable(),


### PR DESCRIPTION
## Problem

The TCB evaluation page (`/{workspace}/apps/{app_id}/attestations/tcb-evaluation`) throws a zod `invalid_type` error:

```
{ "code": "invalid_type", "expected": "string", "received": "number", "path": [ "kms_info", "chain_id" ] }
```

## Root cause

`KmsInfoSchema.chain_id` in `get_app_attestation.ts` has been `z.string().nullable()` since the action was first added (commit 4d534e9), but the backend `GET /apps/{appId}/attestations` endpoint serializes `chain_id` as an integer or null (`_normalize_kms_chain_id(value: int | None) -> int | None`, DB column `Mapped[Optional[int]]`).

The bug stayed hidden because legacy / PHALA-KMS apps serialize `chain_id` as `null` (which `z.string().nullable()` accepts). Only on-chain KMS apps return a numeric `chain_id` and trip the validation.

## Fix

Change `chain_id` to `z.number().nullable()`, matching the backend. Every other `chain_id` schema in the codebase is already `z.number()`.

## Test

`bun run fmt && bun run lint && bun run type-check && bun run test` — all pass (725 tests).