### PR TITLE
feat(js): support replica OS image selection

### DIFF
--- a/js/src/actions/cvms/get_available_os_images.test.ts
+++ b/js/src/actions/cvms/get_available_os_images.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { GetAvailableOSImagesResponseSchema } from "./get_available_os_images";
+
+describe("GetAvailableOSImagesResponseSchema", () => {
+  it("preserves the slug and global enablement of each variant", () => {
+    const result = GetAvailableOSImagesResponseSchema.parse([
+      {
+        version: [0, 5, 8],
+        prod: {
+          name: "dstack-0.5.8",
+          slug: "dstack-0.5.8-target",
+          os_image_hash: "0x1234",
+          is_current: false,
+          enabled: false,
+        },
+        dev: null,
+      },
+    ]);
+
+    expect(result[0]?.prod?.slug).toBe("dstack-0.5.8-target");
+    expect(result[0]?.prod?.enabled).toBe(false);
+  });
+});

--- a/js/src/actions/cvms/get_available_os_images.ts
+++ b/js/src/actions/cvms/get_available_os_images.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { CvmIdSchema, type CvmIdInput } from "../../types/cvm_id";
+import { type CvmIdInput, CvmIdSchema } from "../../types/cvm_id";
 import { defineAction } from "../../utils/define-action";
 
 /**
@@ -7,8 +7,10 @@ import { defineAction } from "../../utils/define-action";
  */
 export const OSImageVariantSchema = z.object({
   name: z.string(),
+  slug: z.string(),
   os_image_hash: z.string().nullable(),
   is_current: z.boolean(),
+  enabled: z.boolean(),
 });
 
 export type OSImageVariant = z.infer<typeof OSImageVariantSchema>;

--- a/js/src/actions/cvms/replicate_cvm.test.ts
+++ b/js/src/actions/cvms/replicate_cvm.test.ts
@@ -1,0 +1,49 @@
+import type { Client } from "../../client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { replicateCvm, ReplicateCvmRequestSchema } from "./replicate_cvm";
+
+describe("replicateCvm", () => {
+  let client: Client;
+
+  beforeEach(() => {
+    client = {
+      post: vi.fn(),
+      config: { version: "2026-05-22" as const },
+    } as unknown as Client;
+  });
+
+  it("accepts and sends an explicit OS image", async () => {
+    const response = {
+      id: "cvm_1",
+      name: "replica",
+      status: "running",
+      teepod_id: 1,
+      teepod: { id: 1, name: "node" },
+      app_id: "app_test",
+      vm_uuid: "uuid-1",
+      instance_id: null,
+      vcpu: 2,
+      memory: 4096,
+      disk_size: 20,
+      base_image: "dstack-0.5.8-target",
+      created_at: "2026-01-01T00:00:00Z",
+      encrypted_env_pubkey: null,
+    };
+    (client.post as ReturnType<typeof vi.fn>).mockResolvedValue(response);
+
+    await replicateCvm(client, {
+      id: "source",
+      node_id: 7,
+      os_image: "dstack-0.5.8-target",
+    });
+
+    expect(client.post).toHaveBeenCalledWith("/cvms/source/replicas", {
+      node_id: 7,
+      os_image: "dstack-0.5.8-target",
+    });
+  });
+
+  it("rejects an empty OS image", () => {
+    expect(ReplicateCvmRequestSchema.safeParse({ id: "source", os_image: "" }).success).toBe(false);
+  });
+});

--- a/js/src/actions/cvms/replicate_cvm.ts
+++ b/js/src/actions/cvms/replicate_cvm.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { type Client, type SafeResult } from "../../client";
+import type { Client, SafeResult } from "../../client";
 import type { ApiVersion } from "../../types/client";
-import { CvmIdSchema, CvmIdObjectSchema, refineCvmId } from "../../types/cvm_id";
-import { getVMSchemaForVersion, type VMForVersion } from "../../types/cvm_info";
+import { CvmIdObjectSchema, CvmIdSchema, refineCvmId } from "../../types/cvm_id";
+import { type VMForVersion, getVMSchemaForVersion } from "../../types/cvm_info";
 
 /**
  * Replicate (scale up) a CVM by creating a new replica
@@ -39,6 +39,7 @@ import { getVMSchemaForVersion, type VMForVersion } from "../../types/cvm_info";
 export const ReplicateCvmRequestSchema = refineCvmId(
   CvmIdObjectSchema.extend({
     node_id: z.number().optional(),
+    os_image: z.string().min(1).optional(),
   }),
 );
 
@@ -54,8 +55,11 @@ export async function replicateCvm<V extends ApiVersion>(
 ): Promise<VMForVersion<V>> {
   const parsed = ReplicateCvmRequestSchema.parse(request);
   const { cvmId } = CvmIdSchema.parse(parsed);
-  const { node_id } = parsed;
-  const response = await client.post(`/cvms/${cvmId}/replicas`, { node_id });
+  const { node_id, os_image } = parsed;
+  const response = await client.post(`/cvms/${cvmId}/replicas`, {
+    node_id,
+    os_image,
+  });
   return getVMSchemaForVersion(client.config.version).parse(response) as VMForVersion<V>;
 }
 


### PR DESCRIPTION
## What changed

- accept an optional `os_image` when replicating a CVM and forward it to the API
- expose each available image variant's `slug` and global `enabled` state
- cover replica request serialization and available-image response parsing

## Why

The Phala Cloud admin UI needs to preserve the source image by default while allowing an explicit compatible image change during replication. It also needs the global publication state to label disabled variants without losing their slug.

## Impact

SDK consumers can explicitly choose the replica OS image. Existing calls remain unchanged because `os_image` is optional.

## Validation

- Biome
- TypeScript typecheck
- SDK build
- `vitest --run src/actions/cvms/replicate_cvm.test.ts src/actions/cvms/get_available_os_images.test.ts` (3 tests passed)

The full local SDK suite currently has 9 pre-existing fixture mismatches caused by the resolved viem Ethereum RPC changing from `eth.merkle.io` to `ethereum.reth.rs`; the two changed test files pass.