### PR TITLE
refactor(cli): centralize API error presentation

### DIFF
--- a/cli/src/commands/allow-devices/index.ts
+++ b/cli/src/commands/allow-devices/index.ts
@@ -480,7 +480,9 @@ async function resolveAppContract(
 	} else {
 		const infoResult = await safeGetCvmInfo(client, { id: cvmIdentifier });
 		if (!infoResult.success) {
-			context.fail(infoResult.error.message);
+			context.failWithError(infoResult.error.cause ?? infoResult.error, {
+				operation: "Manage devices",
+			});
 			return null;
 		}
 
@@ -501,7 +503,9 @@ async function resolveAppContract(
 		appId: normalizeAllowlistAppId(appId),
 	});
 	if (!allowlistResult.success) {
-		context.fail(allowlistResult.error.message);
+		context.failWithError(allowlistResult.error.cause ?? allowlistResult.error, {
+			operation: "Manage devices",
+		});
 		return null;
 	}
 
@@ -634,9 +638,9 @@ async function runList(
 		return 0;
 	} catch (error) {
 		maybeLogRpcHint(error, activeChain, effectiveRpc, input.json);
-		context.fail(
-			`Failed: ${error instanceof Error ? error.message : String(error)}`,
-		);
+		context.failWithError(error, {
+			operation: "Manage devices",
+		});
 		return 1;
 	}
 }
@@ -673,7 +677,9 @@ async function runAdd(
 			const client = await getClient(context);
 			const nodesResult = await safeGetAvailableNodes(client);
 			if (!nodesResult.success) {
-				context.fail(nodesResult.error.message);
+				context.failWithError(nodesResult.error.cause ?? nodesResult.error, {
+					operation: "Manage devices",
+				});
 				return 1;
 			}
 
@@ -761,7 +767,9 @@ async function runAdd(
 					effectiveRpc,
 					input.json,
 				);
-				context.fail(`Failed to add ${deviceId}: ${err.error.message}`);
+				context.failWithError(err.error, {
+					operation: `Add device ${deviceId}`,
+				});
 				return 1;
 			}
 
@@ -821,9 +829,9 @@ async function runAdd(
 			return 0;
 		}
 		maybeLogRpcHint(error, activeChain, effectiveRpc, input.json);
-		context.fail(
-			`Failed: ${error instanceof Error ? error.message : String(error)}`,
-		);
+		context.failWithError(error, {
+			operation: "Manage devices",
+		});
 		return 1;
 	}
 }
@@ -935,7 +943,9 @@ async function runRemove(
 					effectiveRpc,
 					input.json,
 				);
-				context.fail(`Failed to remove ${deviceId}: ${err.error.message}`);
+				context.failWithError(err.error, {
+					operation: `Remove device ${deviceId}`,
+				});
 				return 1;
 			}
 
@@ -1012,9 +1022,9 @@ async function runRemove(
 			return 0;
 		}
 		maybeLogRpcHint(error, activeChain, effectiveRpc, input.json);
-		context.fail(
-			`Failed: ${error instanceof Error ? error.message : String(error)}`,
-		);
+		context.failWithError(error, {
+			operation: "Manage devices",
+		});
 		return 1;
 	}
 }
@@ -1055,9 +1065,9 @@ async function runAllowAny(
 		});
 	} catch (error) {
 		maybeLogRpcHint(error, activeChain, effectiveRpc, input.json);
-		context.fail(
-			`Failed: ${error instanceof Error ? error.message : String(error)}`,
-		);
+		context.failWithError(error, {
+			operation: "Manage devices",
+		});
 		return 1;
 	}
 }
@@ -1086,9 +1096,9 @@ async function runDisallowAny(
 		});
 	} catch (error) {
 		maybeLogRpcHint(error, activeChain, effectiveRpc, input.json);
-		context.fail(
-			`Failed: ${error instanceof Error ? error.message : String(error)}`,
-		);
+		context.failWithError(error, {
+			operation: "Manage devices",
+		});
 		return 1;
 	}
 }
@@ -1127,9 +1137,9 @@ async function runToggleAllowAny(
 		});
 	} catch (error) {
 		maybeLogRpcHint(error, activeChain, effectiveRpc, input.json);
-		context.fail(
-			`Failed: ${error instanceof Error ? error.message : String(error)}`,
-		);
+		context.failWithError(error, {
+			operation: "Manage devices",
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/apps/index.ts
+++ b/cli/src/commands/apps/index.ts
@@ -40,9 +40,10 @@ async function runAppsCommand(
 		});
 
 		if (result.success === false) {
-			const cause = result.error.cause;
-			logger.logDetailedError(cause ?? result.error);
-			context.fail(result.error.message);
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "List apps",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -70,12 +71,10 @@ async function runAppsCommand(
 		logger.info(`Page ${data.page}/${data.totalPages} (total ${data.total})`);
 		return 0;
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail(
-			`Failed to list apps: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		context.failWithError(error, {
+			operation: "List apps",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/auth/login/index.ts
+++ b/cli/src/commands/auth/login/index.ts
@@ -129,8 +129,10 @@ async function runLoginCommand(
 		logger.info(`Open in Web UI at ${CLOUD_URL}/dashboard/`);
 		return 0;
 	} catch (error) {
-		logger.error("Failed to set API key");
-		logger.logDetailedError(error);
+		context.failWithError(error, {
+			operation: "Login",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/cp/index.ts
+++ b/cli/src/commands/cp/index.ts
@@ -107,15 +107,21 @@ async function runCpCommand(
 					);
 				}
 			} catch (error) {
-				if (error instanceof NoGatewayError) {
-					logger.error(error.message);
-				} else if (error instanceof CvmNotRunningError) {
-					logger.error(error.message);
-					logger.info("Please start the CVM first using: phala cvms start");
+				if (error instanceof NoGatewayError || error instanceof CvmNotRunningError) {
+					context.failWithError(error, {
+						operation: "Copy file",
+						debug: Boolean((input as { debug?: boolean }).debug),
+						guidance: (
+							error instanceof CvmNotRunningError
+								? "Please start the CVM first using: phala cvms start"
+								: undefined
+						),
+					});
 				} else {
-					logger.error(
-						error instanceof Error ? error.message : "Failed to fetch CVM info",
-					);
+					context.failWithError(error, {
+						operation: "Copy file",
+						debug: Boolean((input as { debug?: boolean }).debug),
+					});
 				}
 				return 1;
 			}

--- a/cli/src/commands/cvms/attestation/index.ts
+++ b/cli/src/commands/cvms/attestation/index.ts
@@ -28,7 +28,10 @@ async function runCvmsAttestationCommand(
 		const infoResult = await safeGetCvmInfo(client, context.cvmId);
 
 		if (!infoResult.success) {
-			context.fail(infoResult.error.message);
+			context.failWithError(infoResult.error.cause ?? infoResult.error, {
+				operation: "Get attestation",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -148,12 +151,10 @@ async function runCvmsAttestationCommand(
 			throw error;
 		}
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail(
-			`Failed to get attestation information: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		context.failWithError(error, {
+			operation: "Get attestation",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/cvms/delete/index.ts
+++ b/cli/src/commands/cvms/delete/index.ts
@@ -29,7 +29,10 @@ async function runCvmsDeleteCommand(
 		const infoResult = await safeGetCvmInfo(client, context.cvmId);
 
 		if (!infoResult.success) {
-			context.fail(infoResult.error.message);
+			context.failWithError(infoResult.error.cause ?? infoResult.error, {
+				operation: "Delete CVM",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -71,9 +74,10 @@ async function runCvmsDeleteCommand(
 		spinner.stop(true);
 
 		if (!result.success) {
-			context.fail(
-				`Failed to delete CVM ${cvmIdentifier}: ${result.error.message}`,
-			);
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "Delete CVM",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -85,8 +89,10 @@ async function runCvmsDeleteCommand(
 		logger.success(`CVM ${cvmIdentifier} deleted successfully`);
 		return 0;
 	} catch (error) {
-		context.fail("Failed to delete CVM");
-		logger.logDetailedError(error);
+		context.failWithError(error, {
+			operation: "Delete CVM",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/cvms/device-allowlist/index.ts
+++ b/cli/src/commands/cvms/device-allowlist/index.ts
@@ -27,7 +27,10 @@ async function runCvmsDeviceAllowlistCommand(
 
 		const infoResult = await safeGetCvmInfo(client, context.cvmId);
 		if (!infoResult.success) {
-			context.fail(infoResult.error.message);
+			context.failWithError(infoResult.error.cause ?? infoResult.error, {
+				operation: "Manage device allowlist",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -45,7 +48,10 @@ async function runCvmsDeviceAllowlistCommand(
 
 		const result = await safeGetAppDeviceAllowlist(client, { appId });
 		if (!result.success) {
-			context.fail(result.error.message);
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "Manage device allowlist",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -86,12 +92,10 @@ async function runCvmsDeviceAllowlistCommand(
 
 		return 0;
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail(
-			`Failed to get device allowlist: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		context.failWithError(error, {
+			operation: "Manage device allowlist",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/cvms/get/index.ts
+++ b/cli/src/commands/cvms/get/index.ts
@@ -31,7 +31,10 @@ async function runCvmsGetCommand(
 		spinner.stop(true);
 
 		if (!result.success) {
-			context.fail(result.error.message);
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "Get CVM",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -75,12 +78,10 @@ async function runCvmsGetCommand(
 
 		return 0;
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail(
-			`Failed to get CVM details: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		context.failWithError(error, {
+			operation: "Get CVM",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/cvms/list-node/index.ts
+++ b/cli/src/commands/cvms/list-node/index.ts
@@ -11,7 +11,7 @@ import {
 } from "./command";
 
 async function runCvmsListNodesCommand(
-	_input: CvmsListNodesCommandInput,
+	input: CvmsListNodesCommandInput,
 	context: CommandContext,
 ): Promise<number> {
 	try {
@@ -107,8 +107,10 @@ async function runCvmsListNodesCommand(
 
 		return 0;
 	} catch (error) {
-		context.fail("Failed to list available nodes");
-		logger.logDetailedError(error);
+		context.failWithError(error, {
+			operation: "List CVM nodes",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/cvms/list/index.ts
+++ b/cli/src/commands/cvms/list/index.ts
@@ -53,11 +53,14 @@ async function runCvmsListCommand(
 
 		if (result.success === false) {
 			const cause = result.error.cause;
-			logger.logDetailedError(cause ?? result.error);
-			const message = isTimeoutCause(cause)
-				? formatTimeoutMessage(resolveTimeoutSeconds(context))
-				: result.error.message;
-			context.fail(message);
+			if (isTimeoutCause(cause)) {
+				context.fail(formatTimeoutMessage(resolveTimeoutSeconds(context)));
+				return 1;
+			}
+			context.failWithError(cause ?? result.error, {
+				operation: "List CVMs",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -85,12 +88,10 @@ async function runCvmsListCommand(
 		logger.info(`Page ${data.page}/${data.totalPages} (total ${data.total})`);
 		return 0;
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail(
-			`Failed to list CVMs: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		context.failWithError(error, {
+			operation: "List CVMs",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/cvms/logs-handler.ts
+++ b/cli/src/commands/cvms/logs-handler.ts
@@ -134,11 +134,10 @@ export function createLogsHandler<TInput extends BaseLogsInput, TOptions>(
 
 			return 0;
 		} catch (error) {
-			context.fail(
-				`Failed to fetch ${logTypeName} logs: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
-			);
+			context.failWithError(error, {
+				operation: `Fetch ${logTypeName} logs`,
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			await checkAndWarnIfLogsDisabled(appId, context);
 			return 1;
 		}

--- a/cli/src/commands/cvms/replicate/index.ts
+++ b/cli/src/commands/cvms/replicate/index.ts
@@ -1,10 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import {
-	type PhalaCloudError,
 	ResourceError,
 	type Client,
-	type ErrorLink,
 	type EnvVar,
 	SUPPORTED_CHAINS,
 	safeAddComposeHash,
@@ -14,8 +12,6 @@ import {
 	safeGetAppCvms,
 	safeGetCvmInfo,
 	encryptEnvVars,
-	formatErrorMessage,
-	formatStructuredError,
 } from "@phala/cloud";
 import { getClient } from "@/src/lib/client";
 import { getEncryptPubkey } from "@/src/commands/envs/get-encrypt-pubkey";
@@ -23,7 +19,6 @@ import { defineCommand } from "@/src/core/define-command";
 import { isInJsonMode } from "@/src/core/json-mode";
 import type { CommandContext } from "@/src/core/types";
 import { CLOUD_URL } from "@/src/utils/constants";
-import { logger } from "@/src/utils/logger";
 import {
 	cvmsReplicateCommandMeta,
 	cvmsReplicateCommandSchema,
@@ -515,22 +510,10 @@ async function runCvmsReplicateCommand(
 			return 0;
 		}
 	} catch (error) {
-		logger.error("Failed to create CVM replica");
-		if (error instanceof ResourceError) {
-			process.stderr.write(`${formatStructuredError(error)}\n`);
-			const links = error.links as ErrorLink[] | undefined;
-			if (links && links.length > 0) {
-				for (const link of links) {
-					process.stderr.write(`  ${link.label}: ${link.url}\n`);
-				}
-			}
-			return 1;
-		}
-		if (error instanceof Error) {
-			process.stderr.write(`${formatErrorMessage(error as PhalaCloudError)}\n`);
-			return 1;
-		}
-		logger.logDetailedError(error);
+		context.failWithError(error, {
+			operation: "Replicate CVM",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/cvms/resize/index.ts
+++ b/cli/src/commands/cvms/resize/index.ts
@@ -84,7 +84,10 @@ async function runCvmsResizeCommand(
 		const infoResult = await safeGetCvmInfo(client, context.cvmId);
 
 		if (!infoResult.success) {
-			context.fail(infoResult.error.message);
+			context.failWithError(infoResult.error.cause ?? infoResult.error, {
+				operation: "Resize CVM",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -237,9 +240,10 @@ ${CLOUD_URL}/dashboard/cvms/app_${resolvedAppId}`,
 		}
 		return 0;
 	} catch (error) {
-		logger.error("Failed to resize CVM");
-		logger.logDetailedError(error);
-		context.fail(error instanceof Error ? error.message : String(error));
+		context.failWithError(error, {
+			operation: "Resize CVM",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/cvms/restart/index.ts
+++ b/cli/src/commands/cvms/restart/index.ts
@@ -31,7 +31,10 @@ async function runCvmsRestartCommand(
 		const infoResult = await safeGetCvmInfo(client, context.cvmId);
 
 		if (!infoResult.success) {
-			context.fail(infoResult.error.message);
+			context.failWithError(infoResult.error.cause ?? infoResult.error, {
+				operation: "Restart CVM",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -57,7 +60,10 @@ async function runCvmsRestartCommand(
 		spinner.stop(true);
 
 		if (!result.success) {
-			context.fail(`Failed to restart CVM: ${result.error.message}`);
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "Restart CVM",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -92,8 +98,10 @@ ${CLOUD_URL}/dashboard/cvms/app_${response.app_id}`,
 		);
 		return 0;
 	} catch (error) {
-		context.fail("Failed to restart CVM");
-		logger.logDetailedError(error);
+		context.failWithError(error, {
+			operation: "Restart CVM",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/cvms/runtime-config/index.ts
+++ b/cli/src/commands/cvms/runtime-config/index.ts
@@ -3,7 +3,6 @@ import { defineCommand } from "@/src/core/define-command";
 import { isInJsonMode } from "@/src/core/json-mode";
 import type { CommandContext } from "@/src/core/types";
 import { getClient } from "@/src/lib/client";
-import { logger } from "@/src/utils/logger";
 import {
 	cvmsRuntimeConfigCommandMeta,
 	cvmsRuntimeConfigCommandSchema,
@@ -11,7 +10,7 @@ import {
 } from "./command";
 
 async function runCvmsRuntimeConfigCommand(
-	_input: CvmsRuntimeConfigCommandInput,
+	input: CvmsRuntimeConfigCommandInput,
 	context: CommandContext,
 ): Promise<number> {
 	if (!context.cvmId) {
@@ -26,7 +25,10 @@ async function runCvmsRuntimeConfigCommand(
 		const result = await safeGetCvmUserConfig(client, context.cvmId);
 
 		if (!result.success) {
-			context.fail(`Failed to get runtime config: ${result.error.message}`);
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "Get runtime config",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -53,8 +55,10 @@ async function runCvmsRuntimeConfigCommand(
 
 		return 0;
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail("Failed to get CVM runtime config");
+		context.failWithError(error, {
+			operation: "Get runtime config",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }
@@ -65,5 +69,3 @@ export const cvmsRuntimeConfigCommand = defineCommand({
 	schema: cvmsRuntimeConfigCommandSchema,
 	handler: runCvmsRuntimeConfigCommand,
 });
-
-export default cvmsRuntimeConfigCommand;

--- a/cli/src/commands/cvms/start/index.ts
+++ b/cli/src/commands/cvms/start/index.ts
@@ -35,7 +35,10 @@ async function runCvmsStartCommand(
 		spinner.stop(true);
 
 		if (!result.success) {
-			context.fail(`Failed to start CVM: ${result.error.message}`);
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "Start CVM",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -67,8 +70,10 @@ ${CLOUD_URL}/dashboard/cvms/app_${response.app_id}`,
 		);
 		return 0;
 	} catch (error) {
-		context.fail("Failed to start CVM");
-		logger.logDetailedError(error);
+		context.failWithError(error, {
+			operation: "Start CVM",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/cvms/stop/index.ts
+++ b/cli/src/commands/cvms/stop/index.ts
@@ -35,7 +35,10 @@ async function runCvmsStopCommand(
 		spinner.stop(true);
 
 		if (!result.success) {
-			context.fail(`Failed to stop CVM: ${result.error.message}`);
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "Stop CVM",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -67,8 +70,10 @@ ${CLOUD_URL}/dashboard/cvms/app_${response.app_id}`,
 		);
 		return 0;
 	} catch (error) {
-		context.fail("Failed to stop CVM");
-		logger.logDetailedError(error);
+		context.failWithError(error, {
+			operation: "Stop CVM",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/cvms/upgrade/index.ts
+++ b/cli/src/commands/cvms/upgrade/index.ts
@@ -58,7 +58,10 @@ async function runCvmsUpgradeCommand(
 		const infoResult = await safeGetCvmInfo(client, context.cvmId);
 
 		if (!infoResult.success) {
-			context.fail(infoResult.error.message);
+			context.failWithError(infoResult.error.cause ?? infoResult.error, {
+				operation: "Upgrade CVM",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 

--- a/cli/src/commands/deploy/handler.ts
+++ b/cli/src/commands/deploy/handler.ts
@@ -17,15 +17,11 @@ import { parseDiskSizeInput, parseMemoryInput } from "@/src/utils/units";
 import {
 	type Client,
 	type EnvVar,
-	type ErrorLink,
 	CvmIdSchema,
 	MAX_COMPOSE_PAYLOAD_BYTES,
-	RequestError,
-	ResourceError,
 	SUPPORTED_CHAINS,
 	createClient,
 	encryptEnvVars,
-	formatStructuredError,
 	parseEnvVars,
 	safeAddComposeHash,
 	safeAddDevice,
@@ -113,168 +109,6 @@ export function applyForceStopOption(
 ): void {
 	if (!forceStop) return;
 	patchBody.allow_force_stop = true;
-}
-
-/**
- * Handle provision error with structured error response
- */
-function handleProvisionError(
-	error: unknown,
-	options: Options,
-): string | object {
-	// Check if it's a ResourceError with structured details
-	if (error instanceof ResourceError) {
-		if (options.json) {
-			return {
-				success: false,
-				error_code: error.errorCode,
-				message: error.message,
-				details: error.structuredDetails,
-				suggestions: error.suggestions,
-				links: error.links,
-			};
-		}
-		return formatStructuredError(error);
-	}
-
-	// RequestError from the SDK: .detail is extracted from the response body
-	// (e.g. { error_code: "ERR-02-009", message: "...", ... })
-	if (
-		error instanceof RequestError &&
-		typeof error.detail === "object" &&
-		error.detail !== null &&
-		"error_code" in error.detail
-	) {
-		const { error_code, message, details, suggestions, links } =
-			error.detail as {
-				error_code: string;
-				message: string;
-				details?: Array<{
-					field?: string;
-					value?: unknown;
-					message?: string;
-				}>;
-				suggestions?: string[];
-				links?: Array<{ url: string; label: string }>;
-			};
-
-		if (options.json) {
-			return {
-				success: false,
-				error_code,
-				message,
-				details,
-				suggestions,
-				links,
-			};
-		}
-
-		let output = `\nError [${error_code}]: ${message}\n`;
-
-		if (details && details.length > 0) {
-			output += "\nDetails:\n";
-			for (const d of details) {
-				if (d.message) {
-					output += `  - ${d.message}\n`;
-				} else if (d.field && d.value !== undefined) {
-					output += `  - ${d.field}: ${d.value}\n`;
-				}
-			}
-		}
-
-		if (suggestions && suggestions.length > 0) {
-			output += "\nSuggestions:\n";
-			for (const s of suggestions) {
-				output += `  - ${s}\n`;
-			}
-		}
-
-		if (links && links.length > 0) {
-			output += "\nLearn more:\n";
-			for (const link of links) {
-				output += `  - ${link.label}: ${link.url}\n`;
-			}
-		}
-
-		return output;
-	}
-
-	// Parse structured error from plain object (backward compatibility)
-	if (error && typeof error === "object" && "response" in error) {
-		const errorWithResponse = error as {
-			response?: {
-				data?: {
-					detail?: unknown;
-				};
-			};
-		};
-		const errorData = errorWithResponse.response?.data?.detail;
-		if (
-			errorData &&
-			typeof errorData === "object" &&
-			"error_code" in errorData
-		) {
-			const { error_code, message, details, suggestions, links } =
-				errorData as {
-					error_code: string;
-					message: string;
-					details?: Array<{
-						field?: string;
-						value?: unknown;
-						message?: string;
-					}>;
-					suggestions?: string[];
-					links?: Array<{ url: string; label: string }>;
-				};
-
-			if (options.json) {
-				return {
-					success: false,
-					error_code,
-					message,
-					details,
-					suggestions,
-					links,
-				};
-			}
-
-			let output = `\nError [${error_code}]: ${message}\n`;
-
-			if (details && details.length > 0) {
-				output += "\nDetails:\n";
-				for (const d of details) {
-					if (d.message) {
-						output += `  - ${d.message}\n`;
-					} else if (d.field && d.value !== undefined) {
-						output += `  - ${d.field}: ${d.value}\n`;
-					}
-				}
-			}
-
-			if (suggestions && suggestions.length > 0) {
-				output += "\nSuggestions:\n";
-				for (const s of suggestions) {
-					output += `  - ${s}\n`;
-				}
-			}
-
-			if (links && links.length > 0) {
-				output += "\nLearn more:\n";
-				for (const link of links) {
-					output += `  - ${link.label}: ${link.url}\n`;
-				}
-			}
-
-			return output;
-		}
-	}
-
-	// Fallback to generic error
-	const message =
-		error instanceof Error ? error.message : String(error || "Unknown error");
-	return options.json
-		? { success: false, error: message }
-		: `\nError: ${message}\n`;
 }
 
 const API_VERSION = "2026-05-22" as const;
@@ -882,11 +716,6 @@ const deployNewCvm = async (
 	// Provision - backend will auto-match resources
 	const provision_result = await safeProvisionCvm(client, payload);
 	if (!provision_result.success) {
-		const formattedError = handleProvisionError(
-			provision_result.error,
-			validatedOptions,
-		);
-		logger.error("Error in provisioning CVM:", formattedError);
 		throw provision_result.error;
 	}
 	// biome-ignore lint/suspicious/noExplicitAny: type inference issue with @phala/cloud library
@@ -945,12 +774,8 @@ const deployNewCvm = async (
 		});
 
 		if (!deploy_result.success) {
-			logger.logDetailedError(deploy_result, "Deploy App Auth");
-			const errorMsg =
-				typeof deploy_result === "object" && deploy_result !== null
-					? JSON.stringify(deploy_result)
-					: String(deploy_result);
-			throw new Error(`Deployment contract failed: ${errorMsg}`);
+			const failure = deploy_result as { error?: unknown };
+			throw failure.error ?? new Error("Deployment contract failed");
 		}
 
 		// biome-ignore lint/suspicious/noExplicitAny: type inference issue with @phala/cloud library
@@ -969,10 +794,7 @@ const deployNewCvm = async (
 		});
 
 		if (!resp.success) {
-			logger.logDetailedError(resp.error, "Get App Env Encrypt PubKey");
-			throw new Error(
-				`Failed to get app env encrypt pubkey: ${resp.error.message}`,
-			);
+			throw resp.error;
 		}
 
 		const pubkey = verifyAndExtractEnvEncryptPubkey(
@@ -1006,10 +828,7 @@ const deployNewCvm = async (
 	}
 
 	if (!commit_result.success) {
-		logger.logDetailedError(commit_result.error, "Commit CVM Provision");
-		throw new Error(
-			`Failed to commit CVM provision: ${commit_result.error.message}`,
-		);
+		throw commit_result.error;
 	}
 	// biome-ignore lint/suspicious/noExplicitAny: type inference issue with @phala/cloud library
 	const cvm = commit_result.data as any;
@@ -1054,8 +873,7 @@ const updateCvm = async (
 		id: validatedOptions.uuid,
 	});
 	if (!cvm_result.success) {
-		logger.logDetailedError(cvm_result.error, "Get CVM Info");
-		throw new Error(`Failed to get cvm info: ${cvm_result.error.message}`);
+		throw cvm_result.error;
 	}
 	// biome-ignore lint/suspicious/noExplicitAny: type inference issue with @phala/cloud library
 	const cvm = cvm_result.data as any;
@@ -1074,10 +892,7 @@ const updateCvm = async (
 				kms: kmsSlug,
 			});
 			if (!resp.success) {
-				logger.logDetailedError(resp.error, "Get App Env Encrypt PubKey");
-				throw new Error(
-					`Failed to get app env encrypt pubkey: ${resp.error.message}`,
-				);
+				throw resp.error;
 			}
 			const pubkey = verifyAndExtractEnvEncryptPubkey(
 				resp.data,
@@ -1127,11 +942,6 @@ const updateCvm = async (
 	// biome-ignore lint/suspicious/noExplicitAny: dynamic patch body
 	const patchResult = await safePatchCvm(client, patchBody as any);
 	if (!patchResult.success) {
-		const formattedError = handleProvisionError(
-			patchResult.error,
-			validatedOptions,
-		);
-		logger.error("Error updating CVM:", formattedError);
 		throw patchResult.error;
 	}
 
@@ -1373,7 +1183,6 @@ const updateCvm = async (
 				context,
 			);
 		} catch (error: unknown) {
-			logger.logDetailedError(error, "Wait for CVM Ready");
 			throw new Error(
 				`Wait failed: ${error instanceof Error ? error.message : String(error)}`,
 			);
@@ -1464,7 +1273,7 @@ const commitCvmUpdate = async (
 export async function runDeploy(
 	input: DeployCommandInput,
 	context: CommandContext,
-): Promise<void> {
+): Promise<number> {
 	try {
 		// Handle --commit mode: skip compose file reading entirely
 		// commit-update endpoint is token-based (no API key required),
@@ -1589,25 +1398,16 @@ export async function runDeploy(
 				preLaunchScriptContent,
 			);
 		}
+		return 0;
 	} catch (error) {
-		if (input.json !== false) {
-			context.stderr.write(
-				`${JSON.stringify(
-					{
-						success: false,
-						error: error instanceof Error ? error.message : String(error),
-						stack:
-							input.debug && error instanceof Error ? error.stack : undefined,
-					},
-					null,
-					2,
-				)}\n`,
-			);
-		} else {
-			context.stderr.write(
-				`${dedent`${error instanceof Error ? error.message : String(error)}`}\n`,
-			);
-		}
-		throw error;
+		const isUpdate = Boolean(context.cvmId);
+		context.failWithError(error, {
+			operation: isUpdate ? "CVM update" : "CVM deployment",
+			debug: input.debug,
+			guidance: isUpdate
+				? "Check the CVM status before retrying. Include the Request ID when contacting support."
+				: undefined,
+		});
+		return 1;
 	}
 }

--- a/cli/src/commands/deploy/index.ts
+++ b/cli/src/commands/deploy/index.ts
@@ -11,12 +11,7 @@ async function handler(
 	input: DeployCommandInput,
 	context: CommandContext,
 ): Promise<number> {
-	try {
-		await runDeploy(input, context);
-		return 0;
-	} catch (error) {
-		return 1;
-	}
+	return runDeploy(input, context);
 }
 
 export const deployCommand = defineCommand({

--- a/cli/src/commands/envs/encrypt/index.ts
+++ b/cli/src/commands/envs/encrypt/index.ts
@@ -33,7 +33,10 @@ async function runEnvsEncryptCommand(
 		const result = await safeGetCvmInfo(client, context.cvmId);
 
 		if (!result.success) {
-			context.fail(result.error.message);
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "Encrypt envs",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 

--- a/cli/src/commands/envs/get-encrypt-pubkey.test.ts
+++ b/cli/src/commands/envs/get-encrypt-pubkey.test.ts
@@ -206,9 +206,9 @@ describe("getEncryptPubkey", () => {
 				},
 			};
 
-			await expect(getEncryptPubkey(mockClient, cvm)).rejects.toThrow(
-				"Failed to get encryption public key",
-			);
+			await expect(getEncryptPubkey(mockClient, cvm)).rejects.toEqual({
+				message: "KMS not found",
+			});
 		});
 	});
 });

--- a/cli/src/commands/envs/get-encrypt-pubkey.ts
+++ b/cli/src/commands/envs/get-encrypt-pubkey.ts
@@ -4,7 +4,6 @@ import {
 	verifyEnvEncryptPublicKeyLegacy,
 	type GetAppEnvEncryptPubKey,
 } from "@phala/cloud";
-import { logger } from "@/src/utils/logger";
 
 function stripHexPrefix(value: string): string {
 	return value.startsWith("0x") ? value.slice(2) : value;
@@ -83,10 +82,7 @@ export async function getEncryptPubkey(
 		});
 
 		if (!resp.success) {
-			logger.logDetailedError(resp.error, "Get App Env Encrypt PubKey");
-			throw new Error(
-				`Failed to get encryption public key: ${resp.error.message}`,
-			);
+			throw resp.error;
 		}
 
 		return verifyAndExtractEnvEncryptPubkey(

--- a/cli/src/commands/envs/update/index.ts
+++ b/cli/src/commands/envs/update/index.ts
@@ -53,7 +53,10 @@ async function runEnvsUpdateCommand(
 		const cvmResult = await safeGetCvmInfo(client, context.cvmId);
 
 		if (!cvmResult.success) {
-			context.fail(cvmResult.error.message);
+			context.failWithError(cvmResult.error.cause ?? cvmResult.error, {
+				operation: "Update envs",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -88,7 +91,10 @@ async function runEnvsUpdateCommand(
 		});
 
 		if (!updateResult.success) {
-			context.fail(updateResult.error.message);
+			context.failWithError(updateResult.error.cause ?? updateResult.error, {
+				operation: "Update envs",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -135,8 +141,11 @@ async function runEnvsUpdateCommand(
 			});
 
 			if (!addHashResult.success) {
-				logger.logDetailedError(addHashResult, "Add Compose Hash");
-				context.fail("Failed to register compose hash on-chain.");
+				const failure = addHashResult as { error?: unknown };
+				context.failWithError(failure.error ?? addHashResult, {
+					operation: "Update envs",
+					debug: Boolean((input as { debug?: boolean }).debug),
+				});
 				return 1;
 			}
 
@@ -154,9 +163,12 @@ async function runEnvsUpdateCommand(
 			});
 
 			if (!retryResult.success) {
-				context.fail(retryResult.error.message);
-				return 1;
-			}
+			context.failWithError(retryResult.error.cause ?? retryResult.error, {
+				operation: "Update envs",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
+			return 1;
+		}
 
 			if (retryResult.data.status === "in_progress") {
 				logger.success(

--- a/cli/src/commands/instance-types/index.ts
+++ b/cli/src/commands/instance-types/index.ts
@@ -103,12 +103,10 @@ async function runInstanceTypesCommand(
 
 		return 0;
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail(
-			`Failed to list instance types: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		context.failWithError(error, {
+			operation: "List instance types",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/instances/add/index.test.ts
+++ b/cli/src/commands/instances/add/index.test.ts
@@ -73,8 +73,9 @@ function makeContext(overrides: Partial<CommandContext> = {}): CommandContext {
 		projectConfig: {},
 		success() {},
 		fail() {},
+		failWithError() {},
 		...overrides,
-	};
+	} as CommandContext;
 }
 
 describe("instances add command", () => {

--- a/cli/src/commands/instances/add/index.ts
+++ b/cli/src/commands/instances/add/index.ts
@@ -1,10 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import {
-	type PhalaCloudError,
 	ResourceError,
 	type Client,
-	type ErrorLink,
 	type EnvVar,
 	SUPPORTED_CHAINS,
 	safeAddComposeHash,
@@ -14,8 +12,6 @@ import {
 	safeGetAppCvms,
 	safeGetCvmInfo,
 	encryptEnvVars,
-	formatErrorMessage,
-	formatStructuredError,
 } from "@phala/cloud";
 import { getClient } from "@/src/lib/client";
 import { getEncryptPubkey } from "@/src/commands/envs/get-encrypt-pubkey";
@@ -23,7 +19,6 @@ import { defineCommand } from "@/src/core/define-command";
 import { isInJsonMode } from "@/src/core/json-mode";
 import type { CommandContext } from "@/src/core/types";
 import { CLOUD_URL } from "@/src/utils/constants";
-import { logger } from "@/src/utils/logger";
 import {
 	instancesAddCommandMeta,
 	instancesAddCommandSchema,
@@ -502,22 +497,10 @@ async function runInstancesAddCommand(
 			return 0;
 		}
 	} catch (error) {
-		logger.error("Failed to create app instance");
-		if (error instanceof ResourceError) {
-			process.stderr.write(`${formatStructuredError(error)}\n`);
-			const links = error.links as ErrorLink[] | undefined;
-			if (links && links.length > 0) {
-				for (const link of links) {
-					process.stderr.write(`  ${link.label}: ${link.url}\n`);
-				}
-			}
-			return 1;
-		}
-		if (error instanceof Error) {
-			process.stderr.write(`${formatErrorMessage(error as PhalaCloudError)}\n`);
-			return 1;
-		}
-		logger.logDetailedError(error);
+		context.failWithError(error, {
+			operation: "Add instance",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/instances/ls/index.ts
+++ b/cli/src/commands/instances/ls/index.ts
@@ -119,12 +119,10 @@ async function runInstancesLsCommand(
 		printTable(columns, rows);
 		return 0;
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail(
-			`Failed to list instances: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		context.failWithError(error, {
+			operation: "List instances",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/instances/rm/index.ts
+++ b/cli/src/commands/instances/rm/index.ts
@@ -81,8 +81,10 @@ async function runInstancesRmCommand(
 		const failed = results.filter((r) => !r.deleted);
 		return failed.length > 0 ? 1 : 0;
 	} catch (error) {
-		context.fail("Failed to delete instance");
-		logger.logDetailedError(error);
+		context.failWithError(error, {
+			operation: "Remove instance",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/kms/chain/index.ts
+++ b/cli/src/commands/kms/chain/index.ts
@@ -65,9 +65,12 @@ function createChainHandler(chain: string) {
 			});
 
 			if (!result.success) {
-				context.fail(result.error.message);
-				return 1;
-			}
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "List KMS chains",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
+			return 1;
+		}
 
 			const data = result.data;
 
@@ -145,12 +148,10 @@ function createChainHandler(chain: string) {
 
 			return 0;
 		} catch (error) {
-			logger.logDetailedError(error);
-			context.fail(
-				`Failed to get KMS details for ${chain}: ${
-					error instanceof Error ? error.message : String(error)
-				}`,
-			);
+			context.failWithError(error, {
+				operation: "List KMS chains",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 	};
@@ -181,7 +182,10 @@ async function runKmsPhalaCommand(
 		const result = await safeGetKmsContract(client, { slug: "phala" });
 
 		if (!result.success) {
-			context.fail(result.error.message);
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "List KMS chains",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -197,12 +201,10 @@ async function runKmsPhalaCommand(
 		kv("CA pubkey", hex(contract.ca_pubkey));
 		return 0;
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail(
-			`Failed to get Phala KMS details: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		context.failWithError(error, {
+			operation: "List KMS chains",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/kms/list/index.ts
+++ b/cli/src/commands/kms/list/index.ts
@@ -31,7 +31,10 @@ async function runKmsListCommand(
 		const result = await safeListKmsContracts(client, { page_size: 100 });
 
 		if (!result.success) {
-			context.fail(result.error.message);
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "List KMS",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -65,12 +68,10 @@ async function runKmsListCommand(
 		printTable(columns, rows);
 		return 0;
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail(
-			`Failed to list KMS contracts: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		context.failWithError(error, {
+			operation: "List KMS",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/kms/nodes/index.ts
+++ b/cli/src/commands/kms/nodes/index.ts
@@ -20,7 +20,10 @@ async function runKmsNodesCommand(
 		const result = await safeListKmsContractNodes(client, { slug: input.slug });
 
 		if (!result.success) {
-			context.fail(result.error.message);
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "List KMS nodes",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -47,12 +50,10 @@ async function runKmsNodesCommand(
 		printTable(columns, rows);
 		return 0;
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail(
-			`Failed to list KMS contract nodes: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		context.failWithError(error, {
+			operation: "List KMS nodes",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/link/index.ts
+++ b/cli/src/commands/link/index.ts
@@ -396,7 +396,9 @@ async function runInteractiveLink(context: CommandContext): Promise<number> {
 	listSpinner.stop(true);
 
 	if (!cvmResult.success) {
-		context.fail(`Failed to fetch CVMs: ${cvmResult.error.message}`);
+		context.failWithError(cvmResult.error.cause ?? cvmResult.error, {
+			operation: "Link project",
+		});
 		return 1;
 	}
 

--- a/cli/src/commands/login/index.ts
+++ b/cli/src/commands/login/index.ts
@@ -286,8 +286,10 @@ export async function runLoginCommand(
 		);
 		return 0;
 	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		context.stderr.write(chalk.red(`Failed to authenticate: ${message}\n`));
+		context.failWithError(error, {
+			operation: "Login",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/logs/index.test.ts
+++ b/cli/src/commands/logs/index.test.ts
@@ -119,8 +119,9 @@ function makeContext(overrides: Partial<CommandContext> = {}): CommandContext {
 		projectConfig: {},
 		success() {},
 		fail() {},
+		failWithError() {},
 		...overrides,
-	};
+	} as CommandContext;
 }
 
 const defaultInput = {

--- a/cli/src/commands/logs/index.ts
+++ b/cli/src/commands/logs/index.ts
@@ -203,11 +203,10 @@ async function runCvmMode(
 
 		return 0;
 	} catch (error) {
-		context.fail(
-			`Failed to fetch CVM ${channel} logs: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		context.failWithError(error, {
+			operation: `Fetch CVM ${channel} logs`,
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }
@@ -290,11 +289,10 @@ async function runContainerMode(
 		}
 		return 0;
 	} catch (error) {
-		context.fail(
-			`Failed to fetch container logs: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		context.failWithError(error, {
+			operation: "Fetch container logs",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		await checkAndWarnIfLogsDisabled(appId);
 		return 1;
 	}

--- a/cli/src/commands/nodes/list/index.ts
+++ b/cli/src/commands/nodes/list/index.ts
@@ -20,7 +20,10 @@ async function runNodesListCommand(
 		// Get current workspace to obtain teamSlug
 		const userResult = await safeGetCurrentUser(client);
 		if (!userResult.success) {
-			context.fail(userResult.error.message);
+			context.failWithError(userResult.error.cause ?? userResult.error, {
+				operation: "List nodes",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -38,7 +41,10 @@ async function runNodesListCommand(
 		});
 
 		if (!result.success) {
-			context.fail(result.error.message);
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "List nodes",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -75,12 +81,10 @@ async function runNodesListCommand(
 		logger.info(`Page ${data.page}/${data.pages} (total ${data.total})`);
 		return 0;
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail(
-			`Failed to list nodes: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		context.failWithError(error, {
+			operation: "List nodes",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/os-images/index.ts
+++ b/cli/src/commands/os-images/index.ts
@@ -28,7 +28,10 @@ async function runOsImagesCommand(
 
 		const firstPageResult = await fetchPage(input.page);
 		if (!firstPageResult.success) {
-			context.fail(firstPageResult.error.message);
+			context.failWithError(firstPageResult.error.cause ?? firstPageResult.error, {
+				operation: "List OS images",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -38,9 +41,12 @@ async function runOsImagesCommand(
 			for (let page = data.page + 1; page <= data.pages; page++) {
 				const pageResult = await fetchPage(page);
 				if (!pageResult.success) {
-					context.fail(pageResult.error.message);
-					return 1;
-				}
+			context.failWithError(pageResult.error.cause ?? pageResult.error, {
+				operation: "List OS images",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
+			return 1;
+		}
 				allItems.push(...pageResult.data.items);
 			}
 			data = {
@@ -76,12 +82,10 @@ async function runOsImagesCommand(
 		logger.info(`Total: ${data.total}`);
 		return 0;
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail(
-			`Failed to list OS images: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		context.failWithError(error, {
+			operation: "List OS images",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/ps/index.test.ts
+++ b/cli/src/commands/ps/index.test.ts
@@ -55,15 +55,16 @@ function makeContext(overrides: Partial<CommandContext> = {}): CommandContext {
 		projectConfig: {},
 		success() {},
 		fail() {},
+		failWithError() {},
 		...overrides,
-	};
+	} as CommandContext;
 }
 
 describe("ps command", () => {
 	let consoleSpy: ReturnType<typeof spyOn>;
 
 	beforeEach(() => {
-		mockSafeGetCvmContainersStats.mockReset();
+		mockSafeGetCvmContainersStats.mockClear();
 		consoleSpy = spyOn(console, "log").mockImplementation(() => {});
 	});
 
@@ -227,17 +228,17 @@ describe("ps command", () => {
 			error: { message: "Unauthorized" },
 		});
 
-		const failMessages: string[] = [];
+		const failErrors: unknown[] = [];
 		const code = await psCommand.run(
 			{ cvmId: "test-app", json: false, interactive: false },
 			makeContext({
 				cvmId: { id: "test-app" },
-				fail: (msg: string) => {
-					failMessages.push(msg);
+				failWithError: (error: unknown) => {
+					failErrors.push(error);
 				},
 			}),
 		);
 		expect(code).toBe(1);
-		expect(failMessages[0]).toBe("Unauthorized");
+		expect(failErrors[0]).toEqual({ message: "Unauthorized" });
 	});
 });

--- a/cli/src/commands/ps/index.ts
+++ b/cli/src/commands/ps/index.ts
@@ -39,7 +39,13 @@ async function runPsCommand(
 		const result = await safeGetCvmContainersStats(client, context.cvmId);
 
 		if (!result.success) {
-			context.fail(result.error.message);
+			context.failWithError(
+				(result.error as { cause?: unknown }).cause ?? result.error,
+				{
+					operation: "List containers",
+					debug: Boolean((input as { debug?: boolean }).debug),
+				},
+			);
 			return 1;
 		}
 
@@ -94,12 +100,10 @@ async function runPsCommand(
 
 		return 0;
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail(
-			`Failed to list containers: ${
-				error instanceof Error ? error.message : String(error)
-			}`,
-		);
+		context.failWithError(error, {
+			operation: "List containers",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/ssh-keys/add/index.ts
+++ b/cli/src/commands/ssh-keys/add/index.ts
@@ -61,7 +61,10 @@ async function runSshKeysAddCommand(
 		});
 
 		if (!result.success) {
-			context.fail(`Failed to add SSH key: ${result.error.message}`);
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "Add SSH key",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -75,8 +78,10 @@ async function runSshKeysAddCommand(
 		);
 		return 0;
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail("Failed to add SSH key");
+		context.failWithError(error, {
+			operation: "Add SSH key",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/ssh-keys/import-github/index.ts
+++ b/cli/src/commands/ssh-keys/import-github/index.ts
@@ -27,7 +27,10 @@ async function runSshKeysImportGithubCommand(
 		spinner.stop(true);
 
 		if (!result.success) {
-			context.fail(`Failed to import SSH keys: ${result.error.message}`);
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "Import GitHub SSH keys",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -55,8 +58,10 @@ async function runSshKeysImportGithubCommand(
 
 		return 0;
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail("Failed to import SSH keys");
+		context.failWithError(error, {
+			operation: "Import GitHub SSH keys",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/ssh-keys/list/index.ts
+++ b/cli/src/commands/ssh-keys/list/index.ts
@@ -12,7 +12,7 @@ import {
 } from "./command";
 
 async function runSshKeysListCommand(
-	_input: SshKeysListCommandInput,
+	input: SshKeysListCommandInput,
 	context: CommandContext,
 ): Promise<number> {
 	try {
@@ -20,7 +20,10 @@ async function runSshKeysListCommand(
 		const result = await safeListSshKeys(client);
 
 		if (!result.success) {
-			context.fail(`Failed to list SSH keys: ${result.error.message}`);
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "List SSH keys",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -56,8 +59,10 @@ async function runSshKeysListCommand(
 		printTable(columns, rows);
 		return 0;
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail("Failed to list SSH keys");
+		context.failWithError(error, {
+			operation: "List SSH keys",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }
@@ -68,5 +73,3 @@ export const sshKeysListCommand = defineCommand({
 	schema: sshKeysListCommandSchema,
 	handler: runSshKeysListCommand,
 });
-
-export default sshKeysListCommand;

--- a/cli/src/commands/ssh-keys/remove/index.ts
+++ b/cli/src/commands/ssh-keys/remove/index.ts
@@ -72,7 +72,10 @@ async function runSshKeysRemoveCommand(
 		const result = await safeDeleteSshKey(client, { keyId });
 
 		if (!result.success) {
-			context.fail(`Failed to remove SSH key: ${result.error.message}`);
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "Remove SSH key",
+				debug: Boolean((input as { debug?: boolean }).debug),
+			});
 			return 1;
 		}
 
@@ -84,8 +87,10 @@ async function runSshKeysRemoveCommand(
 		logger.success(`SSH key ${keyId} removed`);
 		return 0;
 	} catch (error) {
-		logger.logDetailedError(error);
-		context.fail("Failed to remove SSH key");
+		context.failWithError(error, {
+			operation: "Remove SSH key",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/ssh/index.ts
+++ b/cli/src/commands/ssh/index.ts
@@ -98,15 +98,21 @@ async function runSshCommand(
 					);
 				}
 			} catch (error) {
-				if (error instanceof NoGatewayError) {
-					logger.error(error.message);
-				} else if (error instanceof CvmNotRunningError) {
-					logger.error(error.message);
-					logger.info("Please start the CVM first using: phala cvms start");
+				if (error instanceof NoGatewayError || error instanceof CvmNotRunningError) {
+					context.failWithError(error, {
+						operation: "SSH connect",
+						debug: Boolean((input as { debug?: boolean }).debug),
+						guidance: (
+							error instanceof CvmNotRunningError
+								? "Please start the CVM first using: phala cvms start"
+								: undefined
+						),
+					});
 				} else {
-					logger.error(
-						error instanceof Error ? error.message : "Failed to fetch CVM info",
-					);
+					context.failWithError(error, {
+						operation: "SSH connect",
+						debug: Boolean((input as { debug?: boolean }).debug),
+					});
 				}
 				return 1;
 			}

--- a/cli/src/commands/status/index.ts
+++ b/cli/src/commands/status/index.ts
@@ -36,11 +36,10 @@ export async function runStatusCommand(
 		const result = await safeGetCurrentUser(client);
 
 		if (!result.success) {
-			logger.error("Failed to get user information");
-			if (result.error) {
-				logger.error(`Error: ${result.error.message}`);
-			}
-			context.fail(result.error?.message || "Failed to get user information");
+			context.failWithError(result.error.cause ?? result.error, {
+				operation: "Status",
+				debug,
+			});
 			return 1;
 		}
 
@@ -88,17 +87,11 @@ export async function runStatusCommand(
 
 		return 0;
 	} catch (error) {
-		logger.error(
-			"Authentication failed. Your API key may be invalid or expired.",
-		);
-		logger.info('Please set a new API key with "phala login"');
-
-		if (debug) {
-			logger.logDetailedError(error);
-		}
-		context.fail(
-			"Authentication failed. Your API key may be invalid or expired.",
-		);
+		context.failWithError(error, {
+			operation: "Status",
+			debug,
+			guidance: 'Please set a new API key with "phala login".',
+		});
 		return 1;
 	}
 }

--- a/cli/src/commands/switch/index.test.ts
+++ b/cli/src/commands/switch/index.test.ts
@@ -31,6 +31,7 @@ function makeContext(): CommandContext {
 		projectConfig: {},
 		success() {},
 		fail() {},
+		failWithError() {},
 	};
 }
 

--- a/cli/src/commands/whoami/index.ts
+++ b/cli/src/commands/whoami/index.ts
@@ -24,7 +24,10 @@ async function runWhoamiCommand(
 	const result = await safeGetCurrentUser(client);
 
 	if (!result.success) {
-		context.fail(result.error?.message || "Failed to get user information");
+		context.failWithError(result.error.cause ?? result.error, {
+			operation: "Whoami",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
 		return 1;
 	}
 

--- a/cli/src/core/dispatcher.ts
+++ b/cli/src/core/dispatcher.ts
@@ -11,6 +11,11 @@ import { isInJsonMode, setJsonMode } from "./json-mode";
 import { getProjectConfig } from "@/src/utils/project-config";
 import { selectCvm } from "@/src/api/cvms";
 import { checkForUpdates, getCachedUpdateNotice } from "./update-check";
+import {
+	buildJsonCliError,
+	normalizeCliError,
+	renderHumanCliError,
+} from "@/src/utils/logger";
 
 export interface DispatchOptions {
 	readonly registry: CommandRegistry;
@@ -348,6 +353,32 @@ export async function dispatchCommand(
 						stderr.write(`${JSON.stringify(details, null, 2)}\n`);
 					}
 				}
+			},
+
+			failWithError(
+				error: unknown,
+				options?: {
+					readonly operation?: string;
+					readonly debug?: boolean;
+					readonly guidance?: string;
+				},
+			): void {
+				const envelope = normalizeCliError(error);
+				if (isInJsonMode()) {
+					const payload = buildJsonCliError(envelope, {
+						operation: options?.operation,
+						debug: options?.debug,
+					});
+					stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+					return;
+				}
+				stderr.write(
+					renderHumanCliError(envelope, {
+						operation: options?.operation,
+						debug: options?.debug,
+						guidance: options?.guidance,
+					}),
+				);
 			},
 		};
 

--- a/cli/src/core/types.ts
+++ b/cli/src/core/types.ts
@@ -128,6 +128,20 @@ export interface CommandContext {
 	 * In human mode, outputs error message to stderr.
 	 */
 	fail(message: string, details?: unknown): void;
+
+	/**
+	 * Normalize and present an API/local error exactly once.
+	 * JSON mode writes one object to stdout; human mode writes one block to stderr.
+	 * Does not throw; callers should return 1 immediately.
+	 */
+	failWithError(
+		error: unknown,
+		options?: {
+			readonly operation?: string;
+			readonly debug?: boolean;
+			readonly guidance?: string;
+		},
+	): void;
 }
 
 export interface CommandDefinition<Schema extends ZodTypeAny = ZodTypeAny> {

--- a/cli/src/utils/logger.test.ts
+++ b/cli/src/utils/logger.test.ts
@@ -1,0 +1,446 @@
+import { describe, expect, test } from "bun:test";
+import { RequestError, ResourceError } from "@phala/cloud";
+
+import {
+	buildJsonCliError,
+	normalizeCliError,
+	renderHumanCliError,
+	type CliErrorEnvelope,
+} from "./logger";
+
+const INCIDENT_REQUEST_ID = "73bdba99d0d36a8086bcc9593d39ff67";
+const INCIDENT_URL =
+	"https://cloud-api.phala.network/api/v1/cvms/f768b03a-427d-4bf5-af31-171d4edba6b2";
+
+function makeIncidentRequestError(): RequestError {
+	const response = {
+		error: "Internal Server Error",
+		request_id: INCIDENT_REQUEST_ID,
+	};
+
+	return new RequestError("[PATCH] request failed", {
+		status: 500,
+		statusText: "Internal Server Error",
+		data: response,
+		detail: "Internal Server Error",
+		request: new URL(INCIDENT_URL),
+		requestMethod: "PATCH",
+		requestId: INCIDENT_REQUEST_ID,
+	});
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+	if (needle.length === 0) return 0;
+	let count = 0;
+	let index = 0;
+	while (true) {
+		const found = haystack.indexOf(needle, index);
+		if (found === -1) return count;
+		count += 1;
+		index = found + needle.length;
+	}
+}
+
+describe("CLI error envelope", () => {
+	test("normalizes generic 500 RequestError with body request ID", () => {
+		const error = makeIncidentRequestError();
+		const envelope = normalizeCliError(error);
+
+		expect(envelope.message).toBe("Internal Server Error");
+		expect(envelope.requestId).toBe(INCIDENT_REQUEST_ID);
+		expect(envelope.httpStatus).toBe(500);
+		expect(envelope.statusText).toBe("Internal Server Error");
+		expect(envelope.request).toEqual({
+			method: "PATCH",
+			url: INCIDENT_URL,
+		});
+		expect(envelope.response).toEqual({
+			error: "Internal Server Error",
+			request_id: INCIDENT_REQUEST_ID,
+		});
+	});
+
+	test("builds exact JSON envelope for incident 500", () => {
+		const envelope = normalizeCliError(makeIncidentRequestError());
+		const json = buildJsonCliError(envelope, { operation: "CVM update" });
+
+		expect(json).toEqual({
+			success: false,
+			error: "Internal Server Error",
+			operation: "CVM update",
+			request_id: INCIDENT_REQUEST_ID,
+			http_status: 500,
+			status_text: "Internal Server Error",
+			request: {
+				method: "PATCH",
+				url: INCIDENT_URL,
+			},
+			response: {
+				error: "Internal Server Error",
+				request_id: INCIDENT_REQUEST_ID,
+			},
+		});
+	});
+
+	test("renders human failure block once without response or stack by default", () => {
+		const envelope = normalizeCliError(makeIncidentRequestError());
+		const human = renderHumanCliError(envelope, { operation: "CVM update" });
+
+		const expectedLines = [
+			"CVM update failed.",
+			"Message: Internal Server Error",
+			`Request: PATCH ${INCIDENT_URL}`,
+			"HTTP: 500 Internal Server Error",
+			`Request ID: ${INCIDENT_REQUEST_ID}`,
+		];
+
+		for (const line of expectedLines) {
+			expect(countOccurrences(human, line)).toBe(1);
+		}
+		expect(human).not.toContain("Response:");
+		expect(human).not.toContain("Stack:");
+	});
+
+	test("debug human output includes complete response and stack", () => {
+		const error = makeIncidentRequestError();
+		const envelope = normalizeCliError(error);
+		const human = renderHumanCliError(envelope, {
+			operation: "CVM update",
+			debug: true,
+		});
+
+		expect(human).toContain("Response:");
+		expect(human).toContain(`"request_id": "${INCIDENT_REQUEST_ID}"`);
+		expect(human).toContain("Stack:");
+		expect(human).toContain(error.stack ?? "RequestError");
+	});
+
+	test("preserves header-derived request ID on RequestError", () => {
+		const error = new RequestError("[GET] failed", {
+			status: 502,
+			statusText: "Bad Gateway",
+			data: { error: "upstream" },
+			detail: "upstream",
+			request: "https://cloud-api.phala.network/api/v1/cvms",
+			requestMethod: "GET",
+			requestId: "header-rid-001",
+		});
+
+		const envelope = normalizeCliError(error);
+		expect(envelope.requestId).toBe("header-rid-001");
+		expect(buildJsonCliError(envelope).request_id).toBe("header-rid-001");
+	});
+
+	test("normalizes ResourceError structured fields", () => {
+		const response = {
+			error_code: "ERR-02-009",
+			message: "The selected instance type is incompatible",
+			details: [
+				{
+					field: "instance_type",
+					message: "This instance type does not support the selected image",
+				},
+			],
+			suggestions: ["Choose a compatible instance type"],
+			links: [
+				{
+					label: "View instance types",
+					url: "https://cloud.phala.com/instances",
+				},
+			],
+			request_id: "abc123",
+		};
+
+		const error = new ResourceError(response.message, {
+			status: 400,
+			statusText: "Bad Request",
+			detail: response,
+			requestId: "abc123",
+			request: new URL(
+				"https://cloud-api.phala.network/api/v1/cvms/f768b03a-427d-4bf5-af31-171d4edba6b2",
+			),
+			requestMethod: "PATCH",
+			data: response,
+			errorCode: "ERR-02-009",
+			structuredDetails: response.details,
+			suggestions: response.suggestions,
+			links: response.links,
+		});
+
+		const envelope = normalizeCliError(error);
+		const json = buildJsonCliError(envelope, { operation: "CVM update" });
+		const human = renderHumanCliError(envelope, { operation: "CVM update" });
+
+		expect(json).toEqual({
+			success: false,
+			error: "The selected instance type is incompatible",
+			operation: "CVM update",
+			error_code: "ERR-02-009",
+			request_id: "abc123",
+			http_status: 400,
+			status_text: "Bad Request",
+			request: {
+				method: "PATCH",
+				url: INCIDENT_URL,
+			},
+			details: response.details,
+			suggestions: response.suggestions,
+			links: response.links,
+			response,
+		});
+
+		expect(human).toContain("CVM update failed.");
+		expect(human).toContain(
+			"Error [ERR-02-009]: The selected instance type is incompatible",
+		);
+		expect(human).toContain(`Request: PATCH ${INCIDENT_URL}`);
+		expect(human).toContain("HTTP: 400 Bad Request");
+		expect(human).toContain("Request ID: abc123");
+		expect(human).toContain("Details:");
+		expect(human).toContain(
+			"- This instance type does not support the selected image",
+		);
+		expect(human).toContain("Suggestions:");
+		expect(human).toContain("- Choose a compatible instance type");
+		expect(human).toContain("Learn more:");
+		expect(human).toContain(
+			"- View instance types: https://cloud.phala.com/instances",
+		);
+	});
+
+	test("normalizes RequestError.detail structured object", () => {
+		const detail = {
+			error_code: "ERR-01-001",
+			message: "Instance type missing",
+			request_id: "detail-rid",
+			details: [{ message: "missing type" }],
+			suggestions: ["pick a type"],
+		};
+		const error = new RequestError("[POST] failed", {
+			status: 400,
+			statusText: "Bad Request",
+			data: detail,
+			detail,
+			request: "https://cloud-api.phala.network/api/v1/cvms",
+			requestMethod: "POST",
+			requestId: "detail-rid",
+		});
+
+		const envelope = normalizeCliError(error);
+		expect(envelope.errorCode).toBe("ERR-01-001");
+		expect(envelope.message).toBe("Instance type missing");
+		expect(envelope.details).toEqual([{ message: "missing type" }]);
+		expect(envelope.suggestions).toEqual(["pick a type"]);
+	});
+
+	test("unwraps ResultError-style cause while keeping outer message fallback", () => {
+		const cause = makeIncidentRequestError();
+		const wrapper = {
+			message: "Failed to update CVM",
+			cause,
+		};
+
+		const envelope = normalizeCliError(wrapper);
+		expect(envelope.message).toBe("Internal Server Error");
+		expect(envelope.requestId).toBe(INCIDENT_REQUEST_ID);
+		expect(envelope.httpStatus).toBe(500);
+	});
+
+	test("timeout keeps code and omits fabricated HTTP fields", () => {
+		const error = new RequestError(
+			"Request timed out. The server did not respond in time.",
+			{
+				status: 0,
+				statusText: "Request Timeout",
+				detail: "Request timed out. The server did not respond in time.",
+				request: INCIDENT_URL,
+				requestMethod: "PATCH",
+				code: "TIMEOUT",
+			},
+		);
+
+		const envelope = normalizeCliError(error);
+		const json = buildJsonCliError(envelope);
+
+		expect(envelope.message).toContain("timed out");
+		expect(envelope.httpStatus).toBeUndefined();
+		expect(envelope.requestId).toBeUndefined();
+		expect(json.http_status).toBeUndefined();
+		expect(json.request_id).toBeUndefined();
+		expect(json.request).toEqual({ method: "PATCH", url: INCIDENT_URL });
+	});
+
+	test("network failure omits response and request ID", () => {
+		const error = new RequestError("[GET] https://example.test: <no response>", {
+			status: 0,
+			statusText: "Unknown Error",
+			detail: "[GET] https://example.test: <no response>",
+			request: "https://example.test/api",
+			requestMethod: "GET",
+		});
+
+		const envelope = normalizeCliError(error);
+		const json = buildJsonCliError(envelope);
+
+		expect(envelope.httpStatus).toBeUndefined();
+		expect(envelope.requestId).toBeUndefined();
+		expect(envelope.response).toBeUndefined();
+		expect(json.response).toBeUndefined();
+		expect(json.request_id).toBeUndefined();
+	});
+
+	test("plain Error keeps message only", () => {
+		const error = new Error("compose file not found");
+		const envelope = normalizeCliError(error);
+		const json = buildJsonCliError(envelope, { operation: "Deploy" });
+		const human = renderHumanCliError(envelope, { operation: "Deploy" });
+
+		expect(envelope.message).toBe("compose file not found");
+		expect(envelope.httpStatus).toBeUndefined();
+		expect(json).toEqual({
+			success: false,
+			error: "compose file not found",
+			operation: "Deploy",
+		});
+		expect(human).toContain("Deploy failed.");
+		expect(human).toContain("Message: compose file not found");
+		expect(human).not.toContain("HTTP:");
+		expect(human).not.toContain("Request ID:");
+	});
+
+	test("unknown thrown value becomes readable string", () => {
+		const envelope = normalizeCliError(42);
+		expect(envelope.message).toBe("42");
+		expect(buildJsonCliError(envelope)).toEqual({
+			success: false,
+			error: "42",
+		});
+	});
+
+	test("preserves full URL and request ID without truncation", () => {
+		const longId = "a".repeat(128);
+		const longUrl = `${INCIDENT_URL}?token=${"b".repeat(200)}`;
+		const error = new RequestError("boom", {
+			status: 500,
+			statusText: "Internal Server Error",
+			data: { error: "boom", request_id: longId },
+			detail: "boom",
+			request: longUrl,
+			requestMethod: "PATCH",
+			requestId: longId,
+		});
+
+		const envelope = normalizeCliError(error);
+		const human = renderHumanCliError(envelope, { operation: "CVM update" });
+		const json = buildJsonCliError(envelope);
+
+		expect(envelope.requestId).toBe(longId);
+		expect(envelope.request?.url).toBe(longUrl);
+		expect(human).toContain(longId);
+		expect(human).toContain(longUrl);
+		expect(json.request_id).toBe(longId);
+		expect(json.request?.url).toBe(longUrl);
+	});
+
+	test("JSON includes complete response when data exists", () => {
+		const data = {
+			error: "Internal Server Error",
+			request_id: INCIDENT_REQUEST_ID,
+			extra: { nested: true, count: 2 },
+		};
+		const error = new RequestError("fail", {
+			status: 500,
+			statusText: "Internal Server Error",
+			data,
+			detail: "Internal Server Error",
+			requestId: INCIDENT_REQUEST_ID,
+		});
+
+		const json = buildJsonCliError(normalizeCliError(error));
+		expect(json.response).toEqual(data);
+	});
+
+	test("JSON stack is present only with debug", () => {
+		const error = makeIncidentRequestError();
+		const envelope = normalizeCliError(error);
+
+		expect(buildJsonCliError(envelope).stack).toBeUndefined();
+		expect(buildJsonCliError(envelope, { debug: true }).stack).toBe(
+			error.stack,
+		);
+	});
+
+	test("does not emit null or empty filler fields", () => {
+		const envelope: CliErrorEnvelope = {
+			message: "plain",
+		};
+		const json = buildJsonCliError(envelope);
+		expect(Object.keys(json).sort()).toEqual(["error", "success"]);
+		expect(json).not.toHaveProperty("request_id");
+		expect(json).not.toHaveProperty("details");
+		expect(json).not.toHaveProperty("suggestions");
+		expect(json).not.toHaveProperty("links");
+		expect(json).not.toHaveProperty("response");
+	});
+
+	test("never serializes request headers or body", () => {
+		const error = new RequestError("fail", {
+			status: 500,
+			statusText: "Internal Server Error",
+			data: { error: "x" },
+			detail: "x",
+			request: new Request(INCIDENT_URL, {
+				method: "PATCH",
+				headers: {
+					Authorization: "Bearer secret-token",
+					"X-API-Key": "secret-key",
+				},
+				body: JSON.stringify({ password: "secret" }),
+			}),
+			requestMethod: "PATCH",
+			requestId: INCIDENT_REQUEST_ID,
+		});
+
+		const envelope = normalizeCliError(error);
+		const human = renderHumanCliError(envelope, { debug: true });
+		const json = JSON.stringify(buildJsonCliError(envelope, { debug: true }));
+
+		expect(human).not.toContain("secret-token");
+		expect(human).not.toContain("secret-key");
+		expect(human).not.toContain("password");
+		expect(json).not.toContain("secret-token");
+		expect(json).not.toContain("secret-key");
+		expect(json).not.toContain("password");
+		expect(envelope.request?.url).toBe(INCIDENT_URL);
+	});
+
+	test("human guidance is optional and only for human mode", () => {
+		const envelope = normalizeCliError(makeIncidentRequestError());
+		const human = renderHumanCliError(envelope, {
+			operation: "CVM update",
+			guidance:
+				"Check the CVM status before retrying. Include the Request ID when contacting support.",
+		});
+		const json = buildJsonCliError(envelope, { operation: "CVM update" });
+
+		expect(human).toContain(
+			"Check the CVM status before retrying. Include the Request ID when contacting support.",
+		);
+		expect(JSON.stringify(json)).not.toContain("Check the CVM status");
+	});
+
+	test("does not map numeric HTTP code to error_code", () => {
+		const error = new RequestError("server exploded", {
+			status: 500,
+			statusText: "Internal Server Error",
+			data: { error: "server exploded" },
+			detail: "server exploded",
+			code: "500",
+			requestId: INCIDENT_REQUEST_ID,
+		});
+
+		const envelope = normalizeCliError(error);
+		expect(envelope.errorCode).toBeUndefined();
+		expect(buildJsonCliError(envelope).error_code).toBeUndefined();
+	});
+});

--- a/cli/src/utils/logger.ts
+++ b/cli/src/utils/logger.ts
@@ -1,11 +1,453 @@
 import chalk from "chalk";
 import ora, { type Ora } from "ora";
-import type { SafeResult } from "@phala/cloud";
+import {
+	PhalaCloudError,
+	RequestError,
+	ResourceError,
+	type SafeResult,
+} from "@phala/cloud";
 import type { ZodError } from "zod";
 import { isInJsonMode } from "@/src/core/json-mode";
 
 // Re-export setJsonMode for convenience
 export { setJsonMode } from "@/src/core/json-mode";
+
+export interface CliErrorRequest {
+	readonly method?: string;
+	readonly url: string;
+}
+
+export interface CliErrorLink {
+	readonly label: string;
+	readonly url: string;
+}
+
+export interface CliErrorEnvelope {
+	readonly message: string;
+	readonly errorCode?: string;
+	readonly requestId?: string;
+	readonly httpStatus?: number;
+	readonly statusText?: string;
+	readonly request?: CliErrorRequest;
+	readonly details?: unknown;
+	readonly suggestions?: readonly string[];
+	readonly links?: readonly CliErrorLink[];
+	readonly response?: unknown;
+	readonly stack?: string;
+}
+
+export interface CliErrorPresentationOptions {
+	readonly operation?: string;
+	readonly debug?: boolean;
+	/** Human-mode only guidance appended after the normalized fields. */
+	readonly guidance?: string;
+}
+
+export type HumanErrorRenderOptions = CliErrorPresentationOptions;
+export type JsonErrorRenderOptions = Pick<
+	CliErrorPresentationOptions,
+	"operation" | "debug"
+>;
+
+export interface JsonCliError {
+	readonly success: false;
+	readonly error: string;
+	readonly operation?: string;
+	readonly error_code?: string;
+	readonly request_id?: string;
+	readonly http_status?: number;
+	readonly status_text?: string;
+	readonly request?: CliErrorRequest;
+	readonly details?: unknown;
+	readonly suggestions?: readonly string[];
+	readonly links?: readonly CliErrorLink[];
+	readonly response?: unknown;
+	readonly stack?: string;
+}
+
+interface ResultErrorLike {
+	readonly message?: unknown;
+	readonly cause?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object";
+}
+
+function isResultErrorLike(value: unknown): value is ResultErrorLike {
+	return isRecord(value) && "cause" in value;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? value : undefined;
+}
+
+function asStringArray(value: unknown): readonly string[] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	const items = value.filter((item): item is string => typeof item === "string");
+	return items.length > 0 ? items : undefined;
+}
+
+function asCliErrorLinks(value: unknown): readonly CliErrorLink[] | undefined {
+	if (!Array.isArray(value)) return undefined;
+	const links: CliErrorLink[] = [];
+	for (const item of value) {
+		if (!isRecord(item)) continue;
+		const label = asNonEmptyString(item.label);
+		const url = asNonEmptyString(item.url);
+		if (label && url) {
+			links.push({ label, url });
+		}
+	}
+	return links.length > 0 ? links : undefined;
+}
+
+function formatRequestUrl(request: unknown): string | undefined {
+	if (typeof request === "string") {
+		const trimmed = request.trim();
+		return trimmed.length > 0 ? trimmed : undefined;
+	}
+	if (request instanceof URL) {
+		return request.toString();
+	}
+	if (typeof Request !== "undefined" && request instanceof Request) {
+		return request.url;
+	}
+	if (isRecord(request)) {
+		const url = asNonEmptyString(request.url);
+		if (url) return url;
+		const href = asNonEmptyString(request.href);
+		if (href) return href;
+	}
+	return undefined;
+}
+
+function formatRequestMethod(
+	request: unknown,
+	requestMethod: unknown,
+): string | undefined {
+	const explicit = asNonEmptyString(requestMethod)?.toUpperCase();
+	if (explicit) return explicit;
+	if (typeof Request !== "undefined" && request instanceof Request) {
+		const method = asNonEmptyString(request.method)?.toUpperCase();
+		if (method) return method;
+	}
+	if (isRecord(request)) {
+		const method = asNonEmptyString(request.method)?.toUpperCase();
+		if (method) return method;
+	}
+	return undefined;
+}
+
+function buildRequest(
+	request: unknown,
+	requestMethod: unknown,
+): CliErrorRequest | undefined {
+	const url = formatRequestUrl(request);
+	if (!url) return undefined;
+	const method = formatRequestMethod(request, requestMethod);
+	return method ? { method, url } : { url };
+}
+
+function extractStructuredFields(source: unknown): {
+	message?: string;
+	errorCode?: string;
+	requestId?: string;
+	details?: unknown;
+	suggestions?: readonly string[];
+	links?: readonly CliErrorLink[];
+} {
+	if (!isRecord(source)) return {};
+
+	const errorCodeRaw = asNonEmptyString(source.error_code);
+	const errorCode =
+		errorCodeRaw && !/^\d+$/.test(errorCodeRaw) ? errorCodeRaw : undefined;
+
+	return {
+		message: asNonEmptyString(source.message) ?? asNonEmptyString(source.error),
+		errorCode,
+		requestId: asNonEmptyString(source.request_id),
+		details: source.details,
+		suggestions: asStringArray(source.suggestions),
+		links: asCliErrorLinks(source.links),
+	};
+}
+
+function extractMessageFromDetail(detail: unknown): string | undefined {
+	if (typeof detail === "string") {
+		return asNonEmptyString(detail);
+	}
+	if (isRecord(detail)) {
+		return (
+			asNonEmptyString(detail.message) ?? asNonEmptyString(detail.error)
+		);
+	}
+	return undefined;
+}
+
+function semanticErrorCode(code: unknown): string | undefined {
+	const value = asNonEmptyString(code);
+	if (!value) return undefined;
+	if (/^\d+$/.test(value)) return undefined;
+	return value;
+}
+
+function normalizeSdkError(
+	error: PhalaCloudError,
+	fallbackMessage?: string,
+): CliErrorEnvelope {
+	const dataFields = extractStructuredFields(error.data);
+	const detailFields = extractStructuredFields(error.detail);
+	const resource =
+		error instanceof ResourceError
+			? {
+					errorCode: error.errorCode,
+					details: error.structuredDetails,
+					suggestions: error.suggestions,
+					links: error.links?.map((link) => ({
+						label: link.label,
+						url: link.url,
+					})),
+				}
+			: undefined;
+
+	const message =
+		asNonEmptyString(resource ? error.message : undefined) ??
+		dataFields.message ??
+		detailFields.message ??
+		extractMessageFromDetail(error.detail) ??
+		asNonEmptyString(error.message) ??
+		fallbackMessage ??
+		"Unknown error";
+
+	const errorCode =
+		resource?.errorCode ??
+		dataFields.errorCode ??
+		detailFields.errorCode ??
+		semanticErrorCode((error as { code?: unknown }).code);
+
+	const requestId =
+		asNonEmptyString(error.requestId) ??
+		dataFields.requestId ??
+		detailFields.requestId;
+
+	const httpStatus =
+		typeof error.status === "number" && error.status > 0
+			? error.status
+			: undefined;
+	const statusText =
+		httpStatus !== undefined
+			? asNonEmptyString(error.statusText)
+			: undefined;
+
+	const details =
+		resource?.details ?? dataFields.details ?? detailFields.details;
+	const suggestions =
+		resource?.suggestions ??
+		dataFields.suggestions ??
+		detailFields.suggestions;
+	const links = resource?.links ?? dataFields.links ?? detailFields.links;
+
+	const response = error.data !== undefined ? error.data : undefined;
+	const request = buildRequest(error.request, error.requestMethod);
+
+	return {
+		message,
+		...(errorCode ? { errorCode } : {}),
+		...(requestId ? { requestId } : {}),
+		...(httpStatus !== undefined ? { httpStatus } : {}),
+		...(statusText ? { statusText } : {}),
+		...(request ? { request } : {}),
+		...(details !== undefined ? { details } : {}),
+		...(suggestions ? { suggestions } : {}),
+		...(links ? { links } : {}),
+		...(response !== undefined ? { response } : {}),
+		...(error.stack ? { stack: error.stack } : {}),
+	};
+}
+
+/**
+ * Normalize any thrown/returned CLI or SDK failure into a shared envelope.
+ */
+export function normalizeCliError(error: unknown): CliErrorEnvelope {
+	if (isResultErrorLike(error) && error.cause !== undefined) {
+		const nested = normalizeCliError(error.cause);
+		const outerMessage = asNonEmptyString(error.message);
+		if (nested.message && nested.message !== "Unknown error") {
+			return nested;
+		}
+		if (outerMessage) {
+			return { ...nested, message: outerMessage };
+		}
+		return nested;
+	}
+
+	if (error instanceof ResourceError || error instanceof RequestError) {
+		return normalizeSdkError(error);
+	}
+
+	if (error instanceof PhalaCloudError) {
+		return normalizeSdkError(error);
+	}
+
+	if (error instanceof Error) {
+		return {
+			message: asNonEmptyString(error.message) ?? "Unknown error",
+			...(error.stack ? { stack: error.stack } : {}),
+		};
+	}
+
+	const text = String(error || "Unknown error");
+	return { message: text.length > 0 ? text : "Unknown error" };
+}
+
+function formatDetailLines(details: unknown): string[] {
+	if (!Array.isArray(details)) {
+		if (details === undefined || details === null) return [];
+		return [`  - ${typeof details === "string" ? details : JSON.stringify(details)}`];
+	}
+
+	const lines: string[] = [];
+	for (const item of details) {
+		if (typeof item === "string") {
+			lines.push(`  - ${item}`);
+			continue;
+		}
+		if (!isRecord(item)) {
+			lines.push(`  - ${String(item)}`);
+			continue;
+		}
+		const message = asNonEmptyString(item.message);
+		if (message) {
+			lines.push(`  - ${message}`);
+			continue;
+		}
+		const field = asNonEmptyString(item.field);
+		if (field && item.value !== undefined) {
+			const value =
+				typeof item.value === "string" ||
+				typeof item.value === "number" ||
+				typeof item.value === "boolean"
+					? String(item.value)
+					: JSON.stringify(item.value);
+			lines.push(`  - ${field}: ${value}`);
+			continue;
+		}
+		lines.push(`  - ${JSON.stringify(item)}`);
+	}
+	return lines;
+}
+
+/**
+ * Render one human-readable failure block for stderr.
+ */
+export function renderHumanCliError(
+	envelope: CliErrorEnvelope,
+	options: HumanErrorRenderOptions = {},
+): string {
+	const lines: string[] = [];
+	const operation = asNonEmptyString(options.operation);
+
+	if (operation) {
+		lines.push(`${operation} failed.`);
+	}
+
+	if (envelope.errorCode) {
+		lines.push(`Error [${envelope.errorCode}]: ${envelope.message}`);
+	} else {
+		lines.push(`Message: ${envelope.message}`);
+	}
+
+	if (envelope.request) {
+		const method = envelope.request.method
+			? `${envelope.request.method} `
+			: "";
+		lines.push(`Request: ${method}${envelope.request.url}`);
+	}
+
+	if (envelope.httpStatus !== undefined) {
+		const statusText = envelope.statusText ? ` ${envelope.statusText}` : "";
+		lines.push(`HTTP: ${envelope.httpStatus}${statusText}`);
+	}
+
+	if (envelope.requestId) {
+		lines.push(`Request ID: ${envelope.requestId}`);
+	}
+
+	const detailLines = formatDetailLines(envelope.details);
+	if (detailLines.length > 0) {
+		lines.push("");
+		lines.push("Details:");
+		lines.push(...detailLines);
+	}
+
+	if (envelope.suggestions && envelope.suggestions.length > 0) {
+		lines.push("");
+		lines.push("Suggestions:");
+		for (const suggestion of envelope.suggestions) {
+			lines.push(`  - ${suggestion}`);
+		}
+	}
+
+	if (envelope.links && envelope.links.length > 0) {
+		lines.push("");
+		lines.push("Learn more:");
+		for (const link of envelope.links) {
+			lines.push(`  - ${link.label}: ${link.url}`);
+		}
+	}
+
+	const guidance = asNonEmptyString(options.guidance);
+	if (guidance) {
+		lines.push("");
+		lines.push(guidance);
+	}
+
+	if (options.debug) {
+		if (envelope.response !== undefined) {
+			lines.push("");
+			lines.push("Response:");
+			lines.push(JSON.stringify(envelope.response, null, 2));
+		}
+		if (envelope.stack) {
+			lines.push("");
+			lines.push("Stack:");
+			lines.push(envelope.stack);
+		}
+	}
+
+	return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Build one JSON failure envelope for stdout.
+ */
+export function buildJsonCliError(
+	envelope: CliErrorEnvelope,
+	options: JsonErrorRenderOptions = {},
+): JsonCliError {
+	const operation = asNonEmptyString(options.operation);
+
+	return {
+		success: false,
+		error: envelope.message,
+		...(operation ? { operation } : {}),
+		...(envelope.errorCode ? { error_code: envelope.errorCode } : {}),
+		...(envelope.requestId ? { request_id: envelope.requestId } : {}),
+		...(envelope.httpStatus !== undefined
+			? { http_status: envelope.httpStatus }
+			: {}),
+		...(envelope.statusText ? { status_text: envelope.statusText } : {}),
+		...(envelope.request ? { request: envelope.request } : {}),
+		...(envelope.details !== undefined ? { details: envelope.details } : {}),
+		...(envelope.suggestions ? { suggestions: envelope.suggestions } : {}),
+		...(envelope.links ? { links: envelope.links } : {}),
+		...(envelope.response !== undefined ? { response: envelope.response } : {}),
+		...(options.debug && envelope.stack ? { stack: envelope.stack } : {}),
+	};
+}
 
 /**
  * Wraps text at the specified width by splitting on spaces.


### PR DESCRIPTION
## Summary
- Add shared CLI error normalizer/renderer and `CommandContext.failWithError`
- Migrate in-scope API commands (including deploy) to one presentation boundary
- Preserve raw `phala api` and streaming contracts; show request ID exactly once

## Test plan
- [x] `cd cli && bun run type-check`
- [x] `cd cli && bun test`
- [x] pre-commit hooks on commit