### PR TITLE
fix(cli): preserve repeated API query parameters

### DIFF
--- a/cli/src/commands/api/index.ts
+++ b/cli/src/commands/api/index.ts
@@ -61,19 +61,27 @@ function parseJsonValue(value: string): unknown {
  * Parse -f query params into key=value pairs.
  * Supports @file syntax: key=@file.txt reads file content as value.
  */
+type QueryParamValue = string | string[];
+
 function parseQueryParams(
 	fields: string[] | undefined,
-): Record<string, string> {
-	const result: Record<string, string> = {};
+): Record<string, QueryParamValue> {
+	const result: Record<string, QueryParamValue> = {};
 	for (const field of fields ?? []) {
 		const eqIdx = field.indexOf("=");
 		if (eqIdx > 0) {
 			const key = field.slice(0, eqIdx);
-			const value = field.slice(eqIdx + 1);
-			if (value.startsWith("@")) {
-				result[key] = readFileContent(value.slice(1));
-			} else {
+			const rawValue = field.slice(eqIdx + 1);
+			const value = rawValue.startsWith("@")
+				? readFileContent(rawValue.slice(1))
+				: rawValue;
+			const existing = result[key];
+			if (existing === undefined) {
 				result[key] = value;
+			} else if (Array.isArray(existing)) {
+				existing.push(value);
+			} else {
+				result[key] = [existing, value];
 			}
 		}
 	}
@@ -271,7 +279,9 @@ export function resolveRequest(
 	if (Object.keys(queryParams).length > 0) {
 		const params = new URLSearchParams();
 		for (const [key, value] of Object.entries(queryParams)) {
-			params.append(key, value);
+			for (const item of Array.isArray(value) ? value : [value]) {
+				params.append(key, item);
+			}
 		}
 		const separator = finalEndpoint.includes("?") ? "&" : "?";
 		finalEndpoint = `${finalEndpoint}${separator}${params.toString()}`;

--- a/cli/test/commands/api-request-body.test.ts
+++ b/cli/test/commands/api-request-body.test.ts
@@ -223,6 +223,15 @@ describe("resolveRequest - -f query params", () => {
 		expect(result.body).toBeUndefined();
 	});
 
+	test("-f preserves repeated query keys", () => {
+		const result = resolveRequest(
+			baseInput({ query: ["compose_q=runner", "compose_q=base64"] }),
+			"/cvms",
+		);
+
+		expect(result.endpoint).toBe("/cvms?compose_q=runner&compose_q=base64");
+	});
+
 	test("-f appends with & when URL already has query string", () => {
 		const result = resolveRequest(
 			baseInput({ query: ["page=2"] }),


### PR DESCRIPTION
## Summary
- preserve repeated  query keys in Usage: phala api [options] <endpoint>

Make an authenticated HTTP request to Phala Cloud API.

The endpoint should be an API path like "/cvms" or "/users/me".

Use -f key=value to add query parameters (appended to the URL for any method).
Use -F key=value or -F key:=value to add body fields (sent as JSON body).
-F supports both string values (key=value) and typed JSON values (key:=value
for numbers, booleans, null, arrays, objects). Both -f and -F support @file
syntax: -f q=@query.txt, -F config:=@data.json.

Use -d to send raw request body data (cURL-style). If the value is valid JSON,
it will be sent as JSON automatically.

Use --input to send a JSON file as request body, or --input - to read from stdin.

-f (query) can be combined with -F/-d/--input (body). -F, -d, and --input
are mutually exclusive.

Use -q to filter JSON output with jq syntax (built-in, no jq installation needed).

ENVIRONMENT VARIABLES

  PHALA_CLOUD_API_KEY       Override the API key (useful for CI/CD)
  PHALA_CLOUD_API_PREFIX    Override the API base URL [UNSTABLE]

Arguments:
  <endpoint>        API endpoint path

Global options:
  -h, --help              Show help information for the current command
  -v, --version           Show CLI version
  --api-token TOKEN, --api-key TOKEN  API token for authenticating with Phala Cloud
  -j, --json, --no-json   Output in JSON format
  --interactive           Enable interactive mode for commands that support it
  --cvm-id <value>        CVM identifier (UUID, app_id, instance_id, or name)
  --api-version <value>   API version to use (e.g. 2026-01-21, 2026-05-22, 2026-06-23)
  --timeout SECONDS       Request timeout in seconds (default 60)

Basic options:
  -X, --method <value>    HTTP method (default: GET)
  -f, --query <value>     Query parameter: key=value (use key=@file to read from file)
  -F, --field <value>     Body field: key=value (string) or key:=value (typed JSON). Supports @file
  -H, --header <value>    HTTP header: key:value
  -d, --data <value>      Request body data (cURL-style)
  --input <value>         Read body from file (use "-" for stdin)
  -i, --include           Print response headers
  -q, --jq <value>        Filter output with jq expression
  --silent                Don't print response body

Examples:
  # List CVMs
  phala api /cvms
  # Get CVM by app ID
  phala api /cvms/app_xxx
  # Filter with jq
  phala api /cvms -q '.items[].name'
  # GET with query params
  phala api /endpoint -f status=active -f page=2
  # POST with body fields
  phala api /endpoint -X POST -F name=foo -F count:=10
  # POST with cURL-style -d
  phala api /endpoint -X POST -d '{"foo":"bar"}'
  # POST from file
  phala api /endpoint -X POST --input data.json
  # Query params + body combined
  phala api /endpoint -X POST -f page=1 -F name=foo
  # Body field from file
  phala api /endpoint -X POST -F config:=@settings.json
  # Show response headers
  phala api /cvms -i
- append every repeated value to the request URL
- add regression coverage for repeated  parameters

## Validation
- 
- 
ERROR: JAVA_HOME is set to an invalid directory: /Library/Java/JavaVirtualMachines/jdk1.8.0_261.jdk/Contents/Home

Please set the JAVA_HOME variable in your environment to match the
location of your Java installation.
- 
- bun test v1.3.14 (0d9b296a)

⚠️  Integration tests skipped!

To run integration tests:
1. Set PHALA_CLOUD_API_KEY environment variable with a valid API key
2. Optionally set PHALA_CLOUD_API_PREFIX (defaults to production)
3. Run: vitest getCurrentUser.integration.test.ts

Example:
export PHALA_CLOUD_API_KEY="your-api-key"
export PHALA_CLOUD_API_PREFIX="https://staging-api.phala.network/v1"
vitest getCurrentUser.integration.test.ts
  
[dotenv@17.2.3] injecting env (0) from .env -- tip: ✅ audit secrets and track compliance: https://dotenvx.com/ops

⚠️  E2E Full Lifecycle tests skipped!
Set PHALA_CLOUD_API_KEY environment variable to run these tests.

[dotenv@17.2.3] injecting env (0) from .env -- tip: ⚙️  write to custom object with { processEnv: myObject }

⚠️  Nodes list test skipped!
Set PHALA_CLOUD_API_KEY environment variable to run this test.


⚠️  Integration tests for provisionCvm skipped!
Set PHALA_CLOUD_API_KEY and ensure node_id/image/compose_file are valid to run.


⚠️  Integration tests for commitCvmProvision skipped!
Set PHALA_CLOUD_API_KEY to run E2E tests.

  - existing (458 passed, 12 skipped)