### PR TITLE
feat: add iii template

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -6080,5 +6080,27 @@
       "diskSize": 20
     },
     "tags": ["LLM Inference & Model Serving", "Media & Design", "AI Agents"]
+  },
+{
+    "id": "iii",
+    "name": "iii-hq/iii",
+    "description": "Effortlessly compose, extend, and observe every service in real-time for the first time ever.",
+    "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/iii",
+    "author": "iii-hq",
+    "icon": "iii.svg",
+    "envs": [
+      {
+        "key": "III_SDK_VERSION",
+        "required": false,
+        "default": "0.19.2",
+        "description": "Pinned iii-sdk npm package version installed by the verifier service at container startup."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 1,
+      "memory": 2048,
+      "diskSize": 10
+    },
+    "tags": ["AI Agents", "Developer Tools", "Automation"]
   }
 ]

--- a/templates/icons/iii.svg
+++ b/templates/icons/iii.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Camada_1" data-name="Camada 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1075.74 1075.74">
+  <rect x="806.81" y="403.45" width="268.94" height="672.24"/>
+  <rect x="403.4" y="403.45" width="268.94" height="672.24"/>
+  <rect x="0" y="403.45" width="268.94" height="672.24"/>
+  <rect x="806.81" y=".05" width="268.94" height="268.94"/>
+  <rect x="403.4" y=".05" width="268.94" height="268.94"/>
+  <rect x="0" y=".05" width="268.94" height="268.94"/>
+</svg>

--- a/templates/prebuilt/iii/README.md
+++ b/templates/prebuilt/iii/README.md
@@ -1,0 +1,125 @@
+# iii-hq/iii on Phala Cloud
+
+iii is a live service-composition runtime for building, extending, and observing backend systems through three primitives: workers, functions, and triggers. The upstream project lives at [iii-hq/iii](https://github.com/iii-hq/iii).
+
+This Phala Cloud prebuilt template runs the official `iiidev/iii:latest` engine image with `--use-default-config`, plus a small CPU-safe Node.js verifier that installs the real `iii-sdk` package, registers a deterministic worker function, binds it to an iii HTTP trigger, and exposes smoke endpoints. The default deployment requires no provider credentials, makes no LLM or model-provider calls, does not download model weights, and does not require browser authentication.
+
+## Services
+
+- `iii`: Official upstream iii engine image, running the built-in default workers on internal ports `49134`, `3111`, `3112`, and `9464`.
+- `app`: Node.js 22 verifier API that installs `iii-sdk`, connects to the engine over WebSocket, registers `phala::iii_demo`, and exposes port `8080`.
+
+## Category
+
+AI Apps & Workflows
+
+## Ports
+
+- `8080`: Public HTTP port exposed by Phala Cloud for the verifier API.
+- `49134`: Internal iii WebSocket worker connection port.
+- `3111`: Internal iii HTTP trigger port.
+- `3112`: Internal iii stream API port.
+- `9464`: Internal Prometheus metrics port.
+
+## Endpoints
+
+- `GET /healthz`: Verifies that the upstream engine HTTP port is reachable, the real `iii-sdk` package imported, the local worker function can be invoked directly through iii, and the registered iii HTTP trigger responds.
+- `GET /demo?topic=service%20workflow`: Invokes the deterministic worker through both the iii WebSocket function path and the iii HTTP trigger path, then returns evidence for the worker/function/trigger flow.
+- `POST /demo`: Same as `GET /demo`, with a JSON body such as `{"topic":"observe worker services"}`.
+- `GET /v1/models`: Returns an OpenAI-style metadata-only model list for smoke clients. No model is loaded or called.
+- `GET /`: Lists metadata and available endpoints.
+
+The engine-side registered demo route is `POST /phala/iii-demo` on the internal iii HTTP worker at `http://iii:3111/phala/iii-demo`. The public verifier's `/demo` endpoint calls that route for you.
+
+## Deploy
+
+1. Open Phala Cloud and create a deployment from the `iii` prebuilt template.
+2. Keep the default CPU resources for the demo.
+3. Deploy the CVM.
+4. Open the generated public endpoint for port `8080`.
+
+The first startup installs the pinned `iii-sdk` npm package inside the verifier container. Readiness can take a minute or two on a fresh deployment.
+
+## Environment Variables
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `III_SDK_VERSION` | No | `0.19.2` | Pinned `iii-sdk` npm package version installed by the verifier service at container startup. |
+| `PORT` | No | `8080` | Internal verifier HTTP port. The template sets this automatically. |
+| `III_ENGINE_WS_URL` | No | `ws://iii:49134` | Internal WebSocket URL used by the verifier worker to connect to the iii engine. |
+| `III_ENGINE_HTTP_URL` | No | `http://iii:3111` | Internal HTTP URL used by the verifier to call the registered iii HTTP trigger. |
+
+No real secrets are included, and no credential environment variables are required for the default demo.
+
+## Smoke Verification
+
+Use these commands to verify the deployment from your workstation.
+
+Set your Phala Cloud endpoint:
+
+```bash
+export III_URL=https://<your-app-domain>
+```
+
+Check readiness:
+
+```bash
+curl -fsS "$III_URL/healthz"
+```
+
+Run the deterministic iii worker/function/trigger demo:
+
+```bash
+curl -fsS "$III_URL/demo?topic=confidential%20service%20workflow"
+```
+
+Check the compatibility model-list endpoint:
+
+```bash
+curl -fsS "$III_URL/v1/models"
+```
+
+A healthy deployment returns HTTP `200` for all three commands. `/healthz` should report `direct_trigger_ok: true` and `http_trigger_ok: true`.
+
+## Local Verification
+
+From the parent monorepo worktree:
+
+```bash
+docker compose -f templates/prebuilt/iii/docker-compose.yml config
+docker compose -f templates/prebuilt/iii/docker-compose.yml up
+```
+
+Then, in another terminal:
+
+```bash
+curl -fsS http://localhost:8080/healthz
+curl -fsS http://localhost:8080/demo
+curl -fsS http://localhost:8080/v1/models
+```
+
+Stop the local stack when finished:
+
+```bash
+docker compose -f templates/prebuilt/iii/docker-compose.yml down
+```
+
+## Production Notes
+
+This template is intentionally a small no-secret verifier. It proves that the official iii engine can start in a CPU-only CVM and that a real `iii-sdk` worker can register a function and HTTP trigger. It is not a production iii application by itself.
+
+For production usage:
+
+1. Replace the deterministic demo worker with your own iii project workers.
+2. Add only the worker images, package registries, queues, state backends, observability exporters, and provider credentials that your application actually needs.
+3. Use deployment-time secrets for API keys, database credentials, queue credentials, and observability exporter tokens. Do not hard-code real tokens or passwords in the compose file.
+4. Size CPU, memory, disk, and network egress for your worker mix and any external state or message broker dependencies.
+5. Add authentication, authorization, and rate limiting before exposing business or agent endpoints publicly.
+
+The upstream engine Docker example also documents Redis and RabbitMQ-backed configurations. This template does not enable those sidecars by default because the no-credential Phala verifier should stay small, deterministic, and deployable on a `tdx.small`-class CPU instance.
+
+## Attribution
+
+- Upstream project: [iii-hq/iii](https://github.com/iii-hq/iii), built by iii-hq and open-source contributors.
+- Template author attribution: `iii-hq`.
+- Icon: `iii.svg`, sourced from upstream [`docs/assets/iii-black.svg`](https://github.com/iii-hq/iii/blob/main/docs/assets/iii-black.svg).

--- a/templates/prebuilt/iii/docker-compose.yml
+++ b/templates/prebuilt/iii/docker-compose.yml
@@ -1,0 +1,463 @@
+services:
+  iii:
+    image: iiidev/iii:latest
+    restart: unless-stopped
+    init: true
+    command:
+      - --use-default-config
+      - --no-update-check
+    environment:
+      RUST_LOG: info
+      III_EXECUTION_CONTEXT: docker
+      III_ENV: production
+    expose:
+      - "49134"
+      - "3111"
+      - "3112"
+      - "9464"
+
+  app:
+    image: node:22-bookworm-slim
+    restart: unless-stopped
+    init: true
+    depends_on:
+      - iii
+    ports:
+      - "8080:8080"
+    environment:
+      NODE_ENV: production
+      PORT: "8080"
+      III_ENGINE_WS_URL: ws://iii:49134
+      III_ENGINE_HTTP_URL: http://iii:3111
+      III_SDK_VERSION: ${III_SDK_VERSION:-0.19.2}
+      NPM_CONFIG_AUDIT: "false"
+      NPM_CONFIG_FUND: "false"
+      NPM_CONFIG_UPDATE_NOTIFIER: "false"
+    working_dir: /opt/iii-demo
+    configs:
+      - source: iii_demo_server
+        target: /opt/iii-demo/server.mjs
+    command:
+      - /bin/sh
+      - -lc
+      - |
+        set -eu
+        npm install --omit=dev --no-audit --no-fund --no-package-lock --no-save "iii-sdk@$${III_SDK_VERSION}"
+        exec node /opt/iii-demo/server.mjs
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "node -e \"fetch('http://127.0.0.1:' + (process.env.PORT || '8080') + '/healthz').then((response) => process.exit(response.ok ? 0 : 1)).catch(() => process.exit(1))\"",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 180s
+
+configs:
+  iii_demo_server:
+    content: |
+      import http from "node:http";
+      import os from "node:os";
+      import process from "node:process";
+      import { readFileSync } from "node:fs";
+      import { registerWorker } from "iii-sdk";
+
+      const startedAt = Date.now();
+      const serviceName = "iii-phala-demo";
+      const upstreamRepo = "https://github.com/iii-hq/iii";
+      const engineWsUrl = process.env.III_ENGINE_WS_URL || "ws://iii:49134";
+      const engineHttpUrl = (process.env.III_ENGINE_HTTP_URL || "http://iii:3111").replace(/\/+$/, "");
+      const port = Number(process.env.PORT || "8080");
+      const functionId = "phala::iii_demo";
+      const routePath = "/phala/iii-demo";
+      const endpoints = ["/healthz", "/demo", "/v1/models", routePath];
+      const sdkPackage = JSON.parse(readFileSync(new URL("./node_modules/iii-sdk/package.json", import.meta.url), "utf8"));
+
+      const iii = registerWorker(engineWsUrl);
+
+      function errorMessage(error) {
+        if (!error) {
+          return "unknown error";
+        }
+        const name = error.name || "Error";
+        const message = error.message || String(error);
+        return name + ": " + message;
+      }
+
+      function normalizeTopic(value) {
+        const text = typeof value === "string" && value.trim().length > 0 ? value.trim() : "confidential service orchestration";
+        return text.slice(0, 180);
+      }
+
+      function checksum(text) {
+        return Array.from(text).reduce((total, character) => (total + character.charCodeAt(0)) % 10007, 0);
+      }
+
+      function buildPrimitiveDemo(input) {
+        const topic = normalizeTopic(input && input.topic);
+        const words = topic.toLowerCase().match(/[a-z0-9]+/g) || [];
+        const category = words.includes("observe") || words.includes("observability")
+          ? "observability"
+          : words.includes("worker") || words.includes("service")
+            ? "service-composition"
+            : "workflow";
+
+        return {
+          ok: true,
+          service: serviceName,
+          upstream: upstreamRepo,
+          demo: "deterministic iii worker/function/HTTP-trigger demo",
+          credentials_required: false,
+          remote_model_calls: false,
+          model_downloaded: false,
+          cpu_only: true,
+          input: {
+            topic,
+          },
+          iii_primitives: {
+            worker: "phala-template-worker",
+            function_id: functionId,
+            trigger: {
+              type: "http",
+              path: routePath,
+              method: "POST",
+            },
+          },
+          result: {
+            normalized_topic: topic,
+            word_count: words.length,
+            checksum: checksum(topic),
+            category,
+            summary: "iii-sdk registered a local deterministic function with the live iii engine and exposed it through iii-http.",
+          },
+        };
+      }
+
+      iii.registerFunction(functionId, async (input) => {
+        const isHttpRequest = input && typeof input === "object" && input.trigger && input.trigger.type === "http";
+        const body = isHttpRequest ? input.body : input;
+        const payload = buildPrimitiveDemo(body || {});
+        if (isHttpRequest) {
+          return {
+            status_code: 200,
+            body: payload,
+            headers: {
+              "Content-Type": "application/json",
+            },
+          };
+        }
+        return payload;
+      });
+
+      iii.registerTrigger({
+        type: "http",
+        function_id: functionId,
+        config: {
+          api_path: routePath,
+          http_method: "POST",
+        },
+      });
+
+      function runtimeEvidence() {
+        return {
+          node: process.version,
+          platform: process.platform,
+          arch: process.arch,
+          hostname: os.hostname(),
+          uptime_seconds: Math.round((Date.now() - startedAt) / 100) / 10,
+        };
+      }
+
+      async function withTimeout(promise, milliseconds, label) {
+        let timer;
+        const timeout = new Promise((_, reject) => {
+          timer = setTimeout(() => reject(new Error(label + " timed out after " + milliseconds + "ms")), milliseconds);
+        });
+        try {
+          return await Promise.race([promise, timeout]);
+        } finally {
+          clearTimeout(timer);
+        }
+      }
+
+      async function probeEngineHttp() {
+        try {
+          const response = await withTimeout(fetch(engineHttpUrl + "/__phala_iii_probe__"), 5000, "engine HTTP probe");
+          return {
+            reachable: true,
+            status: response.status,
+          };
+        } catch (error) {
+          return {
+            reachable: false,
+            error: errorMessage(error),
+          };
+        }
+      }
+
+      async function triggerDirect(topic) {
+        try {
+          const payload = await withTimeout(
+            iii.trigger({
+              function_id: functionId,
+              payload: {
+                topic,
+              },
+            }),
+            8000,
+            "iii direct trigger"
+          );
+          return {
+            ok: Boolean(payload && payload.ok),
+            payload,
+          };
+        } catch (error) {
+          return {
+            ok: false,
+            error: errorMessage(error),
+          };
+        }
+      }
+
+      async function triggerViaHttp(topic) {
+        try {
+          const response = await withTimeout(
+            fetch(engineHttpUrl + routePath, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                topic,
+              }),
+            }),
+            8000,
+            "iii HTTP trigger"
+          );
+          const text = await response.text();
+          let body = text;
+          try {
+            body = JSON.parse(text);
+          } catch (_error) {
+            body = text;
+          }
+          return {
+            ok: response.ok && Boolean(body && body.ok),
+            status: response.status,
+            body,
+          };
+        } catch (error) {
+          return {
+            ok: false,
+            error: errorMessage(error),
+          };
+        }
+      }
+
+      async function healthPayload() {
+        const topic = "phala cloud iii smoke";
+        const engineHttp = await probeEngineHttp();
+        const direct = await triggerDirect(topic);
+        const httpTrigger = await triggerViaHttp(topic);
+        const ok = typeof registerWorker === "function" && engineHttp.reachable && direct.ok && httpTrigger.ok;
+
+        return {
+          status: ok ? "ok" : "starting",
+          ok,
+          service: serviceName,
+          upstream: upstreamRepo,
+          credentials_required: false,
+          remote_model_calls: false,
+          model_downloaded: false,
+          runtime: runtimeEvidence(),
+          engine: {
+            image: "iiidev/iii:latest",
+            websocket_url: engineWsUrl,
+            http_url: engineHttpUrl,
+            http_probe: engineHttp,
+          },
+          sdk: {
+            package: "iii-sdk",
+            version: sdkPackage.version,
+            import_ok: typeof registerWorker === "function",
+            direct_trigger_ok: direct.ok,
+            http_trigger_ok: httpTrigger.ok,
+          },
+          demo_function: {
+            function_id: functionId,
+            route_path: routePath,
+          },
+        };
+      }
+
+      async function demoPayload(topic) {
+        const normalizedTopic = normalizeTopic(topic);
+        const direct = await triggerDirect(normalizedTopic);
+        const httpTrigger = await triggerViaHttp(normalizedTopic);
+        return {
+          ok: direct.ok && httpTrigger.ok,
+          service: serviceName,
+          upstream: upstreamRepo,
+          credentials_required: false,
+          remote_model_calls: false,
+          model_downloaded: false,
+          cpu_only: true,
+          sdk: {
+            package: "iii-sdk",
+            version: sdkPackage.version,
+          },
+          engine: {
+            image: "iiidev/iii:latest",
+            websocket_url: engineWsUrl,
+            http_url: engineHttpUrl,
+          },
+          direct_trigger: direct,
+          http_trigger: httpTrigger,
+        };
+      }
+
+      function modelsPayload() {
+        return {
+          object: "list",
+          data: [
+            {
+              id: "iii/local-engine-worker-demo",
+              object: "model",
+              created: 0,
+              owned_by: "iii-hq",
+              description: "Compatibility metadata for the CPU-safe iii engine plus iii-sdk worker demo. No LLM model is hosted or called.",
+            },
+          ],
+          upstream: upstreamRepo,
+          credentials_required: false,
+          remote_model_calls: false,
+          model_downloaded: false,
+          engine: {
+            image: "iiidev/iii:latest",
+          },
+          sdk: {
+            package: "iii-sdk",
+            version: sdkPackage.version,
+          },
+        };
+      }
+
+      function rootPayload() {
+        return {
+          service: serviceName,
+          upstream: upstreamRepo,
+          endpoints,
+          credentials_required: false,
+          remote_model_calls: false,
+          model_downloaded: false,
+        };
+      }
+
+      async function readJsonBody(request) {
+        const chunks = [];
+        let size = 0;
+        for await (const chunk of request) {
+          size += chunk.length;
+          if (size > 1048576) {
+            throw new Error("request body exceeds 1 MiB");
+          }
+          chunks.push(chunk);
+        }
+        if (chunks.length === 0) {
+          return {};
+        }
+        const text = Buffer.concat(chunks).toString("utf8");
+        if (text.trim().length === 0) {
+          return {};
+        }
+        return JSON.parse(text);
+      }
+
+      function sendJson(response, statusCode, payload) {
+        const body = Buffer.from(JSON.stringify(payload, null, 2) + "\n", "utf8");
+        response.writeHead(statusCode, {
+          "Content-Type": "application/json; charset=utf-8",
+          "Cache-Control": "no-store",
+          "Content-Length": body.length,
+        });
+        response.end(body);
+      }
+
+      const server = http.createServer((request, response) => {
+        const url = new URL(request.url || "/", "http://localhost");
+        const path = url.pathname.replace(/\/+$/, "") || "/";
+
+        Promise.resolve()
+          .then(async () => {
+            if (path === "/") {
+              if (request.method !== "GET") {
+                sendJson(response, 405, { ok: false, error: "method_not_allowed", endpoints });
+                return;
+              }
+              sendJson(response, 200, rootPayload());
+              return;
+            }
+
+            if (path === "/healthz") {
+              if (request.method !== "GET") {
+                sendJson(response, 405, { ok: false, error: "method_not_allowed", endpoints });
+                return;
+              }
+              const payload = await healthPayload();
+              sendJson(response, payload.ok ? 200 : 503, payload);
+              return;
+            }
+
+            if (path === "/demo") {
+              let topic = url.searchParams.get("topic");
+              if (request.method === "POST") {
+                const body = await readJsonBody(request);
+                topic = body.topic || body.input || topic;
+              } else if (request.method !== "GET") {
+                sendJson(response, 405, { ok: false, error: "method_not_allowed", endpoints });
+                return;
+              }
+              const payload = await demoPayload(topic);
+              sendJson(response, payload.ok ? 200 : 503, payload);
+              return;
+            }
+
+            if (path === "/v1/models") {
+              if (request.method !== "GET") {
+                sendJson(response, 405, { ok: false, error: "method_not_allowed", endpoints });
+                return;
+              }
+              sendJson(response, 200, modelsPayload());
+              return;
+            }
+
+            sendJson(response, 404, {
+              ok: false,
+              error: "not_found",
+              endpoints,
+            });
+          })
+          .catch((error) => {
+            sendJson(response, 500, {
+              ok: false,
+              error: errorMessage(error),
+            });
+          });
+      });
+
+      server.listen(port, "0.0.0.0", () => {
+        console.log(JSON.stringify({
+          event: "startup",
+          service: serviceName,
+          port,
+          upstream: upstreamRepo,
+          engine_ws_url: engineWsUrl,
+          engine_http_url: engineHttpUrl,
+          sdk_version: sdkPackage.version,
+          credentials_required: false,
+          remote_model_calls: false,
+          model_downloaded: false,
+        }));
+      });


### PR DESCRIPTION
## Summary
- Add a Phala Cloud prebuilt template for `iii-hq/iii`.
- Upstream repository: https://github.com/iii-hq/iii
- Template files: `templates/prebuilt/iii/docker-compose.yml`, `templates/prebuilt/iii/README.md`, `templates/config.json`
- Icon: `iii.svg`; source documented in the README.

## Environment variables
- See the template README for optional provider/runtime environment variables. No real secrets are included.

## Validation
- `python sdks/templates/validate.py`
- `git -C sdks diff --check origin/main...HEAD`
- `docker compose -f sdks/templates/prebuilt/iii/docker-compose.yml config >/dev/null`
- static audit: README coverage, config ID uniqueness, icon file, forbidden compose directives, host bind mounts, and secret-like literals

## Deployment smoke
- Deployed with `phala deploy --profile hermes-admin-cvm-check --instance-type tdx.small --node-id 12 --wait --no-public-logs --no-public-sysinfo`
- Smoke CVM: `1fa51d42-2666-4214-9cb2-12eb5d15ec38`
- Smoke app: `7027767b279ea06405fb02a668647fb548e4ce90`
- Endpoint probe: `https://7027767b279ea06405fb02a668647fb548e4ce90-8080.dstack-pha-prod7.phala.network/healthz -> 200 800 0.179879 rc=0`
- Cleanup: temporary smoke CVM deletion requested and verified separately.

cc @Marvin-Cypher for review.
