### PR TITLE
feat: add ralph miner phala template

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ deployments for:
 
 - MCP servers and AI agent tools
 - LLM inference and model-serving demos
+- AI research and GPU miner workspaces
 - Web apps and developer utilities
 - Blockchain, oracle, and data workloads
 - Confidential computing starter kits

--- a/templates/config.json
+++ b/templates/config.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ralph-miner",
+    "name": "RalphLabsAI/ralph miner",
+    "description": "Ralph Bittensor H100-style miner workspace for Phala Cloud H200 TEE. It prepares Ralph, recipe, dependencies, data, the TDX/NVIDIA CC attestation path, and a token-protected JupyterLab environment for miners to continue manually.",
+    "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/ralph-miner",
+    "author": "RalphLabsAI",
+    "tags": [
+      "AI Research",
+      "Bittensor",
+      "TEE & Privacy",
+      "GPU"
+    ],
+    "defaultResource": {
+      "vCPU": 24,
+      "memory": 196608,
+      "diskSize": 300
+    },
+    "envs": [
+      {
+        "key": "JUPYTER_TOKEN",
+        "required": true,
+        "description": "Long random token used to open the JupyterLab workspace on port 8888. Generate one with openssl rand -hex 32 or an equivalent password manager."
+      }
+    ]
+  },
+  {
     "id": "autogen",
     "name": "microsoft/autogen",
     "description": "Microsoft's multi-agent conversation framework; Azure-integrated. This template runs a CPU-only HTTP smoke demo that installs AutoGen Core and AgentChat packages and executes a deterministic local two-agent interaction without external LLM credentials.",

--- a/templates/prebuilt/ralph-miner/README.md
+++ b/templates/prebuilt/ralph-miner/README.md
@@ -1,0 +1,188 @@
+# RalphLabsAI/ralph Jupyter miner workspace on Phala Cloud
+
+Deploy a Phala Cloud H200 TEE CVM that completes the upstream Ralph H100 miner
+setup through step 2, then serves a prepared JupyterLab workspace for the miner
+to continue interactively.
+
+The template does not create wallets, write `.env`, verify registration, submit
+baselines, generate patches, or run `scripts/miner_run.py`. Those are upstream
+step 3 and later, and are intentionally left to the miner inside JupyterLab.
+
+## Metadata
+
+- Template id: `ralph-miner`
+- Display name: `RalphLabsAI/ralph miner`
+- Category: AI Research, Bittensor, TEE & Privacy, GPU
+- Upstream repository: https://github.com/RalphLabsAI/ralph
+- Upstream H100 guide: https://github.com/RalphLabsAI/ralph/blob/main/docs/h100_miner_setup.md
+- Upstream recipe repository: https://github.com/RalphLabsAI/recipe
+- Attestation shim: https://github.com/Dstack-TEE/dstack-examples/tree/main/tsm-shim
+- Default GPU target: H200, `h200.small`
+- Default disk size: `300G`
+
+## What This Template Does
+
+This template maps Phala deployment to the upstream H100 guide as follows:
+
+| Upstream step | Who does it | Phala template behavior |
+| --- | --- | --- |
+| Step 1. Rent the box | Phala Cloud | User creates the Phala deployment. |
+| Step 2. Bootstrap on the H100 | Template | Container starts JupyterLab, clones repos, creates venv, installs Ralph, and prepares data. |
+| Step 3. Bittensor wallet + HF token | Miner | Miner opens JupyterLab and performs this manually. |
+| Step 4+. Submit bundles and iterate | Miner | Miner performs this manually in JupyterLab terminal or notebooks. |
+
+Runtime services:
+
+- `tsm-shim`: runs `ghcr.io/dstack-tee/dstack-tsm-shim:latest` and exposes the
+  dstack quote socket as configfs-tsm-compatible `/run/tsm/report/inblob` and
+  `/run/tsm/report/outblob` FIFOs for later proof runs.
+- `ralph-miner`: starts from
+  `ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-pytorch-cuda:latest`,
+  serves token-protected JupyterLab on port `8888`, and performs the upstream
+  H100 guide's step 2:
+  - clone `https://github.com/RalphLabsAI/ralph.git` to `/workspace/ralph`;
+  - clone `https://github.com/RalphLabsAI/recipe.git` to `/workspace/recipe`;
+  - create `/workspace/ralph/.venv`;
+  - run `pip install -e '.[hub,chain,data]'` inside `/workspace/ralph`, which
+    installs the Hugging Face, Bittensor chain, and data-preparation
+    dependencies miners need for the next steps;
+  - install JupyterLab and register the Ralph venv as the `Ralph (.venv)`
+    notebook kernel;
+  - run `python -m data.prepare --source fineweb-edu --out data/shards --shard-tokens 10000000 --total-tokens 1000000000 --eval-tokens 5000000` inside `/workspace/recipe`.
+
+The `ralph-miner` service sets `RALPH_TSM_REPORT_PATH=/run/tsm/report` so later
+Ralph proof runs can find the Phala/dstack TDX report path without requiring the
+miner to set that variable manually. The compose file intentionally does not
+define `healthcheck` or `security_opt` blocks.
+
+The template installs the Bittensor/Ralph chain dependencies, but it does not
+create, import, download, or copy wallet key material. The registered wallet
+files remain a miner-owned Step 3 action inside JupyterLab.
+
+Prepared paths:
+
+| Path | Purpose |
+| --- | --- |
+| `/workspace/ralph` | Ralph repo cloned from upstream |
+| `/workspace/recipe` | Recipe repo cloned from upstream |
+| `/workspace/ralph/.venv` | Python virtual environment created by the template and registered as the `Ralph (.venv)` Jupyter kernel |
+| `/workspace/recipe/data/shards` | FineWeb-Edu data output path |
+| `/workspace/.bittensor/wallets` | Bittensor wallet directory mounted on a named volume and visible in JupyterLab |
+| `/workspace/status` | Setup status files and local Jupyter log |
+| `/run/tsm/report` | Phala/dstack TDX report path exposed by `tsm-shim`; also exported as `RALPH_TSM_REPORT_PATH` in `ralph-miner` |
+
+## Template Inputs
+
+The miner must provide only a Jupyter token at deployment time.
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `JUPYTER_TOKEN` | Yes | unset | Long random token used to open the JupyterLab workspace on port `8888`. Generate one with `openssl rand -hex 32` or an equivalent password manager. |
+
+Do not paste a wallet password, Hugging Face token, wallet archive, patch URL,
+GitHub token, W&B key, validator bot token, or cloud-provider key into the
+template form.
+
+## Miner Flow After Startup
+
+Open the Phala Cloud URL for port `8888` and enter the `JUPYTER_TOKEN` provided
+at deployment time.
+
+The workspace may become reachable before FineWeb-Edu data preparation finishes.
+Check readiness from a JupyterLab terminal:
+
+```bash
+cat /workspace/status/ready
+cat /workspace/PHALA_RALPH_READY.md
+```
+
+Then continue from upstream step 3. Example `.env` shape:
+
+```bash
+cd /workspace/ralph
+cat > .env <<'EOF'
+RALPH_CHAIN=bittensor
+BT_NETWORK=finney
+BT_NETUID=40
+BT_WALLET=<your-miner-wallet>
+BT_HOTKEY=default
+BT_WALLET_PASSWORD=<password>
+
+HF_TOKEN=<hf-write-token>
+RALPH_HF_REPO=RalphLabsAI/proof-bundles
+EOF
+chmod 600 .env
+```
+
+Upload or copy the already-registered Bittensor wallet into the normal wallet
+path visible from JupyterLab:
+
+```text
+/workspace/.bittensor/wallets/<BT_WALLET>/coldkey
+/workspace/.bittensor/wallets/<BT_WALLET>/hotkeys/<BT_HOTKEY>
+```
+
+Use the JupyterLab file browser, JupyterLab terminal, or another
+miner-controlled copy method to place the wallet files there. The template does
+not generate wallet keys, does not import a wallet tarball, and does not ask for
+wallet key material in the template form.
+
+From there, follow the upstream H100 guide's registration check and
+`scripts/miner_run.py` commands. Use the prepared venv:
+
+```bash
+cd /workspace/ralph
+source .venv/bin/activate
+set -a && source .env && set +a
+```
+
+The recipe repository uses `configs/h100_proxy.json`; the upstream H100 guide
+contains snippets that mention both `configs/proxy_h100.json` and
+`configs/h100_proxy.json`.
+
+## Expected Logs
+
+During startup:
+
+```text
+[ralph-phala] clone RalphLabsAI/ralph
+[ralph-phala] clone RalphLabsAI/recipe
+[ralph-phala] create-venv /workspace/ralph/.venv
+[ralph-phala] jupyter-ready port=8888 token=provided-by-template-env
+[ralph-phala] data-prepare fineweb-edu
+[ralph-phala] workspace-ready /workspace/PHALA_RALPH_READY.md
+```
+
+## Verification
+
+Run these checks from a `phala-cloud` worktree:
+
+```bash
+python3 templates/validate.py
+git diff --check origin/main...HEAD
+docker compose -f templates/prebuilt/ralph-miner/docker-compose.yml config >/dev/null
+```
+
+The compose file intentionally escapes shell `$` as `$$` inside inline
+`configs.*.content`, because Docker Compose interpolates inline config content
+before Phala starts the CVM workload.
+
+## Security Notes
+
+- Use a long random `JUPYTER_TOKEN`; anyone with the public port `8888` URL and
+  token can access the workspace.
+- The startup log does not print the Jupyter token. Jupyter's own server log is
+  redirected to `/workspace/status/jupyter.log` rather than container stdout.
+- Keep wallet files, `BT_WALLET_PASSWORD`, `HF_TOKEN`, patches, and generated
+  proof artifacts out of source control.
+- Disable public logs for real proof runs because logs may include operational
+  metadata.
+- The template mounts `/var/run/dstack.sock` into `tsm-shim` so later Ralph proof
+  runs can obtain a TDX quote through the Phala/dstack attestation path.
+
+## Production Notes
+
+The default image installs Ralph dependencies during container startup for
+first-run convenience. For repeated production mining, replace the image with a
+prebuilt digest-pinned Ralph Jupyter image in a follow-up PR so H200 time is not
+spent on package installation.

--- a/templates/prebuilt/ralph-miner/docker-compose.yml
+++ b/templates/prebuilt/ralph-miner/docker-compose.yml
@@ -1,0 +1,191 @@
+name: ralph-miner-phala
+
+services:
+  tsm-shim:
+    image: ghcr.io/dstack-tee/dstack-tsm-shim:latest
+    restart: unless-stopped
+    environment:
+      TSM_REPORT_DIR: /run/tsm/report
+      TSM_REPORT_MODE: "0666"
+    volumes:
+      - /var/run/dstack.sock:/var/run/dstack.sock
+      - tsm-report:/run/tsm/report
+
+  ralph-miner:
+    image: ghcr.io/kubeflow/kubeflow/notebook-servers/jupyter-pytorch-cuda:latest
+    restart: unless-stopped
+    init: true
+    user: root
+    depends_on:
+      - tsm-shim
+    working_dir: /workspace
+    ports:
+      - "8888:8888"
+    environment:
+      HOME: /workspace
+      PYTHONDONTWRITEBYTECODE: "1"
+      PYTHONUNBUFFERED: "1"
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
+      JUPYTER_TOKEN: ${JUPYTER_TOKEN:-}
+      RALPH_TSM_REPORT_PATH: /run/tsm/report
+      HF_HOME: /workspace/.cache/huggingface
+      HF_DATASETS_CACHE: /workspace/.cache/huggingface/datasets
+    volumes:
+      - ralph-work:/workspace
+      - bittensor-wallets:/workspace/.bittensor/wallets
+      - tsm-report:/run/tsm/report
+    configs:
+      - source: ralph_jupyter_bootstrap
+        target: /usr/local/bin/ralph-jupyter-bootstrap.sh
+        mode: 0555
+    entrypoint:
+      - /bin/bash
+      - /usr/local/bin/ralph-jupyter-bootstrap.sh
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+configs:
+  ralph_jupyter_bootstrap:
+    content: |
+      #!/usr/bin/env bash
+      set -Eeuo pipefail
+
+      mkdir -p /workspace/status /workspace/.cache/huggingface /workspace/.bittensor/wallets
+      chmod 0700 /workspace/.bittensor /workspace/.bittensor/wallets || true
+      date -u +%Y-%m-%dT%H:%M:%SZ > /workspace/status/started
+
+      log() {
+        printf '[ralph-phala] %s\n' "$$*"
+      }
+
+      fail_keepalive() {
+        log "setup-failed; container remains alive for Phala logs"
+        date -u +%Y-%m-%dT%H:%M:%SZ > /workspace/status/failed
+        tail -f /dev/null
+      }
+
+      trap fail_keepalive ERR
+
+      if [ -z "$${JUPYTER_TOKEN:-}" ]; then
+        log "missing-required-env JUPYTER_TOKEN"
+        exit 2
+      fi
+
+      if ! command -v git >/dev/null 2>&1; then
+        log "missing-command git"
+        exit 1
+      fi
+
+      if command -v python3 >/dev/null 2>&1; then
+        PYTHON_BIN=python3
+      elif command -v python >/dev/null 2>&1; then
+        PYTHON_BIN=python
+      else
+        log "missing-command python"
+        exit 1
+      fi
+
+      if [ ! -d /workspace/ralph/.git ]; then
+        log "clone RalphLabsAI/ralph"
+        git clone https://github.com/RalphLabsAI/ralph.git /workspace/ralph
+      else
+        log "repo-present /workspace/ralph"
+      fi
+
+      if [ ! -d /workspace/recipe/.git ]; then
+        log "clone RalphLabsAI/recipe"
+        git clone https://github.com/RalphLabsAI/recipe.git /workspace/recipe
+      else
+        log "repo-present /workspace/recipe"
+      fi
+
+      cd /workspace/ralph
+      if [ ! -d .venv ]; then
+        log "create-venv /workspace/ralph/.venv"
+        if ! "$$PYTHON_BIN" -m venv .venv; then
+          "$$PYTHON_BIN" -m pip install --user virtualenv
+          "$$PYTHON_BIN" -m virtualenv .venv
+        fi
+      fi
+      # shellcheck disable=SC1091
+      source .venv/bin/activate
+      python -m pip install --upgrade pip setuptools wheel
+      python -m pip install --no-cache-dir -e '.[hub,chain,data]'
+      python -m pip install --no-cache-dir jupyterlab ipykernel
+      python -m ipykernel install --user --name ralph --display-name "Ralph (.venv)"
+
+      : > /workspace/status/jupyter.log
+      chmod 0600 /workspace/status/jupyter.log
+      nohup /workspace/ralph/.venv/bin/python -m jupyter lab \
+        --ip=0.0.0.0 \
+        --port=8888 \
+        --no-browser \
+        --allow-root \
+        --ServerApp.root_dir=/workspace \
+        --ServerApp.token="$$JUPYTER_TOKEN" \
+        --ServerApp.password='' \
+        > /workspace/status/jupyter.log 2>&1 &
+      JUPYTER_PID="$$!"
+      echo "$$JUPYTER_PID" > /workspace/status/jupyter.pid
+      sleep 2
+      if ! kill -0 "$$JUPYTER_PID" 2>/dev/null; then
+        log "jupyter-start-failed see /workspace/status/jupyter.log"
+        exit 1
+      fi
+      log "jupyter-ready port=8888 token=provided-by-template-env"
+
+      if [ ! -f /workspace/recipe/data/data_manifest.json ]; then
+        log "data-prepare fineweb-edu"
+        cd /workspace/recipe
+        PYTHONPATH=/workspace/recipe /workspace/ralph/.venv/bin/python -m data.prepare \
+          --source fineweb-edu \
+          --out data/shards \
+          --shard-tokens 10000000 \
+          --total-tokens 1000000000 \
+          --eval-tokens 5000000
+      else
+        log "data-manifest-present /workspace/recipe/data/data_manifest.json"
+      fi
+
+      cat > /workspace/PHALA_RALPH_READY.md <<'MD'
+      # Ralph Jupyter Workspace Ready
+
+      This workspace has completed the Phala equivalent of the upstream Ralph H100 miner setup through step 2:
+
+      - `/workspace/ralph` exists.
+      - `/workspace/recipe` exists.
+      - `/workspace/ralph/.venv` exists.
+      - Ralph has been installed into the venv with hub, chain, and data dependencies.
+      - FineWeb-Edu data preparation has run or found an existing manifest.
+      - JupyterLab is running on port 8888 with the Ralph venv registered as the `Ralph (.venv)` kernel.
+
+      Continue from upstream step 3 in JupyterLab:
+
+      1. Open a Jupyter terminal.
+      2. Upload or copy the registered Bittensor wallet into `/workspace/.bittensor/wallets/<BT_WALLET>`.
+      3. Create `/workspace/ralph/.env` with your `BT_*` and `HF_*` values.
+      4. Run the upstream registration check and `scripts/miner_run.py` from `/workspace/ralph`.
+
+      Quick terminal start:
+
+      ```bash
+      cd /workspace/ralph
+      source .venv/bin/activate
+      set -a && source .env && set +a
+      ```
+      MD
+
+      date -u +%Y-%m-%dT%H:%M:%SZ > /workspace/status/ready
+      log "workspace-ready /workspace/PHALA_RALPH_READY.md"
+      tail -f /dev/null
+
+volumes:
+  ralph-work:
+  bittensor-wallets:
+  tsm-report:


### PR DESCRIPTION
## Summary
- Add a `ralph-miner` prebuilt template and register it in `templates/config.json`.
- Bootstrap only the upstream Ralph H100 guide through Step 2: Ralph/recipe clones, venv, dependencies, JupyterLab, TSM report path, and FineWeb-Edu data preparation.
- Make the miner flow Jupyter-first: no SSH service, no SSH public-key input, and no `nvidia/cuda:*ubuntu*` base image.
- Keep miner-owned secrets out of the template form; the only required template input is `JUPYTER_TOKEN` for port `8888` JupyterLab access.

## Validation
- `python templates/validate.py`
- Ralph config env check: only `JUPYTER_TOKEN`
- YAML parse, Jupyter-only compose shape check, inline config `$` escaping check, and extracted bootstrap `bash -n`
- SSH/Ubuntu residue scan for the Ralph template
- `git diff --check`

`docker compose config` was not run locally because Docker CLI is not installed on this workstation.