### PR TITLE
feat(cli): add `phala docs` — explore live docs from the terminal (agent-friendly)

### DIFF
--- a/cli/COMMANDS.md
+++ b/cli/COMMANDS.md
@@ -193,6 +193,46 @@ export DSTACK_SIMULATOR_ENDPOINT=/path/to/dstack.sock
 export TAPPD_SIMULATOR_ENDPOINT=/path/to/tappd.sock
 ```
 
+## Documentation Commands
+
+### `phala docs`
+
+Search and read the live Phala documentation (docs.phala.com) directly from the terminal. No authentication required. Especially useful for AI coding agents: everything published on the docs site is explorable through these commands, so an agent with the CLI installed always has current documentation.
+
+#### Subcommands:
+
+- **`search <query...>`**: Full-text search with relevance ranking. Returns titles, links, and content excerpts.
+
+- **`read <page...>`**: Read one or more pages in full. Accepts page paths (e.g. `/dstack/overview`) or `docs.phala.com` URLs.
+
+- **`tree [path]`**: Show the docs site structure as a directory tree.
+  - Options:
+    - `-L, --depth <n>`: Maximum depth to display (default: 2)
+
+- **`grep <pattern> [path]`**: Regex search across all docs content (ripgrep, smart-case).
+  - Options:
+    - `-l, --files`: Only list matching page paths
+
+- **`feedback <page> <message...>`**: Report incorrect or outdated documentation to the docs team.
+
+All subcommands support `-j, --json`. Set `PHALA_DOCS_MCP_URL` to override the docs server endpoint.
+
+#### Usage Examples:
+
+```bash
+# Search the docs
+phala docs search deploy a CVM with GPU
+
+# Explore the docs structure
+phala docs tree /phala-cloud --depth 3
+
+# Read a full page
+phala docs read /dstack/getting-started
+
+# Find every mention of an env var
+phala docs grep PHALA_CLOUD_API_KEY --files
+```
+
 ## Examples
 
 Here are some examples of how to use the Phala Cloud CLI:

--- a/cli/src/commands/docs/command.ts
+++ b/cli/src/commands/docs/command.ts
@@ -1,0 +1,12 @@
+import type { CommandGroup } from "@/src/core/types";
+
+export const docsGroup: CommandGroup = {
+	path: ["docs"],
+	meta: {
+		name: "docs",
+		category: "advanced",
+		description:
+			"Search and read the live Phala documentation (docs.phala.com) from the terminal",
+		stability: "unstable",
+	},
+};

--- a/cli/src/commands/docs/feedback/command.ts
+++ b/cli/src/commands/docs/feedback/command.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import { jsonOption } from "@/src/core/common-flags";
+import type { CommandMeta } from "@/src/core/types";
+
+export const docsFeedbackCommandMeta: CommandMeta = {
+	name: "feedback",
+	category: "advanced",
+	description:
+		"Report a documentation problem (incorrect, outdated, or confusing content) to the Phala docs team",
+	stability: "unstable",
+	arguments: [
+		{
+			name: "page",
+			description:
+				"Docs page path the feedback is about (e.g. /phala-cloud/getting-started)",
+			required: true,
+			target: "page",
+		},
+		{
+			name: "message...",
+			description: "Description of the issue",
+			required: true,
+			variadic: true,
+			target: "message",
+		},
+	],
+	options: [jsonOption],
+	examples: [
+		{
+			name: "Report an outdated page",
+			value:
+				'phala docs feedback /phala-cloud/getting-started "The login example still shows the deprecated auth command"',
+		},
+	],
+};
+
+export const docsFeedbackCommandSchema = z.object({
+	page: z.string().min(1),
+	message: z.array(z.string()).min(1),
+	json: z.boolean().default(false),
+});
+
+export type DocsFeedbackCommandInput = z.infer<
+	typeof docsFeedbackCommandSchema
+>;

--- a/cli/src/commands/docs/feedback/index.ts
+++ b/cli/src/commands/docs/feedback/index.ts
@@ -1,0 +1,47 @@
+import { defineCommand } from "@/src/core/define-command";
+import type { CommandContext } from "@/src/core/types";
+import {
+	callDocsTool,
+	normalizeDocPath,
+	resolveDocsMcpUrl,
+} from "@/src/lib/docs-mcp";
+import {
+	type DocsFeedbackCommandInput,
+	docsFeedbackCommandMeta,
+	docsFeedbackCommandSchema,
+} from "./command";
+
+async function runDocsFeedbackCommand(
+	input: DocsFeedbackCommandInput,
+	context: CommandContext,
+): Promise<number> {
+	const path = normalizeDocPath(input.page).replace(/\.mdx$/, "");
+	const feedback = input.message.join(" ");
+	try {
+		const response = await callDocsTool(
+			"submit_feedback",
+			{ path, feedback },
+			{ url: resolveDocsMcpUrl(context.env) },
+		);
+		if (input.json) {
+			context.success({ path, feedback, response });
+			return 0;
+		}
+		context.stdout.write(
+			`${response.trim() || "Feedback submitted."} Thanks for helping improve the docs.\n`,
+		);
+		return 0;
+	} catch (error) {
+		context.fail(error instanceof Error ? error.message : String(error));
+		return 1;
+	}
+}
+
+export const docsFeedbackCommand = defineCommand({
+	path: ["docs", "feedback"],
+	meta: docsFeedbackCommandMeta,
+	schema: docsFeedbackCommandSchema,
+	handler: runDocsFeedbackCommand,
+});
+
+export default docsFeedbackCommand;

--- a/cli/src/commands/docs/feedback/index.ts
+++ b/cli/src/commands/docs/feedback/index.ts
@@ -28,7 +28,7 @@ async function runDocsFeedbackCommand(
 			return 0;
 		}
 		context.stdout.write(
-			`${response.trim() || "Feedback submitted."} Thanks for helping improve the docs.\n`,
+			`${response.trim() || "Feedback submitted. Thanks for helping improve the docs."}\n`,
 		);
 		return 0;
 	} catch (error) {

--- a/cli/src/commands/docs/grep/command.ts
+++ b/cli/src/commands/docs/grep/command.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+import { jsonOption } from "@/src/core/common-flags";
+import type { CommandMeta } from "@/src/core/types";
+
+export const docsGrepCommandMeta: CommandMeta = {
+	name: "grep",
+	category: "advanced",
+	description:
+		"Grep the full text of the Phala documentation (ripgrep, smart-case). For relevance-ranked results use `phala docs search`.",
+	stability: "unstable",
+	arguments: [
+		{
+			name: "pattern",
+			description: "Regex pattern to search for",
+			required: true,
+			target: "pattern",
+		},
+		{
+			name: "path",
+			description: "Docs path to search under (default: /)",
+			required: false,
+			target: "path",
+		},
+	],
+	options: [
+		{
+			name: "files",
+			shorthand: "l",
+			description: "Only list matching file paths",
+			type: "boolean",
+			target: "files",
+		},
+		jsonOption,
+	],
+	examples: [
+		{
+			name: "Find every mention of an env var",
+			value: "phala docs grep PHALA_CLOUD_API_KEY",
+		},
+		{
+			name: "Search within one section",
+			value: 'phala docs grep "attestation" /dstack',
+		},
+		{
+			name: "List matching pages only",
+			value: "phala docs grep tdx_quote --files",
+		},
+	],
+};
+
+export const docsGrepCommandSchema = z.object({
+	pattern: z.string().min(1),
+	path: z.string().optional(),
+	files: z.boolean().default(false),
+	json: z.boolean().default(false),
+});
+
+export type DocsGrepCommandInput = z.infer<typeof docsGrepCommandSchema>;

--- a/cli/src/commands/docs/grep/index.ts
+++ b/cli/src/commands/docs/grep/index.ts
@@ -1,0 +1,57 @@
+import { defineCommand } from "@/src/core/define-command";
+import type { CommandContext } from "@/src/core/types";
+import {
+	normalizeDocPath,
+	resolveDocsMcpUrl,
+	runDocsFsCommand,
+	shellQuote,
+} from "@/src/lib/docs-mcp";
+import {
+	type DocsGrepCommandInput,
+	docsGrepCommandMeta,
+	docsGrepCommandSchema,
+} from "./command";
+
+async function runDocsGrepCommand(
+	input: DocsGrepCommandInput,
+	context: CommandContext,
+): Promise<number> {
+	const path = input.path ? normalizeDocPath(input.path) : "/";
+	const flags = input.files ? "-Sl" : "-Sn";
+	try {
+		const result = await runDocsFsCommand(
+			`rg ${flags} ${shellQuote(input.pattern)} ${shellQuote(path)}`,
+			{ url: resolveDocsMcpUrl(context.env) },
+		);
+		// rg exits 1 on "no matches" with empty stderr
+		if (result.exit !== 0 && result.stderr.trim()) {
+			context.fail(result.stderr.trim());
+			return 1;
+		}
+		const matches = result.stdout;
+		if (input.json) {
+			context.success({ pattern: input.pattern, path, matches });
+			return 0;
+		}
+		if (!matches.trim()) {
+			context.stdout.write(
+				`No matches for "${input.pattern}". Try \`phala docs search\` for relevance-ranked results.\n`,
+			);
+			return 0;
+		}
+		context.stdout.write(matches.endsWith("\n") ? matches : `${matches}\n`);
+		return 0;
+	} catch (error) {
+		context.fail(error instanceof Error ? error.message : String(error));
+		return 1;
+	}
+}
+
+export const docsGrepCommand = defineCommand({
+	path: ["docs", "grep"],
+	meta: docsGrepCommandMeta,
+	schema: docsGrepCommandSchema,
+	handler: runDocsGrepCommand,
+});
+
+export default docsGrepCommand;

--- a/cli/src/commands/docs/index.ts
+++ b/cli/src/commands/docs/index.ts
@@ -1,0 +1,19 @@
+import { docsGroup } from "./command";
+import { docsFeedbackCommand } from "./feedback";
+import { docsGrepCommand } from "./grep";
+import { docsReadCommand } from "./read";
+import { docsSearchCommand } from "./search";
+import { docsTreeCommand } from "./tree";
+
+export const docsCommands = {
+	group: docsGroup,
+	commands: [
+		docsSearchCommand,
+		docsReadCommand,
+		docsTreeCommand,
+		docsGrepCommand,
+		docsFeedbackCommand,
+	],
+};
+
+export default docsCommands;

--- a/cli/src/commands/docs/read/command.ts
+++ b/cli/src/commands/docs/read/command.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { jsonOption } from "@/src/core/common-flags";
+import type { CommandMeta } from "@/src/core/types";
+
+export const docsReadCommandMeta: CommandMeta = {
+	name: "read",
+	category: "advanced",
+	description:
+		"Read one or more Phala documentation pages in full. Accepts page paths from `phala docs search`/`phala docs tree` or docs.phala.com URLs.",
+	stability: "unstable",
+	arguments: [
+		{
+			name: "page...",
+			description:
+				"Page path (e.g. /phala-cloud/getting-started) or docs.phala.com URL",
+			required: true,
+			variadic: true,
+			target: "pages",
+		},
+	],
+	options: [jsonOption],
+	examples: [
+		{
+			name: "Read a page by path",
+			value: "phala docs read /dstack/getting-started",
+		},
+		{
+			name: "Read a page by URL",
+			value:
+				"phala docs read https://docs.phala.com/phala-cloud/getting-started/overview",
+		},
+		{
+			name: "Read multiple pages",
+			value: "phala docs read /dstack/overview /dstack/faqs",
+		},
+	],
+};
+
+export const docsReadCommandSchema = z.object({
+	pages: z.array(z.string()).min(1),
+	json: z.boolean().default(false),
+});
+
+export type DocsReadCommandInput = z.infer<typeof docsReadCommandSchema>;

--- a/cli/src/commands/docs/read/index.ts
+++ b/cli/src/commands/docs/read/index.ts
@@ -1,0 +1,118 @@
+import { defineCommand } from "@/src/core/define-command";
+import type { CommandContext } from "@/src/core/types";
+import {
+	type DocsFsResult,
+	type DocsToolOptions,
+	normalizeDocPath,
+	resolveDocsMcpUrl,
+	runDocsFsCommand,
+	shellQuote,
+} from "@/src/lib/docs-mcp";
+import {
+	type DocsReadCommandInput,
+	docsReadCommandMeta,
+	docsReadCommandSchema,
+} from "./command";
+
+interface PageResult {
+	readonly page: string;
+	readonly resolvedPath: string;
+	readonly content: string | null;
+	readonly error: string | null;
+}
+
+/** Pages are stored as .mdx files; directories index as <dir>/index.mdx. */
+function candidatePaths(path: string): string[] {
+	if (/\.[a-z0-9]+$/i.test(path)) {
+		return [path];
+	}
+	return [`${path}.mdx`, path, `${path}/index.mdx`];
+}
+
+async function readPage(
+	page: string,
+	options: DocsToolOptions,
+): Promise<PageResult> {
+	const normalized = normalizeDocPath(page);
+	const candidates = candidatePaths(normalized);
+	let lastFailure: DocsFsResult | null = null;
+	for (const candidate of candidates) {
+		const result = await runDocsFsCommand(
+			`cat ${shellQuote(candidate)}`,
+			options,
+		);
+		if (result.exit === 0) {
+			return {
+				page,
+				resolvedPath: candidate,
+				content: result.stdout,
+				error: null,
+			};
+		}
+		lastFailure = result;
+	}
+	const detail =
+		candidates.length === 1 ? lastFailure?.stderr.trim() : undefined;
+	return {
+		page,
+		resolvedPath: normalized,
+		content: null,
+		error:
+			detail ||
+			`Page not found: ${normalized}. Find pages with \`phala docs search <query>\` or \`phala docs tree\`.`,
+	};
+}
+
+async function runDocsReadCommand(
+	input: DocsReadCommandInput,
+	context: CommandContext,
+): Promise<number> {
+	const options = { url: resolveDocsMcpUrl(context.env) };
+	try {
+		const results: PageResult[] = [];
+		for (const page of input.pages) {
+			results.push(await readPage(page, options));
+		}
+
+		const failed = results.filter((result) => result.error !== null);
+		if (input.json) {
+			if (failed.length === results.length) {
+				context.fail(failed[0].error ?? "Failed to read docs", { results });
+				return 1;
+			}
+			context.success({ pages: results });
+			return 0;
+		}
+
+		for (const result of results) {
+			if (results.length > 1) {
+				context.stdout.write(`==> ${result.resolvedPath} <==\n`);
+			}
+			if (result.content !== null) {
+				context.stdout.write(
+					result.content.endsWith("\n")
+						? result.content
+						: `${result.content}\n`,
+				);
+			} else {
+				context.stderr.write(`${result.error}\n`);
+			}
+			if (results.length > 1) {
+				context.stdout.write("\n");
+			}
+		}
+		return failed.length > 0 ? 1 : 0;
+	} catch (error) {
+		context.fail(error instanceof Error ? error.message : String(error));
+		return 1;
+	}
+}
+
+export const docsReadCommand = defineCommand({
+	path: ["docs", "read"],
+	meta: docsReadCommandMeta,
+	schema: docsReadCommandSchema,
+	handler: runDocsReadCommand,
+});
+
+export default docsReadCommand;

--- a/cli/src/commands/docs/search/command.ts
+++ b/cli/src/commands/docs/search/command.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import { jsonOption } from "@/src/core/common-flags";
+import type { CommandMeta } from "@/src/core/types";
+
+export const docsSearchCommandMeta: CommandMeta = {
+	name: "search",
+	category: "advanced",
+	description:
+		"Search the live Phala documentation. Returns titles, links, and content excerpts. Use `phala docs read <page>` to read a full page.",
+	stability: "unstable",
+	arguments: [
+		{
+			name: "query...",
+			description: "Search query (multiple words are joined)",
+			required: true,
+			variadic: true,
+			target: "query",
+		},
+	],
+	options: [jsonOption],
+	examples: [
+		{
+			name: "Search the docs",
+			value: "phala docs search deploy a CVM with GPU",
+		},
+		{
+			name: "Search and output JSON",
+			value: 'phala docs search "on-chain KMS" --json',
+		},
+	],
+};
+
+export const docsSearchCommandSchema = z.object({
+	query: z.array(z.string()).min(1),
+	json: z.boolean().default(false),
+});
+
+export type DocsSearchCommandInput = z.infer<typeof docsSearchCommandSchema>;

--- a/cli/src/commands/docs/search/index.ts
+++ b/cli/src/commands/docs/search/index.ts
@@ -1,0 +1,49 @@
+import { defineCommand } from "@/src/core/define-command";
+import type { CommandContext } from "@/src/core/types";
+import { callDocsTool, resolveDocsMcpUrl } from "@/src/lib/docs-mcp";
+import {
+	type DocsSearchCommandInput,
+	docsSearchCommandMeta,
+	docsSearchCommandSchema,
+} from "./command";
+
+async function runDocsSearchCommand(
+	input: DocsSearchCommandInput,
+	context: CommandContext,
+): Promise<number> {
+	const query = input.query.join(" ");
+	try {
+		const results = await callDocsTool(
+			"search_phala",
+			{ query },
+			{ url: resolveDocsMcpUrl(context.env) },
+		);
+		if (input.json) {
+			context.success({ query, results });
+			return 0;
+		}
+		if (!results.trim()) {
+			context.stdout.write(
+				`No results for "${query}". Try broader terms, or explore with \`phala docs tree\`.\n`,
+			);
+			return 0;
+		}
+		context.stdout.write(results.endsWith("\n") ? results : `${results}\n`);
+		context.stdout.write(
+			"\nTip: read a full page with `phala docs read <page path>`.\n",
+		);
+		return 0;
+	} catch (error) {
+		context.fail(error instanceof Error ? error.message : String(error));
+		return 1;
+	}
+}
+
+export const docsSearchCommand = defineCommand({
+	path: ["docs", "search"],
+	meta: docsSearchCommandMeta,
+	schema: docsSearchCommandSchema,
+	handler: runDocsSearchCommand,
+});
+
+export default docsSearchCommand;

--- a/cli/src/commands/docs/tree/command.ts
+++ b/cli/src/commands/docs/tree/command.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import { jsonOption } from "@/src/core/common-flags";
+import type { CommandMeta } from "@/src/core/types";
+
+export const docsTreeCommandMeta: CommandMeta = {
+	name: "tree",
+	category: "advanced",
+	description:
+		"Show the structure of the Phala documentation site as a directory tree",
+	stability: "unstable",
+	arguments: [
+		{
+			name: "path",
+			description: "Docs path to start from (default: /)",
+			required: false,
+			target: "path",
+		},
+	],
+	options: [
+		{
+			name: "depth",
+			shorthand: "L",
+			description: "Maximum depth to display (default: 2)",
+			type: "number",
+			target: "depth",
+		},
+		jsonOption,
+	],
+	examples: [
+		{
+			name: "Show the top-level docs structure",
+			value: "phala docs tree",
+		},
+		{
+			name: "Explore a section in depth",
+			value: "phala docs tree /phala-cloud --depth 3",
+		},
+	],
+};
+
+export const docsTreeCommandSchema = z.object({
+	path: z.string().optional(),
+	depth: z.coerce.number().int().min(1).max(10).default(2),
+	json: z.boolean().default(false),
+});
+
+export type DocsTreeCommandInput = z.infer<typeof docsTreeCommandSchema>;

--- a/cli/src/commands/docs/tree/index.ts
+++ b/cli/src/commands/docs/tree/index.ts
@@ -1,0 +1,53 @@
+import { defineCommand } from "@/src/core/define-command";
+import type { CommandContext } from "@/src/core/types";
+import {
+	normalizeDocPath,
+	resolveDocsMcpUrl,
+	runDocsFsCommand,
+	shellQuote,
+} from "@/src/lib/docs-mcp";
+import {
+	type DocsTreeCommandInput,
+	docsTreeCommandMeta,
+	docsTreeCommandSchema,
+} from "./command";
+
+async function runDocsTreeCommand(
+	input: DocsTreeCommandInput,
+	context: CommandContext,
+): Promise<number> {
+	const path = input.path ? normalizeDocPath(input.path) : "/";
+	try {
+		const result = await runDocsFsCommand(
+			`tree ${shellQuote(path)} -L ${input.depth}`,
+			{ url: resolveDocsMcpUrl(context.env) },
+		);
+		if (result.exit !== 0) {
+			context.fail(result.stderr.trim() || `Failed to list ${path}`);
+			return 1;
+		}
+		if (input.json) {
+			context.success({ path, depth: input.depth, tree: result.stdout });
+			return 0;
+		}
+		context.stdout.write(
+			result.stdout.endsWith("\n") ? result.stdout : `${result.stdout}\n`,
+		);
+		context.stdout.write(
+			"\nTip: read a page with `phala docs read <path>`; search with `phala docs search <query>`.\n",
+		);
+		return 0;
+	} catch (error) {
+		context.fail(error instanceof Error ? error.message : String(error));
+		return 1;
+	}
+}
+
+export const docsTreeCommand = defineCommand({
+	path: ["docs", "tree"],
+	meta: docsTreeCommandMeta,
+	schema: docsTreeCommandSchema,
+	handler: runDocsTreeCommand,
+});
+
+export default docsTreeCommand;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -10,6 +10,7 @@ import { authCommands } from "./commands/auth";
 import { configCommands } from "./commands/config";
 import { cvmsCommands } from "./commands/cvms";
 import { deployCommand } from "./commands/deploy";
+import { docsCommands } from "./commands/docs";
 import { envsCommands } from "./commands/envs";
 import { helpCommand } from "./commands/help";
 import { linkCommand } from "./commands/link";
@@ -100,6 +101,11 @@ for (const command of authCommands.commands) {
 
 registry.registerGroup(configCommands.group);
 for (const command of configCommands.commands) {
+	registry.registerCommand(command);
+}
+
+registry.registerGroup(docsCommands.group);
+for (const command of docsCommands.commands) {
 	registry.registerCommand(command);
 }
 

--- a/cli/src/lib/docs-mcp.test.ts
+++ b/cli/src/lib/docs-mcp.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeDocPath, parseDocsFsOutput, shellQuote } from "./docs-mcp";
+
+describe("parseDocsFsOutput", () => {
+	test("parses stdout-only output", () => {
+		const result = parseDocsFsOutput("exit: 0\n--- stdout ---\nhello\nworld\n");
+		expect(result.exit).toBe(0);
+		expect(result.stdout).toBe("hello\nworld\n");
+		expect(result.stderr).toBe("");
+	});
+
+	test("parses stderr-only output", () => {
+		const result = parseDocsFsOutput(
+			"exit: 1\n--- stderr ---\ncat: /x: No such file or directory\n",
+		);
+		expect(result.exit).toBe(1);
+		expect(result.stdout).toBe("");
+		expect(result.stderr).toBe("cat: /x: No such file or directory\n");
+	});
+
+	test("parses combined stdout and stderr", () => {
+		const result = parseDocsFsOutput(
+			"exit: 2\n--- stdout ---\npartial\n--- stderr ---\noops\n",
+		);
+		expect(result.exit).toBe(2);
+		expect(result.stdout).toBe("partial");
+		expect(result.stderr).toBe("oops\n");
+	});
+
+	test("passes through unmarked output", () => {
+		const result = parseDocsFsOutput("just text");
+		expect(result.exit).toBe(0);
+		expect(result.stdout).toBe("just text");
+	});
+});
+
+describe("shellQuote", () => {
+	test("wraps in single quotes", () => {
+		expect(shellQuote("hello world")).toBe("'hello world'");
+	});
+
+	test("escapes embedded single quotes", () => {
+		expect(shellQuote("it's")).toBe(`'it'\\''s'`);
+	});
+});
+
+describe("normalizeDocPath", () => {
+	test("strips docs.phala.com URLs", () => {
+		expect(
+			normalizeDocPath("https://docs.phala.com/phala-cloud/getting-started"),
+		).toBe("/phala-cloud/getting-started");
+	});
+
+	test("adds a leading slash", () => {
+		expect(normalizeDocPath("dstack/overview")).toBe("/dstack/overview");
+	});
+
+	test("drops anchors and query strings", () => {
+		expect(normalizeDocPath("/quickstart#step-2?x=1")).toBe("/quickstart");
+	});
+});

--- a/cli/src/lib/docs-mcp.ts
+++ b/cli/src/lib/docs-mcp.ts
@@ -1,0 +1,185 @@
+/**
+ * Minimal client for the hosted Phala docs MCP server (https://docs.phala.com/mcp).
+ *
+ * The server is a stateless streamable-HTTP MCP endpoint: each tools/call is a
+ * single JSON-RPC POST, answered either as plain JSON or as an SSE frame.
+ * No session handshake is required, so we speak the wire format directly
+ * instead of pulling in an MCP client library.
+ */
+
+const DEFAULT_DOCS_MCP_URL = "https://docs.phala.com/mcp";
+
+export function resolveDocsMcpUrl(
+	env: NodeJS.ProcessEnv = process.env,
+): string {
+	return env.PHALA_DOCS_MCP_URL || DEFAULT_DOCS_MCP_URL;
+}
+
+export interface DocsToolOptions {
+	readonly url?: string;
+}
+
+interface JsonRpcMessage {
+	result?: {
+		isError?: boolean;
+		content?: Array<{ type?: string; text?: string }>;
+	};
+	error?: { code?: number; message?: string };
+}
+
+function parseJsonRpcResponse(body: string): JsonRpcMessage {
+	const trimmed = body.trim();
+	if (trimmed.startsWith("{")) {
+		return JSON.parse(trimmed) as JsonRpcMessage;
+	}
+	// SSE framing: keep the last `data:` line that parses as JSON
+	let last: JsonRpcMessage | undefined;
+	for (const line of trimmed.split("\n")) {
+		if (!line.startsWith("data:")) continue;
+		try {
+			last = JSON.parse(line.slice(5).trim()) as JsonRpcMessage;
+		} catch {
+			// ignore non-JSON data lines (e.g. keep-alives)
+		}
+	}
+	if (!last) {
+		throw new Error("Unexpected response from the docs server");
+	}
+	return last;
+}
+
+export async function callDocsTool(
+	name: string,
+	args: Record<string, unknown>,
+	options: DocsToolOptions = {},
+): Promise<string> {
+	const url = options.url ?? resolveDocsMcpUrl();
+	let response: Response;
+	try {
+		response = await fetch(url, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Accept: "application/json, text/event-stream",
+			},
+			body: JSON.stringify({
+				jsonrpc: "2.0",
+				id: 1,
+				method: "tools/call",
+				params: { name, arguments: args },
+			}),
+		});
+	} catch (error) {
+		throw new Error(
+			`Could not reach the Phala docs server at ${url}. Check your network connection, or browse https://docs.phala.com directly. (${
+				error instanceof Error ? error.message : String(error)
+			})`,
+		);
+	}
+	if (!response.ok) {
+		throw new Error(
+			`Phala docs server returned HTTP ${response.status}. Try again shortly, or browse https://docs.phala.com directly.`,
+		);
+	}
+	const message = parseJsonRpcResponse(await response.text());
+	if (message.error) {
+		throw new Error(
+			`Docs server error: ${message.error.message ?? JSON.stringify(message.error)}`,
+		);
+	}
+	const content = message.result?.content;
+	const text = Array.isArray(content)
+		? content
+				.filter(
+					(item) => item?.type === "text" && typeof item.text === "string",
+				)
+				.map((item) => item.text)
+				.join("\n")
+		: "";
+	if (message.result?.isError) {
+		throw new Error(text || "Docs tool call failed");
+	}
+	return text;
+}
+
+export interface DocsFsResult {
+	readonly exit: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+/**
+ * The filesystem tool wraps command output as:
+ *
+ *   exit: 0
+ *   --- stdout ---
+ *   ...
+ *   --- stderr ---
+ *   ...
+ *
+ * Either section may be absent.
+ */
+export function parseDocsFsOutput(text: string): DocsFsResult {
+	let exit = 0;
+	let rest = text;
+	const exitMatch = text.match(/^exit:\s*(-?\d+)\r?\n?/);
+	if (exitMatch) {
+		exit = Number(exitMatch[1]);
+		rest = text.slice(exitMatch[0].length);
+	}
+
+	let section: "stdout" | "stderr" | null = null;
+	const out: string[] = [];
+	const err: string[] = [];
+	for (const line of rest.split("\n")) {
+		if (line === "--- stdout ---") {
+			section = "stdout";
+			continue;
+		}
+		if (line === "--- stderr ---") {
+			section = "stderr";
+			continue;
+		}
+		if (section === "stderr") {
+			err.push(line);
+		} else if (section === "stdout") {
+			out.push(line);
+		}
+	}
+	if (section === null) {
+		return { exit, stdout: rest, stderr: "" };
+	}
+	return { exit, stdout: out.join("\n"), stderr: err.join("\n") };
+}
+
+export async function runDocsFsCommand(
+	command: string,
+	options: DocsToolOptions = {},
+): Promise<DocsFsResult> {
+	const text = await callDocsTool(
+		"query_docs_filesystem_phala",
+		{ command },
+		options,
+	);
+	return parseDocsFsOutput(text);
+}
+
+/** Single-quote a value for the docs virtual filesystem shell. */
+export function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Normalize a docs page reference to a virtual filesystem path.
+ * Accepts full docs.phala.com URLs, paths with or without a leading slash,
+ * and strips anchors/query strings.
+ */
+export function normalizeDocPath(input: string): string {
+	let path = input.trim();
+	path = path.replace(/^https?:\/\/docs\.phala\.com/i, "");
+	path = path.split("#")[0].split("?")[0];
+	if (!path.startsWith("/")) {
+		path = `/${path}`;
+	}
+	return path;
+}


### PR DESCRIPTION
## Summary

Adds a `phala docs` command group so users — and especially AI coding agents driving the CLI — can explore everything on **docs.phala.com** directly from the terminal, with zero setup. No MCP registration, no links to paste: if the agent has the `phala` CLI, it has the current docs.

| Command | What it does |
|---|---|
| `phala docs search <query>` | Relevance-ranked full-text search (titles, links, excerpts) |
| `phala docs read <page>` | Read full pages by path or `docs.phala.com` URL |
| `phala docs tree [path] -L <depth>` | Browse the docs site as a directory tree |
| `phala docs grep <pattern> [path]` | Ripgrep across all docs content (`--files` for paths only) |
| `phala docs feedback <page> <msg>` | Report incorrect/outdated docs to the docs team |

All subcommands support `--json`, require no authentication, exit non-zero with actionable hints on failure, and human output cross-links the sibling subcommands so an agent that discovers one discovers them all.

## How it works

The hosted docs MCP server (`https://docs.phala.com/mcp`) is a **stateless** streamable-HTTP endpoint, so each call is a single JSON-RPC POST — implemented in a ~180-line wire-format client (`cli/src/lib/docs-mcp.ts`) with no MCP SDK dependency.

- `search` uses the server's `search_phala` tool
- `read` / `tree` / `grep` use `query_docs_filesystem_phala`, a virtual filesystem over the published docs that accepts `cat` / `tree` / `rg` commands
- `read` normalizes URLs → paths, strips anchors, and auto-resolves `page` → `page.mdx` → `page/index.mdx`
- `PHALA_DOCS_MCP_URL` overrides the endpoint

Because everything is served live, docs updates are visible to the CLI immediately — bundled `phala help` topics stay version-pinned to the installed CLI, while `phala docs` is the freshness channel.

## Testing

- Unit tests for the filesystem-output parser, shell quoting, and path normalization (`cli/src/lib/docs-mcp.test.ts`)
- Full CLI suite: 416 pass / 0 fail; biome format + lint clean; `tsc --noEmit` clean
- Live-tested against docs.phala.com: search, tree, read (path + URL + fallback resolution), grep (`--files`), JSON mode, and error paths (missing page, bad tree path) all verified

## Follow-ups (not in this PR)

- Mention `phala docs` in the top-level `--help` epilogue and in error remediation hints
- Document it in `skills/phala-cli/SKILL.md` so agents learn about it up front

🤖 Generated with [Claude Code](https://claude.com/claude-code)