### PR TITLE
fix(cli): reject api method before endpoint

### DIFF
--- a/cli/src/commands/api/command.ts
+++ b/cli/src/commands/api/command.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { commonAuthOptions } from "@/src/core/common-flags";
 import type { CommandMeta } from "@/src/core/types";
 
-const HTTP_METHODS = [
+export const HTTP_METHODS = [
 	"GET",
 	"POST",
 	"PUT",

--- a/cli/src/commands/api/index.ts
+++ b/cli/src/commands/api/index.ts
@@ -6,7 +6,7 @@ import { defineCommand } from "@/src/core/define-command";
 import type { CommandContext } from "@/src/core/types";
 import { resolveAuthForContext } from "@/src/lib/client";
 import { applyJqFilter, formatJqOutput } from "./jq-filter";
-import { apiCommandMeta, apiCommandSchema } from "./command";
+import { apiCommandMeta, apiCommandSchema, HTTP_METHODS } from "./command";
 import type { ApiCommandInput } from "./command";
 
 // Get CLI version for User-Agent
@@ -227,6 +227,32 @@ type ResolvedRequest = {
 	body: Record<string, unknown> | string | undefined;
 };
 
+const HTTP_METHOD_SET = new Set<string>(HTTP_METHODS);
+
+function isHttpMethodToken(value: string): boolean {
+	return HTTP_METHOD_SET.has(value.toUpperCase());
+}
+
+export function getApiMethodPositionUsageError(
+	positionals: readonly string[],
+	executableName = "phala",
+): string | undefined {
+	const [first, second] = positionals;
+	if (!first || !second || !isHttpMethodToken(first)) {
+		return undefined;
+	}
+
+	const method = first.toUpperCase();
+	const endpoint = second.startsWith("/") ? second : `/${second}`;
+	return [
+		`Error: Invalid API command usage. "${first}" looks like an HTTP method, but methods must be passed with -X/--method.`,
+		"",
+		"Correct examples:",
+		`  ${executableName} api ${endpoint}`,
+		`  ${executableName} api ${endpoint} -X ${method}`,
+	].join("\n");
+}
+
 /**
  * Resolve the final HTTP method, endpoint, and body for an API request.
  *
@@ -258,6 +284,15 @@ export async function runApiCommand(
 	input: ApiCommandInput,
 	context: CommandContext,
 ): Promise<number | undefined> {
+	const usageError = getApiMethodPositionUsageError(
+		context.rawPositionals,
+		context.cli?.executableName,
+	);
+	if (usageError) {
+		context.stderr.write(`${usageError}\n`);
+		return 1;
+	}
+
 	const auth = resolveAuthForContext(context, { apiToken: input.apiToken });
 
 	if (!auth.apiKey) {

--- a/cli/test/commands/api-request-body.test.ts
+++ b/cli/test/commands/api-request-body.test.ts
@@ -4,9 +4,12 @@ import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
 	buildApiRequestBody,
+	getApiMethodPositionUsageError,
 	resolveRequest,
+	runApiCommand,
 } from "../../src/commands/api/index";
 import type { ApiCommandInput } from "../../src/commands/api/command";
+import type { CommandContext } from "../../src/core/types";
 
 function baseInput(overrides: Partial<ApiCommandInput> = {}): ApiCommandInput {
 	return {
@@ -17,6 +20,82 @@ function baseInput(overrides: Partial<ApiCommandInput> = {}): ApiCommandInput {
 		...overrides,
 	};
 }
+
+function makeApiCommandContext(rawPositionals: string[]): {
+	context: CommandContext;
+	readStderr: () => string;
+} {
+	let stderr = "";
+	const writeStderr = (chunk: string): boolean => {
+		stderr += chunk;
+		return true;
+	};
+
+	return {
+		context: {
+			argv: rawPositionals,
+			rawFlags: {},
+			rawPositionals,
+			cwd: process.cwd(),
+			env: {},
+			stdout: { write: () => true } as unknown as NodeJS.WriteStream,
+			stderr: { write: writeStderr } as unknown as NodeJS.WriteStream,
+			stdin: {} as unknown as NodeJS.ReadStream,
+			projectConfig: {},
+			cli: {
+				executableName: "phala",
+				packageName: "phala",
+				packageVersion: "0.0.0-test",
+				runtime: "bun",
+			},
+			success: () => {},
+			fail: () => {},
+		},
+		readStderr: () => stderr,
+	};
+}
+
+describe("getApiMethodPositionUsageError", () => {
+	test("rejects method-before-endpoint usage", () => {
+		const error = getApiMethodPositionUsageError(["get", "/cvms"], "phala");
+
+		expect(error).toContain("methods must be passed with -X/--method");
+		expect(error).toContain("phala api /cvms");
+		expect(error).toContain("phala api /cvms -X GET");
+	});
+
+	test("rejects method-before-endpoint usage case-insensitively", () => {
+		const error = getApiMethodPositionUsageError(["Post", "endpoint"], "phala");
+
+		expect(error).toContain('"Post" looks like an HTTP method');
+		expect(error).toContain("phala api /endpoint -X POST");
+	});
+
+	test("allows a single endpoint that matches a method name", () => {
+		const error = getApiMethodPositionUsageError(["get"], "phala");
+
+		expect(error).toBeUndefined();
+	});
+
+	test("allows normal endpoint usage", () => {
+		const error = getApiMethodPositionUsageError(["/cvms"], "phala");
+
+		expect(error).toBeUndefined();
+	});
+});
+
+describe("runApiCommand", () => {
+	test("rejects method-before-endpoint usage before authentication", async () => {
+		const { context, readStderr } = makeApiCommandContext(["get", "/cvms"]);
+
+		const code = await runApiCommand(baseInput({ endpoint: "get" }), context);
+
+		expect(code).toBe(1);
+		expect(readStderr()).toContain("methods must be passed with -X/--method");
+		expect(readStderr()).toContain("phala api /cvms -X GET");
+		expect(readStderr()).not.toContain("Not authenticated");
+	});
+});
 
 describe("buildApiRequestBody - -d/--data", () => {
 	test("parses JSON body from -d", () => {


### PR DESCRIPTION
## Summary
- Detect `phala api get /path`-style usage before authentication or API requests.
- Return a usage error with correct `phala api /path` and `phala api /path -X METHOD` examples.
- Add regression coverage for case-insensitive method tokens and handler behavior.

## Test Results
- `cd sdks/js && bun run build`
- `cd sdks/cli && bun run build`
- `cd sdks/cli && bun run type-check`
- `cd sdks/cli && bun run lint`
- `cd sdks/cli && bun test` (426 pass, 12 skip)
- `cd sdks && pre-commit run --files cli/src/commands/api/command.ts cli/src/commands/api/index.ts cli/test/commands/api-request-body.test.ts`

## Test Coverage
- New API method-position validation has unit and handler coverage.

## Review Findings
- No issues found.