### PR TITLE
feat(cli): support immediate force stop during deploy

### DIFF
--- a/cli/src/commands/deploy/command.ts
+++ b/cli/src/commands/deploy/command.ts
@@ -207,6 +207,14 @@ export const deployCommandMeta: CommandMeta = {
 			group: "basic",
 		},
 		{
+			name: "force-stop",
+			description:
+				"Force stop an existing CVM if graceful shutdown exceeds 5 minutes",
+			type: "boolean",
+			target: "forceStop",
+			group: "advanced",
+		},
+		{
 			name: "ssh-pubkey",
 			description: "SSH public key path (default: ~/.ssh/id_rsa.pub)",
 			type: "string",
@@ -391,6 +399,7 @@ export const deployCommandSchema = z.object({
 	privateKey: z.string().optional(),
 	rpcUrl: z.string().optional(),
 	wait: z.boolean().default(false),
+	forceStop: z.boolean().default(false),
 	sshPubkey: z.string().optional(),
 	devOs: z.boolean().optional(),
 	publicLogs: z.boolean().optional(),

--- a/cli/src/commands/deploy/command.ts
+++ b/cli/src/commands/deploy/command.ts
@@ -209,7 +209,7 @@ export const deployCommandMeta: CommandMeta = {
 		{
 			name: "force-stop",
 			description:
-				"Force stop an existing CVM if graceful shutdown exceeds 5 minutes",
+				"Force stop an existing CVM instead of requesting graceful shutdown",
 			type: "boolean",
 			target: "forceStop",
 			group: "advanced",

--- a/cli/src/commands/deploy/handler.test.ts
+++ b/cli/src/commands/deploy/handler.test.ts
@@ -6,7 +6,29 @@
  */
 
 import { describe, test, expect } from "bun:test";
-import { buildProvisionPayload } from "./handler";
+import { deployCommandSchema } from "./command";
+import { applyForceStopOption, buildProvisionPayload } from "./handler";
+
+describe("deploy --force-stop", () => {
+	test("parses the optional update flag", () => {
+		const input = deployCommandSchema.parse({ forceStop: true });
+		expect(input.forceStop).toBe(true);
+	});
+
+	test("opts an update into force stop after five minutes", () => {
+		const patchBody: Record<string, unknown> = {};
+		applyForceStopOption(patchBody, true);
+		expect(patchBody.allow_force_stop).toBe(true);
+		expect(patchBody.shutdown_timeout).toBe(300);
+	});
+
+	test("keeps the default update behavior unchanged", () => {
+		const patchBody: Record<string, unknown> = {};
+		applyForceStopOption(patchBody, false);
+		expect(patchBody.allow_force_stop).toBeUndefined();
+		expect(patchBody.shutdown_timeout).toBeUndefined();
+	});
+});
 
 describe("buildProvisionPayload", () => {
 	const defaultName = "test-cvm";

--- a/cli/src/commands/deploy/handler.test.ts
+++ b/cli/src/commands/deploy/handler.test.ts
@@ -15,11 +15,11 @@ describe("deploy --force-stop", () => {
 		expect(input.forceStop).toBe(true);
 	});
 
-	test("opts an update into force stop after five minutes", () => {
+	test("forces an update to stop without graceful shutdown", () => {
 		const patchBody: Record<string, unknown> = {};
 		applyForceStopOption(patchBody, true);
 		expect(patchBody.allow_force_stop).toBe(true);
-		expect(patchBody.shutdown_timeout).toBe(300);
+		expect(patchBody.shutdown_timeout).toBeUndefined();
 	});
 
 	test("keeps the default update behavior unchanged", () => {

--- a/cli/src/commands/deploy/handler.ts
+++ b/cli/src/commands/deploy/handler.ts
@@ -88,6 +88,7 @@ interface Options {
 	debug?: boolean;
 	apiToken?: string;
 	wait?: boolean;
+	forceStop?: boolean;
 	sshPubkey?: string;
 	devOs?: boolean;
 	publicLogs?: boolean;
@@ -102,6 +103,15 @@ interface Options {
 	composeHash?: string;
 	transactionHash?: string;
 	[key: string]: unknown;
+}
+
+export function applyForceStopOption(
+	patchBody: Record<string, unknown>,
+	forceStop: boolean | undefined,
+): void {
+	if (!forceStop) return;
+	patchBody.allow_force_stop = true;
+	patchBody.shutdown_timeout = 300;
 }
 
 /**
@@ -1043,6 +1053,7 @@ const updateCvm = async (
 	if (validatedOptions.publicSysinfo !== undefined) {
 		patchBody.public_sysinfo = validatedOptions.publicSysinfo;
 	}
+	applyForceStopOption(patchBody, validatedOptions.forceStop);
 
 	// Add prepareOnly flag if set
 	if (validatedOptions.prepareOnly) {

--- a/cli/src/commands/deploy/handler.ts
+++ b/cli/src/commands/deploy/handler.ts
@@ -111,7 +111,6 @@ export function applyForceStopOption(
 ): void {
 	if (!forceStop) return;
 	patchBody.allow_force_stop = true;
-	patchBody.shutdown_timeout = 300;
 }
 
 /**

--- a/js/src/actions/cvms/get_cvm_status_batch.ts
+++ b/js/src/actions/cvms/get_cvm_status_batch.ts
@@ -15,7 +15,9 @@ export const CvmStatusSchema = z.object({
   in_progress: z.boolean(),
   boot_progress: z.string().nullable().optional(),
   boot_error: z.string().nullable().optional(),
+  shutdown_progress: z.string().nullable().optional(),
   operation_type: z.string().nullable().optional(),
+  operation_phase: z.string().nullable().optional(),
   operation_started_at: z.string().nullable().optional(),
   correlation_id: z.string().nullable().optional(),
 });

--- a/js/src/actions/cvms/get_cvm_status_batch.ts
+++ b/js/src/actions/cvms/get_cvm_status_batch.ts
@@ -16,10 +16,15 @@ export const CvmStatusSchema = z.object({
   boot_progress: z.string().nullable().optional(),
   boot_error: z.string().nullable().optional(),
   shutdown_progress: z.string().nullable().optional(),
-  operation_type: z.string().nullable().optional(),
-  operation_phase: z.string().nullable().optional(),
-  operation_started_at: z.string().nullable().optional(),
-  correlation_id: z.string().nullable().optional(),
+  operation: z
+    .object({
+      type: z.string().nullable().optional(),
+      phase: z.string().nullable().optional(),
+      started_at: z.string().nullable().optional(),
+      correlation_id: z.string().nullable().optional(),
+    })
+    .nullable()
+    .optional(),
 });
 
 export type CvmStatus = z.infer<typeof CvmStatusSchema>;


### PR DESCRIPTION
## Summary
- add `deploy --force-stop` for updates to existing CVMs
- send `allow_force_stop=true` without adding a graceful-shutdown timeout, so an explicit force request immediately uses the hard-stop path
- expose shutdown progress and model operation tracking as one nested `operation` object in batch CVM status results

## Behavior
Without `--force-stop`, deploy leaves shutdown policy selection to the backend. With the flag, deploy explicitly skips graceful shutdown.

## Test Coverage
- flag parsing and request construction
- unchanged default deploy behavior
- nested CVM operation status schema

## Test Results
- `pre-commit run --all-files`
- JS SDK: 774 passed
- CLI: 429 passed, 12 skipped
- JS SDK and CLI format, lint, type-check, and build commands passed

## Test Failure Investigation
The earlier three JS failures came from the stale submodule revision: `compose_unchanged` had gained a Zod default, but the provision response fixture still omitted it. SDK `main` fixed the fixture in `ced4741`; this branch includes that fix and the full JS suite passes.
