### PR TITLE
fix(cli): include error code in deploy provision error output

### DIFF
--- a/cli/src/commands/deploy/handler.ts
+++ b/cli/src/commands/deploy/handler.ts
@@ -20,6 +20,7 @@ import {
 	type ErrorLink,
 	CvmIdSchema,
 	MAX_COMPOSE_PAYLOAD_BYTES,
+	RequestError,
 	ResourceError,
 	createClient,
 	encryptEnvVars,
@@ -133,6 +134,68 @@ function handleProvisionError(
 			};
 		}
 		return formatStructuredError(error);
+	}
+
+	// RequestError from the SDK: .detail is extracted from the response body
+	// (e.g. { error_code: "ERR-02-009", message: "...", ... })
+	if (
+		error instanceof RequestError &&
+		typeof error.detail === "object" &&
+		error.detail !== null &&
+		"error_code" in error.detail
+	) {
+		const { error_code, message, details, suggestions, links } =
+			error.detail as {
+				error_code: string;
+				message: string;
+				details?: Array<{
+					field?: string;
+					value?: unknown;
+					message?: string;
+				}>;
+				suggestions?: string[];
+				links?: Array<{ url: string; label: string }>;
+			};
+
+		if (options.json) {
+			return {
+				success: false,
+				error_code,
+				message,
+				details,
+				suggestions,
+				links,
+			};
+		}
+
+		let output = `\nError [${error_code}]: ${message}\n`;
+
+		if (details && details.length > 0) {
+			output += "\nDetails:\n";
+			for (const d of details) {
+				if (d.message) {
+					output += `  - ${d.message}\n`;
+				} else if (d.field && d.value !== undefined) {
+					output += `  - ${d.field}: ${d.value}\n`;
+				}
+			}
+		}
+
+		if (suggestions && suggestions.length > 0) {
+			output += "\nSuggestions:\n";
+			for (const s of suggestions) {
+				output += `  - ${s}\n`;
+			}
+		}
+
+		if (links && links.length > 0) {
+			output += "\nLearn more:\n";
+			for (const link of links) {
+				output += `  - ${link.label}: ${link.url}\n`;
+			}
+		}
+
+		return output;
 	}
 
 	// Parse structured error from plain object (backward compatibility)


### PR DESCRIPTION
## Summary

`handleProvisionError` in the deploy handler had three paths for formatting API errors, but `RequestError` from `safeProvisionCvm` would fall through to the generic fallback, losing the error code:

- **Path 1** (`instanceof ResourceError`) did not match — `defineAction` catches exceptions and returns the raw `RequestError`, not a parsed `ResourceError`.
- **Path 2** checked `error.response?.data?.detail`, but `RequestError.response` is a raw Fetch `Response` object with no `.data` property. The structured error detail lives at `error.detail` (extracted by `RequestError.fromFetchError`).

Add a new path between the two that handles `RequestError` with a structured `.detail` object containing `error_code`.

**Before:**
```
✗ Error in provisioning CVM: 
Error: The configuration parameters are not compatible with each other
```

**After:**
```
✗ Error in provisioning CVM: 
Error [ERR-02-009]: The configuration parameters are not compatible with each other

Suggestions:
  - Retry the deployment with a different KMS or node configuration
  - Contact support if the issue persists
```

## Test plan

- [ ] `bun run build && bun run test` — 429 pass, 0 fail
- [ ] `bun run fmt && bun run lint && bun run type-check` — all pass