### PR TITLE
feat: add Chatwoot prebuilt template

### DIFF
--- a/templates/config.json
+++ b/templates/config.json
@@ -6127,5 +6127,74 @@
       "diskSize": 10
     },
     "tags": ["AI Agents", "Developer Tools", "Automation"]
+  },
+  {
+    "id": "chatwoot",
+    "name": "chatwoot/chatwoot",
+    "description": "Open-source customer support platform for live chat, shared inboxes, contacts, automation, and multi-channel conversations. This template deploys the official Chatwoot v4.16.0 Rails and Sidekiq images with locked PostgreSQL/pgvector and Redis versions.",
+    "repo": "https://github.com/Phala-Network/phala-cloud/tree/main/templates/prebuilt/chatwoot",
+    "author": "chatwoot",
+    "icon": "chatwoot.svg",
+    "envs": [
+      {
+        "key": "SECRET_KEY_BASE",
+        "required": true,
+        "description": "Stable Rails encryption and signing secret. Generate with openssl rand -hex 64."
+      },
+      {
+        "key": "POSTGRES_PASSWORD",
+        "required": true,
+        "description": "Stable PostgreSQL password for the Chatwoot database. Generate with openssl rand -hex 32."
+      },
+      {
+        "key": "REDIS_PASSWORD",
+        "required": true,
+        "description": "Stable Redis password used by Rails and Sidekiq. Generate with openssl rand -hex 32."
+      },
+      {
+        "key": "FRONTEND_URL",
+        "required": false,
+        "description": "Optional public Chatwoot URL. The template derives the Phala app domain by default."
+      },
+      {
+        "key": "ENABLE_ACCOUNT_SIGNUP",
+        "required": false,
+        "default": "true",
+        "description": "Allows first-account registration. Set to false after bootstrap when public registration should close."
+      },
+      {
+        "key": "MAILER_SENDER_EMAIL",
+        "required": false,
+        "default": "Chatwoot <accounts@chatwoot.example>",
+        "description": "Sender address used for account and notification email."
+      },
+      {
+        "key": "SMTP_ADDRESS",
+        "required": false,
+        "description": "Optional SMTP server hostname for outbound email."
+      },
+      {
+        "key": "SMTP_PORT",
+        "required": false,
+        "default": "587",
+        "description": "SMTP server port."
+      },
+      {
+        "key": "SMTP_USERNAME",
+        "required": false,
+        "description": "Optional SMTP username."
+      },
+      {
+        "key": "SMTP_PASSWORD",
+        "required": false,
+        "description": "Optional SMTP password."
+      }
+    ],
+    "defaultResource": {
+      "vCPU": 4,
+      "memory": 8192,
+      "diskSize": 40
+    },
+    "tags": ["Web Apps", "Automation", "Data & Storage"]
   }
 ]

--- a/templates/icons/chatwoot.svg
+++ b/templates/icons/chatwoot.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="512px" height="512px" viewBox="0 0 512 512" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 59.1 (86144) - https://sketch.com -->
+    <title>woot-log</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Logo" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="woot-log" fill-rule="nonzero">
+            <circle id="Oval" fill="#47A7F6" cx="256" cy="256" r="256"></circle>
+            <path d="M362.807947,368.807947 L244.122956,368.807947 C178.699407,368.807947 125.456954,315.561812 125.456954,250.12177 C125.456954,184.703089 178.699407,131.456954 244.124143,131.456954 C309.565494,131.456954 362.807947,184.703089 362.807947,250.12177 L362.807947,368.807947 Z" id="Fill-1" stroke="#FFFFFF" stroke-width="6" fill="#FFFFFF"></path>
+        </g>
+    </g>
+</svg>

--- a/templates/prebuilt/chatwoot/README.md
+++ b/templates/prebuilt/chatwoot/README.md
@@ -1,0 +1,100 @@
+# chatwoot/chatwoot on Phala Cloud
+
+## Deploy, check, customize
+
+1. Generate three stable secrets:
+   - `SECRET_KEY_BASE`: `openssl rand -hex 64`
+   - `POSTGRES_PASSWORD`: `openssl rand -hex 32`
+   - `REDIS_PASSWORD`: `openssl rand -hex 32`
+2. Deploy this template with the default 4 vCPU, 8 GB memory, and 40 GB disk.
+3. Wait for the database migration and Rails startup, then open `https://<your-app-domain>/app/auth/signup` to create the first account.
+4. After the first account exists, set `ENABLE_ACCOUNT_SIGNUP=false` and redeploy if public registration should close.
+5. Add SMTP settings before inviting teammates or enabling email inboxes.
+
+## What runs
+
+This template deploys the official Chatwoot self-hosted stack with versions locked for reproducibility:
+
+- `proxy`: Caddy `2.10.2` public HTTPS-gateway adapter on port `80`.
+- `rails`: Chatwoot web application and API, `chatwoot/chatwoot:v4.16.0` on the internal port `3000`.
+- `sidekiq`: background jobs using the same Chatwoot image.
+- `migrate`: one-shot `bundle exec rails db:chatwoot_prepare` database preparation.
+- `postgres`: PostgreSQL 16 with pgvector, `pgvector/pgvector:0.8.1-pg16`.
+- `redis`: Redis persistence and job queue, `redis:8.2.5-alpine`.
+
+The Caddy service publishes port `80` and forwards the Phala gateway's HTTPS scheme to Rails. Rails, PostgreSQL, and Redis stay internal to the Compose network. Named volumes preserve uploads, PostgreSQL data, and Redis data.
+
+## Required environment variables
+
+| Variable | Generator | Purpose |
+| --- | --- | --- |
+| `SECRET_KEY_BASE` | `openssl rand -hex 64` | Rails encryption and signing secret. Keep it stable across redeploys. |
+| `POSTGRES_PASSWORD` | `openssl rand -hex 32` | Chatwoot PostgreSQL password. |
+| `REDIS_PASSWORD` | `openssl rand -hex 32` | Chatwoot Redis password. |
+
+Optional settings:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `FRONTEND_URL` | Phala app domain | Public Chatwoot URL used in links and callbacks. Set explicitly for a custom domain. |
+| `ENABLE_ACCOUNT_SIGNUP` | `true` | Allows first-account creation. Set to `false` after bootstrap when public signup is unwanted. |
+| `FORCE_SSL` | `false` | Caddy supplies the public HTTPS forwarding headers to Rails. |
+| `LOG_LEVEL` | `info` | Rails log verbosity. |
+| `MAILER_SENDER_EMAIL` | `Chatwoot <accounts@chatwoot.example>` | Sender used for account and notification email. |
+| `SMTP_ADDRESS` | empty | SMTP server hostname. |
+| `SMTP_PORT` | `587` | SMTP server port. |
+| `SMTP_USERNAME` | empty | SMTP username. |
+| `SMTP_PASSWORD` | empty | SMTP password. |
+| `SMTP_AUTHENTICATION` | `plain` | SMTP authentication method. |
+| `SMTP_ENABLE_STARTTLS_AUTO` | `true` | Enables STARTTLS when supported. |
+
+## Persistent data
+
+- `chatwoot_storage`: local attachment and Active Storage files.
+- `postgres_data`: accounts, contacts, conversations, settings, and application records.
+- `redis_data`: persistent Redis data for Sidekiq and caching.
+
+Back up `chatwoot_storage` and `postgres_data` before upgrades. Keep the three required secrets in a secure secret manager.
+
+## Verify / smoke test
+
+Verify the public service after the migration has completed:
+
+```bash
+curl -fsSI https://<your-app-domain>/app/login
+curl -fsS https://<your-app-domain>/api
+```
+
+The login request should return a successful HTTP response. The API root should return Chatwoot API metadata. In Phala Cloud, verify that `rails`, `sidekiq`, `postgres`, and `redis` are running and that the one-shot `migrate` service exited successfully.
+
+For local Compose validation:
+
+```bash
+SECRET_KEY_BASE=validation-secret \
+POSTGRES_PASSWORD=validation-postgres-password \
+REDIS_PASSWORD=validation-redis-password \
+docker compose -f templates/prebuilt/chatwoot/docker-compose.yml config
+```
+
+## Version upgrades
+
+All runtime images use immutable version tags at the template level. Upgrade by changing the Chatwoot image tag for `rails`, `sidekiq`, and `migrate` together, reviewing the upstream release notes, backing up persistent data, and redeploying. The `migrate` service applies the matching database preparation task during startup.
+
+This template starts at Chatwoot `v4.16.0`, released on July 18, 2026. PostgreSQL and Redis versions are also locked to prevent automatic major or minor image movement.
+
+## Upstream sources
+
+- Repository: [chatwoot/chatwoot](https://github.com/chatwoot/chatwoot)
+- Locked release: [v4.16.0](https://github.com/chatwoot/chatwoot/releases/tag/v4.16.0)
+- Official production Compose: [`docker-compose.production.yaml`](https://github.com/chatwoot/chatwoot/blob/v4.16.0/docker-compose.production.yaml)
+- Official environment reference: [`.env.example`](https://github.com/chatwoot/chatwoot/blob/v4.16.0/.env.example)
+- Official Rails entrypoint: [`docker/entrypoints/rails.sh`](https://github.com/chatwoot/chatwoot/blob/v4.16.0/docker/entrypoints/rails.sh)
+- Template icon: upstream [`app/javascript/design-system/images/logo-thumbnail.svg`](https://github.com/chatwoot/chatwoot/blob/v4.16.0/app/javascript/design-system/images/logo-thumbnail.svg)
+
+## Security and production notes
+
+- The template references secrets through environment variables and contains no embedded credentials.
+- SMTP and external channel credentials are added by the deployer after first boot.
+- Local Active Storage is appropriate for a single Compose deployment. Configure an object-storage service for multi-instance production.
+- Keep Rails, PostgreSQL, and Redis private. This template publishes only Caddy's web port.
+- Size resources according to traffic and worker load. The default allocation prioritizes a reliable first deployment over minimum memory usage.

--- a/templates/prebuilt/chatwoot/docker-compose.yml
+++ b/templates/prebuilt/chatwoot/docker-compose.yml
@@ -1,0 +1,159 @@
+services:
+  proxy:
+    image: caddy:2.10.2-alpine
+    restart: unless-stopped
+    depends_on:
+      rails:
+        condition: service_healthy
+    ports:
+      - "80:80"
+    configs:
+      - source: caddy_config
+        target: /etc/caddy/Caddyfile
+
+  rails:
+    image: chatwoot/chatwoot:v4.16.0
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+    environment: &chatwoot_environment
+      NODE_ENV: production
+      RAILS_ENV: production
+      INSTALLATION_ENV: docker
+      FRONTEND_URL: ${FRONTEND_URL:-https://${DSTACK_APP_DOMAIN:-localhost}}
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      ENABLE_ACCOUNT_SIGNUP: ${ENABLE_ACCOUNT_SIGNUP:-true}
+      FORCE_SSL: ${FORCE_SSL:-false}
+      ACTIVE_STORAGE_SERVICE: local
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: "5432"
+      POSTGRES_DATABASE: chatwoot
+      POSTGRES_USERNAME: chatwoot
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+      RAILS_LOG_TO_STDOUT: "true"
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      MAILER_SENDER_EMAIL: ${MAILER_SENDER_EMAIL:-Chatwoot <accounts@chatwoot.example>}
+      SMTP_ADDRESS: ${SMTP_ADDRESS:-}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USERNAME: ${SMTP_USERNAME:-}
+      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      SMTP_AUTHENTICATION: ${SMTP_AUTHENTICATION:-plain}
+      SMTP_ENABLE_STARTTLS_AUTO: ${SMTP_ENABLE_STARTTLS_AUTO:-true}
+    entrypoint: docker/entrypoints/rails.sh
+    command:
+      - bundle
+      - exec
+      - rails
+      - server
+      - -p
+      - "3000"
+      - -b
+      - 0.0.0.0
+    volumes:
+      - chatwoot_storage:/app/storage
+    healthcheck:
+      test:
+        - CMD
+        - ruby
+        - -rnet/http
+        - -e
+        - "exit(Net::HTTP.get_response(URI('http://127.0.0.1:3000/api')).is_a?(Net::HTTPSuccess) ? 0 : 1)"
+      interval: 30s
+      timeout: 10s
+      retries: 10
+      start_period: 180s
+
+  sidekiq:
+    image: chatwoot/chatwoot:v4.16.0
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment: *chatwoot_environment
+    command:
+      - bundle
+      - exec
+      - sidekiq
+      - -C
+      - config/sidekiq.yml
+    volumes:
+      - chatwoot_storage:/app/storage
+
+  migrate:
+    image: chatwoot/chatwoot:v4.16.0
+    restart: "no"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment: *chatwoot_environment
+    command:
+      - bundle
+      - exec
+      - rails
+      - db:chatwoot_prepare
+
+  postgres:
+    image: pgvector/pgvector:0.8.1-pg16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: chatwoot
+      POSTGRES_USER: chatwoot
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - pg_isready -U chatwoot -d chatwoot
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  redis:
+    image: redis:8.2.5-alpine
+    restart: unless-stopped
+    command:
+      - redis-server
+      - --appendonly
+      - "yes"
+      - --requirepass
+      - ${REDIS_PASSWORD}
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - redis-cli -a "$$REDIS_PASSWORD" ping | grep PONG
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+
+volumes:
+  chatwoot_storage:
+  postgres_data:
+  redis_data:
+
+configs:
+  caddy_config:
+    content: |
+      :80 {
+        reverse_proxy rails:3000 {
+          header_up X-Forwarded-Proto https
+          header_up X-Forwarded-Port 443
+        }
+        encode gzip zstd
+      }


### PR DESCRIPTION
## Summary

- add a beginner-oriented Chatwoot prebuilt template using the official self-hosted stack
- lock Chatwoot to `v4.16.0`, pgvector/PostgreSQL to `0.8.1-pg16`, Redis to `8.2.5-alpine`, and Caddy to `2.10.2-alpine`
- add one-shot database preparation, persistent volumes, health checks, SMTP options, and an upstream-derived icon
- adapt forwarded HTTPS headers through Caddy for the Phala gateway

## Verification

- `python3 templates/validate.py`
- `docker compose -f templates/prebuilt/chatwoot/docker-compose.yml config`
- `git diff --check`
- real Phala Cloud deployment on prod7 (`tdx.medium`)
- Chatwoot API returned version `4.16.0` with queue and data services `ok`
- onboarding page returned HTTP 200
- Rails, PostgreSQL, and Redis reported healthy; Sidekiq and Caddy were running; migration exited 0

## Test deployment

Dashboard: https://cloud.phala.com/dashboard/cvms/cdfccd72-8deb-4567-b28d-7d267b816129

The test CVM is intentionally left running for maintainer testing.
