### PR TITLE
fix(cli): harden phala docs grep pattern passing and MCP request timeout

### DIFF
--- a/cli/src/commands/docs/feedback/index.ts
+++ b/cli/src/commands/docs/feedback/index.ts
@@ -3,7 +3,7 @@ import type { CommandContext } from "@/src/core/types";
 import {
 	callDocsTool,
 	normalizeDocPath,
-	resolveDocsMcpUrl,
+	resolveDocsToolOptions,
 } from "@/src/lib/docs-mcp";
 import {
 	type DocsFeedbackCommandInput,
@@ -21,7 +21,7 @@ async function runDocsFeedbackCommand(
 		const response = await callDocsTool(
 			"submit_feedback",
 			{ path, feedback },
-			{ url: resolveDocsMcpUrl(context.env) },
+			resolveDocsToolOptions(context),
 		);
 		if (input.json) {
 			context.success({ path, feedback, response });

--- a/cli/src/commands/docs/grep/index.ts
+++ b/cli/src/commands/docs/grep/index.ts
@@ -20,7 +20,7 @@ async function runDocsGrepCommand(
 	const flags = input.files ? "-Sl" : "-Sn";
 	try {
 		const result = await runDocsFsCommand(
-			`rg ${flags} ${shellQuote(input.pattern)} ${shellQuote(path)}`,
+			`rg ${flags} -e ${shellQuote(input.pattern)} ${shellQuote(path)}`,
 			{ url: resolveDocsMcpUrl(context.env) },
 		);
 		// rg exits 1 on "no matches" with empty stderr

--- a/cli/src/commands/docs/grep/index.ts
+++ b/cli/src/commands/docs/grep/index.ts
@@ -2,7 +2,7 @@ import { defineCommand } from "@/src/core/define-command";
 import type { CommandContext } from "@/src/core/types";
 import {
 	normalizeDocPath,
-	resolveDocsMcpUrl,
+	resolveDocsToolOptions,
 	runDocsFsCommand,
 	shellQuote,
 } from "@/src/lib/docs-mcp";
@@ -21,7 +21,7 @@ async function runDocsGrepCommand(
 	try {
 		const result = await runDocsFsCommand(
 			`rg ${flags} -e ${shellQuote(input.pattern)} ${shellQuote(path)}`,
-			{ url: resolveDocsMcpUrl(context.env) },
+			resolveDocsToolOptions(context),
 		);
 		// rg exits 1 on "no matches" with empty stderr
 		if (result.exit !== 0 && result.stderr.trim()) {

--- a/cli/src/commands/docs/read/index.ts
+++ b/cli/src/commands/docs/read/index.ts
@@ -4,7 +4,7 @@ import {
 	type DocsFsResult,
 	type DocsToolOptions,
 	normalizeDocPath,
-	resolveDocsMcpUrl,
+	resolveDocsToolOptions,
 	runDocsFsCommand,
 	shellQuote,
 } from "@/src/lib/docs-mcp";
@@ -67,7 +67,7 @@ async function runDocsReadCommand(
 	input: DocsReadCommandInput,
 	context: CommandContext,
 ): Promise<number> {
-	const options = { url: resolveDocsMcpUrl(context.env) };
+	const options = resolveDocsToolOptions(context);
 	try {
 		const results: PageResult[] = [];
 		for (const page of input.pages) {

--- a/cli/src/commands/docs/search/index.ts
+++ b/cli/src/commands/docs/search/index.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from "@/src/core/define-command";
 import type { CommandContext } from "@/src/core/types";
-import { callDocsTool, resolveDocsMcpUrl } from "@/src/lib/docs-mcp";
+import { callDocsTool, resolveDocsToolOptions } from "@/src/lib/docs-mcp";
 import {
 	type DocsSearchCommandInput,
 	docsSearchCommandMeta,
@@ -16,7 +16,7 @@ async function runDocsSearchCommand(
 		const results = await callDocsTool(
 			"search_phala",
 			{ query },
-			{ url: resolveDocsMcpUrl(context.env) },
+			resolveDocsToolOptions(context),
 		);
 		if (input.json) {
 			context.success({ query, results });

--- a/cli/src/commands/docs/tree/index.ts
+++ b/cli/src/commands/docs/tree/index.ts
@@ -2,7 +2,7 @@ import { defineCommand } from "@/src/core/define-command";
 import type { CommandContext } from "@/src/core/types";
 import {
 	normalizeDocPath,
-	resolveDocsMcpUrl,
+	resolveDocsToolOptions,
 	runDocsFsCommand,
 	shellQuote,
 } from "@/src/lib/docs-mcp";
@@ -20,7 +20,7 @@ async function runDocsTreeCommand(
 	try {
 		const result = await runDocsFsCommand(
 			`tree ${shellQuote(path)} -L ${input.depth}`,
-			{ url: resolveDocsMcpUrl(context.env) },
+			resolveDocsToolOptions(context),
 		);
 		if (result.exit !== 0) {
 			context.fail(result.stderr.trim() || `Failed to list ${path}`);

--- a/cli/src/lib/docs-mcp.ts
+++ b/cli/src/lib/docs-mcp.ts
@@ -7,7 +7,13 @@
  * instead of pulling in an MCP client library.
  */
 
+import type { CommandContext } from "@/src/core/types";
+import { resolveTimeoutSeconds } from "./client";
+
 const DEFAULT_DOCS_MCP_URL = "https://docs.phala.com/mcp";
+
+/** Default request timeout for docs MCP calls; overridable per call. */
+const DEFAULT_DOCS_TIMEOUT_MS = 60_000;
 
 export function resolveDocsMcpUrl(
 	env: NodeJS.ProcessEnv = process.env,
@@ -17,6 +23,7 @@ export function resolveDocsMcpUrl(
 
 export interface DocsToolOptions {
 	readonly url?: string;
+	readonly timeoutMs?: number;
 }
 
 interface JsonRpcMessage {
@@ -54,10 +61,12 @@ export async function callDocsTool(
 	options: DocsToolOptions = {},
 ): Promise<string> {
 	const url = options.url ?? resolveDocsMcpUrl();
+	const timeoutMs = options.timeoutMs ?? DEFAULT_DOCS_TIMEOUT_MS;
 	let response: Response;
 	try {
 		response = await fetch(url, {
 			method: "POST",
+			signal: AbortSignal.timeout(timeoutMs),
 			headers: {
 				"Content-Type": "application/json",
 				Accept: "application/json, text/event-stream",
@@ -70,6 +79,13 @@ export async function callDocsTool(
 			}),
 		});
 	} catch (error) {
+		if (error instanceof DOMException && error.name === "TimeoutError") {
+			throw new Error(
+				`Phala docs server at ${url} did not respond within ${Math.round(
+					timeoutMs / 1000,
+				)}s. Try again shortly, or browse https://docs.phala.com directly.`,
+			);
+		}
 		throw new Error(
 			`Could not reach the Phala docs server at ${url}. Check your network connection, or browse https://docs.phala.com directly. (${
 				error instanceof Error ? error.message : String(error)
@@ -167,6 +183,19 @@ export async function runDocsFsCommand(
 /** Single-quote a value for the docs virtual filesystem shell. */
 export function shellQuote(value: string): string {
 	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Build DocsToolOptions from a command context: docs server URL from the
+ * environment, request timeout from the global --timeout flag.
+ */
+export function resolveDocsToolOptions(
+	context: CommandContext,
+): DocsToolOptions {
+	return {
+		url: resolveDocsMcpUrl(context.env),
+		timeoutMs: resolveTimeoutSeconds(context) * 1000,
+	};
 }
 
 /**

--- a/cli/test/interface-compat/error-messages.test.ts
+++ b/cli/test/interface-compat/error-messages.test.ts
@@ -85,12 +85,18 @@ describe("CLI Interface Compatibility - Error Handling (v1.0.40 baseline)", () =
 		];
 
 		for (const { cmd, reason, timeout } of errorTests) {
-			test(`${reason}: ${cmd.split(" ")[0]}`, async () => {
-				const result = await runCommand(cmd, { expectError: true, timeout });
+			// Give bun's test timeout headroom above the execa timeout; the
+			// default 5s is shorter than the 10s some cases allow the command.
+			test(
+				`${reason}: ${cmd.split(" ")[0]}`,
+				async () => {
+					const result = await runCommand(cmd, { expectError: true, timeout });
 
-				expect(result.exitCode).toBeGreaterThan(0);
-				expect((result.stdout + result.stderr).length).toBeGreaterThan(0);
-			});
+					expect(result.exitCode).toBeGreaterThan(0);
+					expect((result.stdout + result.stderr).length).toBeGreaterThan(0);
+				},
+				(timeout ?? 3000) + 5000,
+			);
 		}
 	});
 


### PR DESCRIPTION
## Summary

Review follow-ups from #485 (which merged before these could land):

- **`docs grep`: pass the pattern via `-e`.** A pattern starting with `-` would otherwise be parsed by rg as flags (e.g. `-foo` becomes `-f oo` and fails with a confusing "No such file or directory" error). `--` was considered first, but the docs virtual filesystem shell does not support it (verified live: `rg ... --` returns "unrecognized option '--'"), while `-e` works for both regular and dash-leading patterns.
- **docs MCP calls now have a request timeout.** Every call previously used a bare `fetch` with no timeout, so a hung docs server would block the CLI indefinitely -- especially painful for agent-driven usage. `callDocsTool` applies `AbortSignal.timeout` (default 60s, matching the CLI-wide default, overridable per call), and a new `resolveDocsToolOptions` helper wires the global `--timeout` flag into all five docs subcommands. Timeout failures get a distinct, actionable error message instead of the generic network-error one.
- **test fix:** the `errorTests` loop in `error-messages.test.ts` allows cases up to 10s via the execa timeout, but bun:test kills any test at its default 5s. Cases with a real API round trip (e.g. `cvms get invalid-id-format`) exceed 5s on slower networks and fail locally / in the pre-commit hook despite correct behavior. Each case now gets a bun timeout 5s above its execa timeout. CI was unaffected because its API latency is lower.

## Testing

- `bun run fmt / lint / type-check / test` all clean (469 tests, 0 fail)
- pre-commit hooks pass locally (previously blocked by the 5s bun test timeout described above)
- Live smoke tests against docs.phala.com:
  - `phala docs grep --files PHALA_CLOUD_API_KEY` works unchanged
  - server-side `rg -Sn -e '-foo' /` returns exit 1 (no matches) instead of the flag-parsing error
  - `PHALA_DOCS_MCP_URL=http://10.255.255.1/mcp phala docs search test --timeout 2` aborts in ~2.3s with: "Phala docs server at ... did not respond within 2s. Try again shortly, or browse https://docs.phala.com directly."
