### PR TITLE
security(ci): harden SDK release workflows

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Parse release command
         id: parse
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -203,6 +203,7 @@ jobs:
       group: release-go-${{ github.event_name == 'workflow_dispatch' && inputs.ref || needs.parse.outputs.ref }}
       cancel-in-progress: false
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    environment: release
     env:
       RELEASE_TYPE: ${{ github.event_name == 'workflow_dispatch' && inputs.release_type || needs.parse.outputs.release_type }}
       PRERELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || needs.parse.outputs.prerelease }}
@@ -234,8 +235,16 @@ jobs:
             exit 1
           fi
 
+          case "$SOURCE_REF" in
+            main|refs/tags/v*) ;;
+            *)
+              echo "Unsupported source ref: $SOURCE_REF (must be main or refs/tags/v*)"
+              exit 1
+              ;;
+          esac
+
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: ${{ env.SOURCE_REF }}
@@ -246,7 +255,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go/go.mod
 
@@ -274,13 +283,13 @@ jobs:
         run: go test -count=1 ./...
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
       - name: Generate changelog
         run: |
-          npm install -g conventional-changelog-cli conventional-changelog-conventionalcommits
+          npm install -g conventional-changelog-cli@5.0.0 conventional-changelog-conventionalcommits@8.0.0 --ignore-scripts
 
           conventional-changelog -p conventionalcommits \
             --commit-path "go" \
@@ -369,7 +378,7 @@ jobs:
 
       - name: Comment success
         if: ${{ success() && env.ISSUE_NUMBER != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -409,7 +418,7 @@ jobs:
 
       - name: Comment failure
         if: ${{ failure() && env.ISSUE_NUMBER != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -69,7 +69,7 @@ jobs:
     steps:
       - name: Parse release command
         id: parse
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -231,6 +231,7 @@ jobs:
       group: release-${{ github.event_name == 'workflow_dispatch' && inputs.package || needs.parse.outputs.package }}-${{ github.event_name == 'workflow_dispatch' && inputs.ref || needs.parse.outputs.ref }}
       cancel-in-progress: false
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    environment: release
     env:
       PACKAGE: ${{ github.event_name == 'workflow_dispatch' && inputs.package || needs.parse.outputs.package }}
       RELEASE_TYPE: ${{ github.event_name == 'workflow_dispatch' && inputs.release_type || needs.parse.outputs.release_type }}
@@ -278,8 +279,16 @@ jobs:
             exit 1
           fi
 
+          case "$SOURCE_REF" in
+            main|refs/tags/v*) ;;
+            *)
+              echo "Unsupported source ref: $SOURCE_REF (must be main or refs/tags/v*)"
+              exit 1
+              ;;
+          esac
+
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: ${{ env.SOURCE_REF }}
@@ -290,13 +299,13 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org/
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install workspace dependencies
         run: bun install
@@ -377,7 +386,7 @@ jobs:
 
       - name: Generate changelog
         run: |
-          npm install -g conventional-changelog-cli conventional-changelog-conventionalcommits
+          npm install -g conventional-changelog-cli@5.0.0 conventional-changelog-conventionalcommits@8.0.0 --ignore-scripts
 
           # Update CHANGELOG.md (prepends latest release)
           # --commit-path must be relative to the repo root so git log filters
@@ -426,11 +435,12 @@ jobs:
           if grep -q '"@phala/cloud": "workspace:\*"' package.json; then
             JS_VERSION=$(node -e "console.log(require('../js/package.json').version)")
             echo "Resolving workspace:* to version $JS_VERSION"
+            export JS_VERSION
             node -e "
               const fs = require('fs');
               const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
               if (pkg.dependencies && pkg.dependencies['@phala/cloud'] === 'workspace:*') {
-                pkg.dependencies['@phala/cloud'] = '^$JS_VERSION';
+                pkg.dependencies['@phala/cloud'] = '^' + process.env.JS_VERSION;
                 fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
               }
             "
@@ -438,8 +448,8 @@ jobs:
 
       - name: Upgrade npm for trusted publishing
         run: |
-          # Ensure npm 11.5.1 or later for OIDC trusted publishing support
-          npm install -g npm@latest
+          # Ensure npm 11.17.0 or later for OIDC trusted publishing support
+          npm install -g npm@11.17.0 --ignore-scripts
           npm --version
 
       - name: Verify OIDC token and npm authentication
@@ -586,12 +596,14 @@ jobs:
 
       - name: Comment success
         if: ${{ success() && env.ISSUE_NUMBER != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          FILE_LIST: ${{ steps.pack_info.outputs.file_list }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const fileList = `${{ steps.pack_info.outputs.file_list }}`.split('\n').slice(0, 15).join('\n');
+            const fileList = process.env.FILE_LIST.split('\n').slice(0, 15).join('\n');
             const totalFiles = Number('${{ steps.pack_info.outputs.total_files }}');
             const hasMore = totalFiles > 15;
             const usedReleaseBranch = '${{ steps.push.outputs.used_release_branch }}' === 'true';
@@ -637,7 +649,7 @@ jobs:
 
       - name: Comment failure
         if: ${{ failure() && env.ISSUE_NUMBER != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: Parse release command
         id: parse
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -204,7 +204,9 @@ jobs:
       group: release-python-${{ github.event_name == 'workflow_dispatch' && inputs.ref || needs.parse.outputs.ref }}
       cancel-in-progress: false
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    environment: pypi
+    # SECURITY: The PyPI Trusted Publisher configuration must be updated to use
+    # environment name "release" instead of "pypi" so OIDC token exchange keeps working.
+    environment: release
     env:
       RELEASE_TYPE: ${{ github.event_name == 'workflow_dispatch' && inputs.release_type || needs.parse.outputs.release_type }}
       PRERELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || needs.parse.outputs.prerelease }}
@@ -236,8 +238,16 @@ jobs:
             exit 1
           fi
 
+          case "$SOURCE_REF" in
+            main|refs/tags/v*) ;;
+            *)
+              echo "Unsupported source ref: $SOURCE_REF (must be main or refs/tags/v*)"
+              exit 1
+              ;;
+          esac
+
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           ref: ${{ env.SOURCE_REF }}
@@ -248,7 +258,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
       - name: Setup Python
         working-directory: python
@@ -305,7 +315,7 @@ jobs:
 
       - name: Generate changelog
         run: |
-          npm install -g conventional-changelog-cli conventional-changelog-conventionalcommits
+          npm install -g conventional-changelog-cli@5.0.0 conventional-changelog-conventionalcommits@8.0.0 --ignore-scripts
 
           conventional-changelog -p conventionalcommits \
             --commit-path "python" \
@@ -330,7 +340,7 @@ jobs:
           git commit -m "chore(python): release v${NEW_VERSION}"
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: python/dist/
 
@@ -399,7 +409,7 @@ jobs:
 
       - name: Comment success
         if: ${{ success() && env.ISSUE_NUMBER != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -437,7 +447,7 @@ jobs:
 
       - name: Comment failure
         if: ${{ failure() && env.ISSUE_NUMBER != '' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
Addresses security audit findings S4, S5, and S6 for the SDK release pipelines.

### Changes
- **S4 (unreviewed branch release gating)**: Added `environment: release` approval gate to the release job in all three workflows. Added `SOURCE_REF` validation so releases can only run from `main` or `refs/tags/v*`. Note: for the Python workflow, the PyPI Trusted Publisher environment must be updated from `pypi` to `release`.
- **S5 (command injection)**: In `release-npm.yml`, `JS_VERSION` and the package `file_list` are now passed through `env` instead of being interpolated into shell/JS code.
- **S6 (dependency pinning)**: Pinned all GitHub Actions to full commit SHAs, pinned `conventional-changelog-cli` / `conventional-changelog-conventionalcommits` to specific versions, and added `--ignore-scripts` to all global npm installs.

### Affected workflows
- `.github/workflows/release-npm.yml`
- `.github/workflows/release-python.yml`
- `.github/workflows/release-go.yml`
