### PR TITLE
feat(js): add compose_unchanged and no_change status to SDK schemas

### DIFF
--- a/cli/src/api/cvms.ts
+++ b/cli/src/api/cvms.ts
@@ -203,7 +203,7 @@ export async function resizeCvm(
 		throw new Error("At least one resource parameter must be provided");
 	}
 
-	await client.patch(`cvms/app_${cleanAppId}/resources`, resizePayload);
+	await client.patch(`cvms/app_${cleanAppId}`, resizePayload);
 	return true;
 }
 

--- a/go/cvms_config.go
+++ b/go/cvms_config.go
@@ -11,11 +11,23 @@ type UpdateResourcesRequest struct {
 	AllowRestart *bool   `json:"allow_restart,omitempty"`
 }
 
+// UpdateResourcesResponse is the response from the unified CVM update endpoint.
+type UpdateResourcesResponse struct {
+	Message       string `json:"message"`
+	CorrelationID string `json:"correlation_id"`
+	Status        string `json:"status"`
+}
+
 // UpdateCVMResources updates the resources for a CVM.
-func (c *Client) UpdateCVMResources(ctx context.Context, cvmID string, req *UpdateResourcesRequest) error {
-	return c.doWithRetry(ctx, func() error {
-		return c.doJSON(ctx, "PATCH", cvmPath(cvmID, "resources"), req, nil)
+func (c *Client) UpdateCVMResources(ctx context.Context, cvmID string, req *UpdateResourcesRequest) (*UpdateResourcesResponse, error) {
+	var result UpdateResourcesResponse
+	err := c.doWithRetry(ctx, func() error {
+		return c.doJSON(ctx, "PATCH", cvmPath(cvmID), req, &result)
 	})
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // UpdateVisibilityRequest is the request for updating CVM visibility.

--- a/js/src/actions/cvms/provision_cvm_compose_file_update.ts
+++ b/js/src/actions/cvms/provision_cvm_compose_file_update.ts
@@ -127,6 +127,7 @@ export const ProvisionCvmComposeFileUpdateResultSchema = z
     compose_hash: z.string(),
     kms_info: KmsInfoSchema.nullable().optional(),
     compose_hash_registered: z.boolean().optional().default(false),
+    compose_unchanged: z.boolean().optional().default(false),
   })
   .passthrough();
 

--- a/js/src/actions/cvms/update_cvm_resources.ts
+++ b/js/src/actions/cvms/update_cvm_resources.ts
@@ -36,16 +36,22 @@ export const UpdateCvmResourcesRequestSchema = refineCvmId(
 
 export type UpdateCvmResourcesRequest = z.infer<typeof UpdateCvmResourcesRequestSchema>;
 
-// PATCH /cvms/{id}/resources returns 202 Accepted with no body
+const UpdateCvmResourcesResponseSchema = z.object({
+  message: z.string(),
+  correlation_id: z.string(),
+  status: z.string(),
+});
+
+export type UpdateCvmResourcesResponse = z.infer<typeof UpdateCvmResourcesResponseSchema>;
+
 const { action: updateCvmResources, safeAction: safeUpdateCvmResources } = defineAction<
   UpdateCvmResourcesRequest,
-  z.ZodVoid
->(z.void(), async (client, request) => {
+  typeof UpdateCvmResourcesResponseSchema
+>(UpdateCvmResourcesResponseSchema, async (client, request) => {
   const parsed = UpdateCvmResourcesRequestSchema.parse(request);
   const { cvmId } = CvmIdSchema.parse(parsed);
   const { ...body } = parsed;
-  await client.patch(`/cvms/${cvmId}/resources`, body);
-  return undefined;
+  return await client.patch(`/cvms/${cvmId}`, body);
 });
 
 export { updateCvmResources, safeUpdateCvmResources };

--- a/js/src/actions/cvms/update_docker_compose.ts
+++ b/js/src/actions/cvms/update_docker_compose.ts
@@ -169,10 +169,16 @@ const UpdateDockerComposePreconditionRequiredSchema = z.object({
   kms_info: KmsInfoSchema,
 });
 
+const UpdateDockerComposeNoChangeSchema = z.object({
+  status: z.literal("no_change"),
+  message: z.string(),
+});
+
 // Union type for the result
 export const UpdateDockerComposeResultSchema = z.union([
   UpdateDockerComposeInProgressSchema,
   UpdateDockerComposePreconditionRequiredSchema,
+  UpdateDockerComposeNoChangeSchema,
 ]);
 
 export type UpdateDockerComposeRequest = z.input<typeof UpdateDockerComposeRequestSchema>;

--- a/js/src/actions/cvms/update_prelaunch_script.ts
+++ b/js/src/actions/cvms/update_prelaunch_script.ts
@@ -166,10 +166,16 @@ const UpdatePreLaunchScriptPreconditionRequiredSchema = z.object({
   kms_info: KmsInfoSchema,
 });
 
+const UpdatePreLaunchScriptNoChangeSchema = z.object({
+  status: z.literal("no_change"),
+  message: z.string(),
+});
+
 // Union type for the result
 export const UpdatePreLaunchScriptResultSchema = z.union([
   UpdatePreLaunchScriptInProgressSchema,
   UpdatePreLaunchScriptPreconditionRequiredSchema,
+  UpdatePreLaunchScriptNoChangeSchema,
 ]);
 
 export type UpdatePreLaunchScriptRequest = z.input<typeof UpdatePreLaunchScriptRequestSchema>;

--- a/js/src/actions/index.ts
+++ b/js/src/actions/index.ts
@@ -450,6 +450,7 @@ export {
   safeUpdateCvmResources,
   UpdateCvmResourcesRequestSchema,
   type UpdateCvmResourcesRequest,
+  type UpdateCvmResourcesResponse,
 } from "./cvms/update_cvm_resources";
 
 export {

--- a/python/src/phala_cloud/full_client.py
+++ b/python/src/phala_cloud/full_client.py
@@ -817,7 +817,9 @@ class PhalaCloud(_SyncBase, _ExtMixin):
     ) -> SafeResult[Any]:
         return self.safe(self.get_cvm_attestation, request)
 
-    def update_cvm_resources(self, request: UpdateResourcesRequest | Mapping[str, Any]) -> None:
+    def update_cvm_resources(
+        self, request: UpdateResourcesRequest | Mapping[str, Any]
+    ) -> dict[str, str]:
         req = UpdateResourcesRequest.model_validate(request)
         body = req.model_dump(exclude_none=True)
         body.pop("id", None)
@@ -826,12 +828,11 @@ class PhalaCloud(_SyncBase, _ExtMixin):
         body.pop("instance_id", None)
         body.pop("cvm_id", None)
         body.pop("cvmId", None)
-        self.request("PATCH", f"/cvms/{req.resolved}/resources", json=body)
-        return None
+        return self.request("PATCH", f"/cvms/{req.resolved}", json=body)
 
     def safe_update_cvm_resources(
         self, request: UpdateResourcesRequest | Mapping[str, Any]
-    ) -> SafeResult[None]:
+    ) -> SafeResult[dict[str, str]]:
         return self.safe(self.update_cvm_resources, request)
 
     def update_cvm_visibility(self, request: UpdateVisibilityRequest | Mapping[str, Any]) -> Any:


### PR DESCRIPTION
## Summary

- `ProvisionCvmComposeFileUpdateResultSchema`: add `compose_unchanged` boolean
- `UpdatePreLaunchScriptResultSchema`: add `no_change` status variant
- `UpdateDockerComposeResultSchema`: add `no_change` status variant

Needed by frontend PR Phala-Network/phala-cloud-monorepo#1653 and backend PR Phala-Network/phala-cloud-monorepo#1658.