### PR TITLE
feat(js): declare billing_status and suspended_at on the workspace schema

### DIFF
--- a/js/src/actions/cvms/provision_cvm_compose_file_update.test.ts
+++ b/js/src/actions/cvms/provision_cvm_compose_file_update.test.ts
@@ -58,7 +58,7 @@ describe("provisionCvmComposeFileUpdate", () => {
         ...mockAppCompose,
         update_env_vars: undefined
       });
-      expect(result).toEqual(mockProvisionResponse);
+      expect(result).toEqual({ ...mockProvisionResponse, compose_unchanged: false });
     });
 
     it("should include update_env_vars=true in request body when specified", async () => {
@@ -160,7 +160,7 @@ describe("provisionCvmComposeFileUpdate", () => {
 
       const result = await provisionCvmComposeFileUpdate(mockClient, mockProvisionRequest);
 
-      expect(result).toEqual(responseWithExtraFields);
+      expect(result).toEqual({ ...responseWithExtraFields, compose_unchanged: false });
     });
   });
 
@@ -172,7 +172,7 @@ describe("provisionCvmComposeFileUpdate", () => {
 
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data).toEqual(mockProvisionResponse);
+        expect(result.data).toEqual({ ...mockProvisionResponse, compose_unchanged: false });
       }
     });
 

--- a/js/src/actions/workspaces/list_workspaces.test.ts
+++ b/js/src/actions/workspaces/list_workspaces.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { WorkspaceResponseSchema } from "./list_workspaces";
+
+const base = {
+  id: "wks_abc",
+  name: "Acme",
+  slug: "acme",
+  tier: "level_1",
+  role: "owner",
+  is_default: true,
+  created_at: "2026-07-15T00:00:00Z",
+};
+
+describe("WorkspaceResponseSchema", () => {
+  it("keeps the billing lifecycle state", () => {
+    const parsed = WorkspaceResponseSchema.parse({
+      ...base,
+      billing_status: "abandoned",
+      suspended_at: null,
+    });
+
+    expect(parsed.billing_status).toBe("abandoned");
+    expect(parsed.suspended_at).toBeNull();
+  });
+
+  it("defaults billing_status to active, matching the API", () => {
+    // The field has a server-side default, so a response may omit it. Parsing to
+    // undefined would push that check onto every caller.
+    expect(WorkspaceResponseSchema.parse(base).billing_status).toBe("active");
+  });
+
+  it("carries suspended_at when the workspace is suspended", () => {
+    const parsed = WorkspaceResponseSchema.parse({
+      ...base,
+      billing_status: "suspended",
+      suspended_at: "2026-06-15T00:00:00Z",
+    });
+
+    expect(parsed.suspended_at).toBe("2026-06-15T00:00:00Z");
+  });
+
+  it("rejects a lifecycle state the API cannot produce", () => {
+    expect(() => WorkspaceResponseSchema.parse({ ...base, billing_status: "deleted" })).toThrow();
+  });
+});

--- a/js/src/actions/workspaces/list_workspaces.ts
+++ b/js/src/actions/workspaces/list_workspaces.ts
@@ -75,6 +75,13 @@ export const WorkspaceResponseSchema = z
     is_default: z.boolean(),
     created_at: z.string(),
     confidential_models_enabled: z.boolean().optional(),
+    /**
+     * Billing lifecycle state. A suspended workspace still runs but owes money;
+     * an abandoned one is closed and read-only until its balance is settled.
+     */
+    billing_status: z.enum(["active", "suspended", "abandoned"]).default("active"),
+    /** When the workspace was suspended. Null unless billing_status is suspended. */
+    suspended_at: z.string().nullable().optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Why

The API returns `billing_status` and `suspended_at` on every workspace response and always has. The schema never declared either, so `.passthrough()` delivered them as `unknown` and consumers cast their way in:

```ts
(workspaceData as Record<string, unknown>).suspended_at as string | null | undefined
```

That is a cast standing in for a schema. `billing_status` is about to matter: a closed (`abandoned`) workspace is read-only and needs to render as such, which is impossible without the field being typed.

## What

- `billing_status: z.enum(["active", "suspended", "abandoned"]).default("active")` — mirrors the server-side default, so callers get a state instead of a `| undefined` each has to interpret. The enum is closed deliberately: a fourth value should fail at the boundary, not flow into a comparison that quietly answers `false`.
- `suspended_at: z.string().nullable().optional()`
- Shared by `listWorkspaces` and `getWorkspace` — both parse `WorkspaceResponseSchema`.

## Also: the suite was red before this PR

`bun run test` has been failing on `main` since 33699d8 (#468, merged 2026-06-19), which added `compose_unchanged: z.boolean().optional().default(false)` to the provision response schema without updating `provision_cvm_compose_file_update.test.ts`. Three assertions compare the SDK's parsed output against the raw mocked payload, and the default makes them differ by exactly that field. `js/**` changes trigger these checks, so this PR could not be green without it.

Fixed on the assertion side rather than by adding the field to the mock: the mock is what the server sends, the server may legitimately omit the field, and writing it into the mock would retire the only coverage the default has. Separate commit (`ced4741`).

Full suite is green now — 767 passing.

## Scope

JS only. The Go SDK's `Workspace` struct models a smaller, different subset (no `role`, `is_default`, `created_at` or `confidential_models_enabled`; its list response is an untyped `GenericObject`), so adding `billing_status` there alone would be arbitrary. Python has no workspace types.

## Consumer

Phala Cloud's read-only-abandoned-workspace work depends on this. That PR bumps the submodule pointer once this lands.