### PR TITLE
feat(js): add managed_env to CVM detail schemas

### DIFF
--- a/js/src/actions/cvms/get_cvm_info.test.ts
+++ b/js/src/actions/cvms/get_cvm_info.test.ts
@@ -42,38 +42,6 @@ const mockCvmInfoData: CvmDetailV20251028 = {
     chain_id: 1,
     kms_contract_address: "0x1234567890123456789012345678901234567890",
     gateway_app_id: "gateway-123",
-    chain: {
-      id: 1,
-      name: "Ethereum",
-      nativeCurrency: {
-        name: "Ether",
-        symbol: "ETH",
-        decimals: 18
-      },
-      rpcUrls: {
-        default: {
-          http: ["https://eth.merkle.io"]
-        }
-      },
-      blockExplorers: {
-        default: {
-          name: "Etherscan",
-          url: "https://etherscan.io",
-          apiUrl: "https://api.etherscan.io/api"
-        }
-      },
-      blockTime: 12000,
-      contracts: {
-        ensUniversalResolver: {
-          address: "0xeeeeeeee14d718c2b47d9923deab1335e144eeee",
-          blockCreated: 23085558
-        },
-        multicall3: {
-          address: "0xca11bde05977b3631167028862be2a173976ca11",
-          blockCreated: 14353601
-        }
-      }
-    }
   },
   contract_address: "0x9876543210987654321098765432109876543210",
   deployer_address: "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd",

--- a/js/src/actions/cvms/get_cvm_list.test.ts
+++ b/js/src/actions/cvms/get_cvm_list.test.ts
@@ -52,38 +52,6 @@ const mockCvmData: CvmInfoV20251028 = {
     chain_id: 1,
     kms_contract_address: "0x1234567890123456789012345678901234567890",
     gateway_app_id: "gateway-123",
-    chain: {
-      id: 1,
-      name: "Ethereum",
-      nativeCurrency: {
-        name: "Ether",
-        symbol: "ETH",
-        decimals: 18
-      },
-      rpcUrls: {
-        default: {
-          http: ["https://eth.merkle.io"]
-        }
-      },
-      blockExplorers: {
-        default: {
-          name: "Etherscan",
-          url: "https://etherscan.io",
-          apiUrl: "https://api.etherscan.io/api"
-        }
-      },
-      blockTime: 12000,
-      contracts: {
-        ensUniversalResolver: {
-          address: "0xeeeeeeee14d718c2b47d9923deab1335e144eeee",
-          blockCreated: 23085558
-        },
-        multicall3: {
-          address: "0xca11bde05977b3631167028862be2a173976ca11",
-          blockCreated: 14353601
-        }
-      }
-    }
   },
   vcpu: 2,
   memory: 4096,

--- a/js/src/types/cvm_info_v20251028.ts
+++ b/js/src/types/cvm_info_v20251028.ts
@@ -99,6 +99,7 @@ export const CvmDetailV20251028Schema = z.object({
   instance_type: z.string().optional().nullable(),
   public_sysinfo: z.boolean().optional().default(false),
   public_logs: z.boolean().optional().default(false),
+  managed_env: z.boolean().optional().default(false),
   dapp_dashboard_url: z.string().optional().nullable(),
   syslog_endpoint: z.string().optional().nullable(),
   kms_info: KmsInfoSchema.optional().nullable(),

--- a/js/src/types/cvm_info_v20260121.ts
+++ b/js/src/types/cvm_info_v20260121.ts
@@ -160,6 +160,7 @@ export const CvmInfoV20260121Schema = z.object({
   public_tcbinfo: z.boolean().optional(),
   gateway_enabled: z.boolean().optional(),
   secure_time: z.boolean().optional(),
+  managed_env: z.boolean().optional().default(false),
   listed: z.boolean().optional().default(false),
   storage_fs: z.string().optional(),
   workspace: WorkspaceRefSchema.nullable().optional(),


### PR DESCRIPTION
## Summary

- Add `managed_env` to CVM detail response schemas for API versions `2025-10-28` and `2026-01-21`.
- Drop hardcoded viem chain RPC URLs from CVM info/list mocks so tests no longer break when upstream default RPC endpoints change.

Used by monorepo PR for managed init_script partial encrypted-env merge.

## Test plan

- [x] JS SDK typecheck / build / tests via pre-commit
- [ ] Parse a CVM detail payload with and without `managed_env` and confirm default `false`
