### PR TITLE
feat(sdk): sync Python and Go SDKs with JS changes since js-v0.2.9

### DIFF
--- a/go/client.go
+++ b/go/client.go
@@ -25,7 +25,7 @@ func NewClient(opts ...Option) (*Client, error) {
 	c := &Client{
 		baseURL:    DefaultBaseURL,
 		apiVersion: DefaultAPIVersion,
-		httpClient: &http.Client{},
+		httpClient: &http.Client{Timeout: DefaultTimeout},
 		userAgent:  "phala-cloud-sdk-go/" + sdkVersion,
 		headers:    make(map[string]string),
 		maxRetries: 30,

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -176,3 +176,27 @@ func TestWithTimeout(t *testing.T) {
 		t.Errorf("timeout = %v, want 30s", c.httpClient.Timeout)
 	}
 }
+
+// TestDefaultTimeout pins the 60s per-request timeout shared with the JS and
+// Python SDKs. Go's zero-valued http.Client means no timeout at all, so a
+// hung connection used to block a caller forever.
+func TestDefaultTimeout(t *testing.T) {
+	client, err := NewClient(WithAPIKey("k"))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if client.httpClient.Timeout != DefaultTimeout {
+		t.Fatalf("timeout = %v, want %v", client.httpClient.Timeout, DefaultTimeout)
+	}
+	if DefaultTimeout != 60*time.Second {
+		t.Fatalf("DefaultTimeout = %v, want 60s", DefaultTimeout)
+	}
+
+	overridden, err := NewClient(WithAPIKey("k"), WithTimeout(5*time.Second))
+	if err != nil {
+		t.Fatalf("NewClient with timeout: %v", err)
+	}
+	if overridden.httpClient.Timeout != 5*time.Second {
+		t.Fatalf("overridden timeout = %v, want 5s", overridden.httpClient.Timeout)
+	}
+}

--- a/go/cvms_compose.go
+++ b/go/cvms_compose.go
@@ -116,3 +116,56 @@ func (c *Client) UpdatePreLaunchScript(ctx context.Context, cvmID, script string
 	}
 	return &result, nil
 }
+
+// PreLaunchScriptUpgradeStatus reports whether a CVM runs an unmodified
+// official pre-launch script and whether a newer official version exists.
+// CanUpgrade is the flag callers act on: it is true only when the CVM is on an
+// official script that is not the latest one.
+type PreLaunchScriptUpgradeStatus struct {
+	CurrentHash        *string `json:"current_hash"`
+	LatestOfficialHash string  `json:"latest_official_hash"`
+	IsOfficial         bool    `json:"is_official"`
+	IsLatest           bool    `json:"is_latest"`
+	CanUpgrade         bool    `json:"can_upgrade"`
+}
+
+// GetPreLaunchScriptUpgradeStatus returns the pre-launch script upgrade status for a CVM.
+func (c *Client) GetPreLaunchScriptUpgradeStatus(ctx context.Context, cvmID string) (*PreLaunchScriptUpgradeStatus, error) {
+	var result PreLaunchScriptUpgradeStatus
+	err := c.doWithRetry(ctx, func() error {
+		return c.doJSON(ctx, "GET", cvmPath(cvmID, "pre-launch-script", "upgrade-status"), nil, &result)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// UpgradePreLaunchScript replaces a CVM's pre-launch script with the latest
+// official version. The script content lives server-side, so only the CVM ID is
+// needed.
+//
+// For contract-owned KMS (ETHEREUM/BASE) the first call fails with a 465
+// APIError carrying the compose hash to register on-chain. Use
+// IsComposePrecondition and ComposePrecondition to read it, then retry with
+// opts carrying the compose hash and the registering transaction hash.
+func (c *Client) UpgradePreLaunchScript(ctx context.Context, cvmID string, opts *ComposeUpdateOptions) (*UpdateResult, error) {
+	headers := map[string]string{}
+	if opts != nil {
+		if opts.ComposeHash != "" {
+			headers["X-Compose-Hash"] = opts.ComposeHash
+		}
+		if opts.TransactionHash != "" {
+			headers["X-Transaction-Hash"] = opts.TransactionHash
+		}
+	}
+
+	var result UpdateResult
+	err := c.doWithRetry(ctx, func() error {
+		return c.doText(ctx, "POST", cvmPath(cvmID, "pre-launch-script", "upgrade-to-latest-official"), "", "", headers, &result)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/go/cvms_config_test.go
+++ b/go/cvms_config_test.go
@@ -131,3 +131,123 @@ func TestUpdateResultNoChangeStatus(t *testing.T) {
 		t.Fatalf("CorrelationID = %q, want corr-1", inProgress.CorrelationID)
 	}
 }
+
+func TestGetPreLaunchScriptUpgradeStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/cvms/cvm-123/pre-launch-script/upgrade-status" {
+			t.Errorf("path = %q, want /cvms/cvm-123/pre-launch-script/upgrade-status", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"current_hash":"aaa","latest_official_hash":"bbb","is_official":true,"is_latest":false,"can_upgrade":true}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(WithAPIKey("k"), WithBaseURL(srv.URL))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	status, err := client.GetPreLaunchScriptUpgradeStatus(context.Background(), "cvm-123")
+	if err != nil {
+		t.Fatalf("GetPreLaunchScriptUpgradeStatus: %v", err)
+	}
+	if !status.CanUpgrade {
+		t.Fatal("CanUpgrade = false, want true")
+	}
+	if status.IsLatest {
+		t.Fatal("IsLatest = true, want false")
+	}
+	if status.CurrentHash == nil || *status.CurrentHash != "aaa" {
+		t.Fatalf("CurrentHash = %v, want aaa", status.CurrentHash)
+	}
+	if status.LatestOfficialHash != "bbb" {
+		t.Fatalf("LatestOfficialHash = %q, want bbb", status.LatestOfficialHash)
+	}
+}
+
+func TestUpgradePreLaunchScriptPhases(t *testing.T) {
+	var gotComposeHash, gotTxHash, gotMethod, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotComposeHash = r.Header.Get("X-Compose-Hash")
+		gotTxHash = r.Header.Get("X-Transaction-Hash")
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"status":"in_progress","message":"queued","correlation_id":"corr-1"}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(WithAPIKey("k"), WithBaseURL(srv.URL))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	// Phase 1: no verification headers.
+	result, err := client.UpgradePreLaunchScript(context.Background(), "cvm-123", nil)
+	if err != nil {
+		t.Fatalf("UpgradePreLaunchScript phase 1: %v", err)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/cvms/cvm-123/pre-launch-script/upgrade-to-latest-official" {
+		t.Errorf("path = %q, want the upgrade-to-latest-official path", gotPath)
+	}
+	if gotComposeHash != "" || gotTxHash != "" {
+		t.Errorf("verification headers sent in phase 1: %q / %q", gotComposeHash, gotTxHash)
+	}
+	if result.Status != UpdateStatusInProgress {
+		t.Errorf("Status = %q, want %q", result.Status, UpdateStatusInProgress)
+	}
+	if result.CorrelationID != "corr-1" {
+		t.Errorf("CorrelationID = %q, want corr-1", result.CorrelationID)
+	}
+
+	// Phase 2: retry with the on-chain registration proof.
+	if _, err := client.UpgradePreLaunchScript(context.Background(), "cvm-123", &ComposeUpdateOptions{
+		ComposeHash:     "hash-1",
+		TransactionHash: "0xtx",
+	}); err != nil {
+		t.Fatalf("UpgradePreLaunchScript phase 2: %v", err)
+	}
+	if gotComposeHash != "hash-1" {
+		t.Errorf("X-Compose-Hash = %q, want hash-1", gotComposeHash)
+	}
+	if gotTxHash != "0xtx" {
+		t.Errorf("X-Transaction-Hash = %q, want 0xtx", gotTxHash)
+	}
+}
+
+func TestUpgradePreLaunchScriptSurfaces465(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(465)
+		_, _ = w.Write([]byte(`{"message":"Compose hash verification required","details":[{"field":"compose_hash","value":"hash-1"},{"field":"app_id","value":"app-1"}]}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(WithAPIKey("k"), WithBaseURL(srv.URL))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	_, err = client.UpgradePreLaunchScript(context.Background(), "cvm-123", nil)
+	if err == nil {
+		t.Fatal("UpgradePreLaunchScript returned no error on 465")
+	}
+	apiErr, ok := err.(*APIError)
+	if !ok {
+		t.Fatalf("error type = %T, want *APIError", err)
+	}
+	if !apiErr.IsComposePrecondition() {
+		t.Fatal("IsComposePrecondition() = false, want true")
+	}
+	precondition, ok := apiErr.ComposePrecondition()
+	if !ok {
+		t.Fatal("ComposePrecondition() reported no structured payload")
+	}
+	if precondition.ComposeHash != "hash-1" || precondition.AppID != "app-1" {
+		t.Fatalf("ComposePrecondition() = %+v, want compose_hash hash-1 / app_id app-1", precondition)
+	}
+}

--- a/go/cvms_config_test.go
+++ b/go/cvms_config_test.go
@@ -85,3 +85,22 @@ func TestReplicateCVMForwardsOSImage(t *testing.T) {
 		t.Fatal("os_image present in the body when unset, want it omitted")
 	}
 }
+
+// TestProvisionComposeUpdateComposeUnchanged covers the no-op signal returned
+// when the submitted compose matches the deployed one.
+func TestProvisionComposeUpdateComposeUnchanged(t *testing.T) {
+	var resp ProvisionCVMResponse
+	if err := json.Unmarshal([]byte(`{"app_id":"app-1","compose_hash":"abc"}`), &resp); err != nil {
+		t.Fatalf("unmarshal provision response: %v", err)
+	}
+	if resp.ComposeUnchanged {
+		t.Fatal("ComposeUnchanged = true when absent from the payload, want false")
+	}
+
+	if err := json.Unmarshal([]byte(`{"app_id":"app-1","compose_hash":"abc","compose_unchanged":true}`), &resp); err != nil {
+		t.Fatalf("unmarshal provision response with compose_unchanged: %v", err)
+	}
+	if !resp.ComposeUnchanged {
+		t.Fatal("ComposeUnchanged = false, want true")
+	}
+}

--- a/go/cvms_config_test.go
+++ b/go/cvms_config_test.go
@@ -104,3 +104,30 @@ func TestProvisionComposeUpdateComposeUnchanged(t *testing.T) {
 		t.Fatal("ComposeUnchanged = false, want true")
 	}
 }
+
+// TestUpdateResultNoChangeStatus covers the no-op variant of the compose and
+// pre-launch script update responses. Without a Status field the whole payload
+// decoded to a zero UpdateResult, indistinguishable from an accepted update.
+func TestUpdateResultNoChangeStatus(t *testing.T) {
+	var noChange UpdateResult
+	if err := json.Unmarshal([]byte(`{"status":"no_change","message":"compose unchanged"}`), &noChange); err != nil {
+		t.Fatalf("unmarshal no_change result: %v", err)
+	}
+	if noChange.Status != UpdateStatusNoChange {
+		t.Fatalf("Status = %q, want %q", noChange.Status, UpdateStatusNoChange)
+	}
+	if noChange.Message != "compose unchanged" {
+		t.Fatalf("Message = %q, want %q", noChange.Message, "compose unchanged")
+	}
+
+	var inProgress UpdateResult
+	if err := json.Unmarshal([]byte(`{"status":"in_progress","message":"queued","correlation_id":"corr-1"}`), &inProgress); err != nil {
+		t.Fatalf("unmarshal in_progress result: %v", err)
+	}
+	if inProgress.Status != UpdateStatusInProgress {
+		t.Fatalf("Status = %q, want %q", inProgress.Status, UpdateStatusInProgress)
+	}
+	if inProgress.CorrelationID != "corr-1" {
+		t.Fatalf("CorrelationID = %q, want corr-1", inProgress.CorrelationID)
+	}
+}

--- a/go/cvms_config_test.go
+++ b/go/cvms_config_test.go
@@ -41,3 +41,47 @@ func TestUpdateCVMListed(t *testing.T) {
 		t.Fatalf("UpdateCVMListed: %v", err)
 	}
 }
+
+// TestReplicateCVMForwardsOSImage covers replica OS image selection: the
+// replica can be pinned to a specific image instead of inheriting the source
+// CVM's one.
+func TestReplicateCVMForwardsOSImage(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cvms/cvm-123/replicas" {
+			t.Errorf("path = %q, want /cvms/cvm-123/replicas", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"cvm_ykL5lbAn","name":"cvm-1","status":"starting"}`))
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(WithAPIKey("k"), WithBaseURL(srv.URL))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	nodeID := 42
+	if _, err := client.ReplicateCVM(context.Background(), "cvm-123", &ReplicateCVMOptions{
+		NodeID:  &nodeID,
+		OSImage: "dstack-0.5.4",
+	}); err != nil {
+		t.Fatalf("ReplicateCVM: %v", err)
+	}
+	if got := body["os_image"]; got != "dstack-0.5.4" {
+		t.Fatalf("os_image = %v, want dstack-0.5.4", got)
+	}
+
+	body = nil
+	if _, err := client.ReplicateCVM(context.Background(), "cvm-123", &ReplicateCVMOptions{
+		NodeID: &nodeID,
+	}); err != nil {
+		t.Fatalf("ReplicateCVM without OS image: %v", err)
+	}
+	if _, ok := body["os_image"]; ok {
+		t.Fatal("os_image present in the body when unset, want it omitted")
+	}
+}

--- a/go/nodes_test.go
+++ b/go/nodes_test.go
@@ -191,3 +191,28 @@ func TestProvisionCVMRequest_MarshalResourceMatchingFields(t *testing.T) {
 		t.Error("skip_gateway = false, want true")
 	}
 }
+
+// TestDeviceIDEntryShape pins the current device_ids wire contract: an entry is
+// keyed by (device_id, algorithm_version) alone. The os_image_ids list was
+// dropped from the API and must not reappear in the struct.
+func TestDeviceIDEntryShape(t *testing.T) {
+	var entry DeviceIDEntry
+	if err := json.Unmarshal([]byte(`{"device_id":"0xdev","algorithm_version":"v1","enabled":true}`), &entry); err != nil {
+		t.Fatalf("unmarshal device ID entry: %v", err)
+	}
+	if entry.DeviceID != "0xdev" || entry.AlgorithmVersion != "v1" || !entry.Enabled {
+		t.Fatalf("entry = %+v, want 0xdev / v1 / enabled", entry)
+	}
+
+	encoded, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal device ID entry: %v", err)
+	}
+	var roundTripped map[string]any
+	if err := json.Unmarshal(encoded, &roundTripped); err != nil {
+		t.Fatalf("unmarshal round-tripped entry: %v", err)
+	}
+	if _, ok := roundTripped["os_image_ids"]; ok {
+		t.Fatal("os_image_ids present in the encoded entry, want it gone")
+	}
+}

--- a/go/types_common.go
+++ b/go/types_common.go
@@ -18,8 +18,22 @@ type Paginated[T any] struct {
 	Pages    int `json:"pages"`
 }
 
+// Update result statuses returned by the compose and pre-launch script update
+// endpoints.
+const (
+	UpdateStatusInProgress           = "in_progress"
+	UpdateStatusPreconditionRequired = "precondition_required"
+	UpdateStatusNoChange             = "no_change"
+)
+
 // UpdateResult represents the result of an update operation that may require on-chain confirmation.
 type UpdateResult struct {
+	// Status discriminates the response variants: in_progress (the update was
+	// accepted), precondition_required (the compose hash needs on-chain
+	// registration first) and no_change (the submitted content matches what is
+	// already deployed, so nothing was done).
+	Status string `json:"status,omitempty"`
+
 	// Normal success fields.
 	RequiresOnChainHash *bool  `json:"requires_on_chain_hash,omitempty"`
 	CorrelationID       string `json:"correlation_id,omitempty"`

--- a/go/types_cvms.go
+++ b/go/types_cvms.go
@@ -285,6 +285,10 @@ type ProvisionCVMResponse struct {
 	KMSID                 string `json:"kms_id,omitempty"`
 	KMSContractID         string `json:"kms_contract_id,omitempty"`
 	ComposeHashRegistered bool   `json:"compose_hash_registered,omitempty"`
+	// ComposeUnchanged is set only by ProvisionCVMComposeFileUpdate: true means
+	// the submitted compose matched the deployed one, so the commit step is a
+	// no-op and can be skipped. Always false for a fresh provision.
+	ComposeUnchanged bool `json:"compose_unchanged,omitempty"`
 }
 
 // CommitCVMProvisionRequest is the request for committing a CVM provision.

--- a/go/types_cvms.go
+++ b/go/types_cvms.go
@@ -405,6 +405,9 @@ type CVMActionResponse = CVMActionResponseV20260522
 // ReplicateCVMOptions holds options for replicating a CVM.
 type ReplicateCVMOptions struct {
 	NodeID *int `json:"node_id,omitempty"`
+	// OSImage pins the replica to a specific OS image slug. Empty means the
+	// replica inherits the source CVM's image.
+	OSImage string `json:"os_image,omitempty"`
 }
 
 // PatchCVMRequest is the request for patching a CVM (multi-field update).

--- a/go/types_cvms.go
+++ b/go/types_cvms.go
@@ -332,6 +332,8 @@ type CVMResourceUsage struct {
 	CPUPercent       *float64 `json:"cpu_percent,omitempty"`
 	MemoryUsedBytes  *int64   `json:"memory_used_bytes,omitempty"`
 	MemoryTotalBytes *int64   `json:"memory_total_bytes,omitempty"`
+	DiskUsedBytes    *int64   `json:"disk_used_bytes,omitempty"`
+	DiskTotalBytes   *int64   `json:"disk_total_bytes,omitempty"`
 	EgressBytes      *int64   `json:"egress_bytes,omitempty"`
 }
 

--- a/go/types_cvms.go
+++ b/go/types_cvms.go
@@ -54,6 +54,7 @@ type CVMInfoFields struct {
 	PublicTcbinfo       *bool                  `json:"public_tcbinfo,omitempty"`
 	GatewayEnabled      *bool                  `json:"gateway_enabled,omitempty"`
 	SecureTime          *bool                  `json:"secure_time,omitempty"`
+	ManagedEnv          bool                   `json:"managed_env"`
 	Listed              bool                   `json:"listed"`
 	StorageFS           *string                `json:"storage_fs,omitempty"`
 	Workspace           *WorkspaceRef          `json:"workspace,omitempty"`

--- a/go/types_cvms_test.go
+++ b/go/types_cvms_test.go
@@ -297,3 +297,24 @@ func TestCVMInfoManagedEnv(t *testing.T) {
 		t.Fatal("ManagedEnv = false, want true")
 	}
 }
+
+func TestCVMResourceUsageDiskFields(t *testing.T) {
+	var usage CVMResourceUsage
+	if err := json.Unmarshal([]byte(`{"disk_used_bytes":1024,"disk_total_bytes":8192}`), &usage); err != nil {
+		t.Fatalf("unmarshal resource usage: %v", err)
+	}
+	if usage.DiskUsedBytes == nil || *usage.DiskUsedBytes != 1024 {
+		t.Fatalf("DiskUsedBytes = %v, want 1024", usage.DiskUsedBytes)
+	}
+	if usage.DiskTotalBytes == nil || *usage.DiskTotalBytes != 8192 {
+		t.Fatalf("DiskTotalBytes = %v, want 8192", usage.DiskTotalBytes)
+	}
+
+	var absent CVMResourceUsage
+	if err := json.Unmarshal([]byte(`{"cpu_percent":1.5}`), &absent); err != nil {
+		t.Fatalf("unmarshal resource usage without disk fields: %v", err)
+	}
+	if absent.DiskUsedBytes != nil || absent.DiskTotalBytes != nil {
+		t.Fatal("disk fields set when absent from the payload, want nil")
+	}
+}

--- a/go/types_cvms_test.go
+++ b/go/types_cvms_test.go
@@ -280,3 +280,20 @@ func TestCVMStatusBatchDeserialization(t *testing.T) {
 		}
 	})
 }
+
+func TestCVMInfoManagedEnv(t *testing.T) {
+	var info CVMInfo
+	if err := json.Unmarshal([]byte(`{"id":"cvm_ykL5lbAn","name":"cvm-1","resource":{},"status":"running"}`), &info); err != nil {
+		t.Fatalf("unmarshal CVM info: %v", err)
+	}
+	if info.ManagedEnv {
+		t.Fatal("ManagedEnv = true when absent from the payload, want false")
+	}
+
+	if err := json.Unmarshal([]byte(`{"id":"cvm_ykL5lbAn","name":"cvm-1","resource":{},"status":"running","managed_env":true}`), &info); err != nil {
+		t.Fatalf("unmarshal CVM info with managed_env: %v", err)
+	}
+	if !info.ManagedEnv {
+		t.Fatal("ManagedEnv = false, want true")
+	}
+}

--- a/go/types_nodes.go
+++ b/go/types_nodes.go
@@ -36,11 +36,10 @@ type TeepodCapacity struct {
 	KMSList           []string         `json:"kms_list,omitempty"`
 }
 
-// DeviceIDEntry is one of a node's device_ids and the OS images it covers.
+// DeviceIDEntry is one of a node's device_ids, keyed by KMS algorithm version.
 type DeviceIDEntry struct {
 	DeviceID         string `json:"device_id"`
 	AlgorithmVersion string `json:"algorithm_version"`
-	OSImageIDs       []int  `json:"os_image_ids"`
 	Enabled          bool   `json:"enabled"`
 }
 

--- a/go/types_workspaces.go
+++ b/go/types_workspaces.go
@@ -2,11 +2,24 @@ package phala
 
 // Workspace represents workspace information.
 type Workspace struct {
-	ID     string  `json:"id"`
-	Name   string  `json:"name"`
-	Slug   *string `json:"slug,omitempty"`
-	Tier   string  `json:"tier"`
-	Avatar *string `json:"avatar,omitempty"`
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	Slug        *string `json:"slug,omitempty"`
+	AvatarURL   *string `json:"avatar_url,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Tier        string  `json:"tier"`
+	Role        *string `json:"role,omitempty"`
+	IsDefault   *bool   `json:"is_default,omitempty"`
+	CreatedAt   *string `json:"created_at,omitempty"`
+
+	ConfidentialModelsEnabled *bool `json:"confidential_models_enabled,omitempty"`
+
+	// BillingStatus is the billing lifecycle state: active, suspended or
+	// abandoned. A suspended workspace still runs but owes money; an abandoned
+	// one is closed and read-only until its balance is settled.
+	BillingStatus *string `json:"billing_status,omitempty"`
+	// SuspendedAt is set only while BillingStatus is "suspended".
+	SuspendedAt *string `json:"suspended_at,omitempty"`
 }
 
 // ListWorkspacesResponse is the response for listing workspaces.

--- a/go/types_workspaces_test.go
+++ b/go/types_workspaces_test.go
@@ -1,0 +1,56 @@
+package phala
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestWorkspaceDecodesBillingLifecycle(t *testing.T) {
+	payload := `{
+		"id": "wks_1",
+		"name": "acme",
+		"slug": "acme",
+		"avatar_url": "https://example.test/a.png",
+		"description": "Acme workspace",
+		"tier": "pro",
+		"role": "owner",
+		"is_default": true,
+		"created_at": "2026-01-01T00:00:00Z",
+		"confidential_models_enabled": true,
+		"billing_status": "suspended",
+		"suspended_at": "2026-08-01T00:00:00Z"
+	}`
+
+	var ws Workspace
+	if err := json.Unmarshal([]byte(payload), &ws); err != nil {
+		t.Fatalf("unmarshal workspace: %v", err)
+	}
+	if ws.AvatarURL == nil || *ws.AvatarURL != "https://example.test/a.png" {
+		t.Fatalf("AvatarURL = %v, want the avatar_url value", ws.AvatarURL)
+	}
+	if ws.Description == nil || *ws.Description != "Acme workspace" {
+		t.Fatalf("Description = %v, want %q", ws.Description, "Acme workspace")
+	}
+	if ws.BillingStatus == nil || *ws.BillingStatus != "suspended" {
+		t.Fatalf("BillingStatus = %v, want suspended", ws.BillingStatus)
+	}
+	if ws.SuspendedAt == nil || *ws.SuspendedAt != "2026-08-01T00:00:00Z" {
+		t.Fatalf("SuspendedAt = %v, want the suspended_at value", ws.SuspendedAt)
+	}
+	if ws.IsDefault == nil || !*ws.IsDefault {
+		t.Fatalf("IsDefault = %v, want true", ws.IsDefault)
+	}
+	if ws.Role == nil || *ws.Role != "owner" {
+		t.Fatalf("Role = %v, want owner", ws.Role)
+	}
+}
+
+func TestWorkspaceOmitsAbsentOptionalFields(t *testing.T) {
+	var ws Workspace
+	if err := json.Unmarshal([]byte(`{"id":"wks_1","name":"acme","tier":"free"}`), &ws); err != nil {
+		t.Fatalf("unmarshal minimal workspace: %v", err)
+	}
+	if ws.BillingStatus != nil || ws.SuspendedAt != nil || ws.AvatarURL != nil {
+		t.Fatal("optional workspace fields set when absent from the payload, want nil")
+	}
+}

--- a/go/version.go
+++ b/go/version.go
@@ -1,5 +1,7 @@
 package phala
 
+import "time"
+
 const (
 	// DefaultAPIVersion is the default Phala Cloud API version.
 	DefaultAPIVersion = "2026-06-23"
@@ -10,6 +12,10 @@ const (
 
 	// DefaultBaseURL is the default Phala Cloud API base URL.
 	DefaultBaseURL = "https://cloud-api.phala.com/api/v1"
+
+	// DefaultTimeout is the default per-request HTTP timeout, matching the JS
+	// and Python SDKs. Override it with WithTimeout.
+	DefaultTimeout = 60 * time.Second
 
 	// sdkVersion is the version of this SDK, used in User-Agent.
 	sdkVersion = "0.2.0"

--- a/python/src/phala_cloud/__init__.py
+++ b/python/src/phala_cloud/__init__.py
@@ -1,7 +1,12 @@
 from . import error_codes
 from .actions import *  # noqa: F403
 from .blockchains import add_compose_hash, deploy_app_auth
-from .client import DEFAULT_API_VERSION, SUPPORTED_API_VERSIONS, ApiVersion
+from .client import (
+    DEFAULT_API_VERSION,
+    DEFAULT_TIMEOUT,
+    SUPPORTED_API_VERSIONS,
+    ApiVersion,
+)
 from .errors import (
     ApiError,
     AuthError,
@@ -37,6 +42,7 @@ __all__ = [
     "BusinessError",
     "ConflictError",
     "DEFAULT_API_VERSION",
+    "DEFAULT_TIMEOUT",
     "PhalaCloud",
     "PhalaCloudError",
     "RequestError",

--- a/python/src/phala_cloud/action_responses.py
+++ b/python/src/phala_cloud/action_responses.py
@@ -76,6 +76,9 @@ class ProvisionCvmComposeFileUpdateResult(CloudModel):
     compose_hash: str
     kms_info: GenericObject | None = None
     compose_hash_registered: bool = False
+    # True when the submitted compose matched the deployed one, meaning the
+    # commit step is a no-op and can be skipped.
+    compose_unchanged: bool = False
 
 
 class CommitCvmProvisionResponseBase(CloudModel):

--- a/python/src/phala_cloud/action_responses.py
+++ b/python/src/phala_cloud/action_responses.py
@@ -81,6 +81,20 @@ class ProvisionCvmComposeFileUpdateResult(CloudModel):
     compose_unchanged: bool = False
 
 
+class PreLaunchScriptUpgradeStatus(CloudModel):
+    """Whether a CVM runs an unmodified official pre-launch script.
+
+    can_upgrade is the one flag callers act on: it is true only when the CVM is
+    on an official script that is not the latest one.
+    """
+
+    current_hash: str | None = None
+    latest_official_hash: str
+    is_official: bool
+    is_latest: bool
+    can_upgrade: bool
+
+
 class CommitCvmProvisionResponseBase(CloudModel):
     name: str
     status: str

--- a/python/src/phala_cloud/action_responses.py
+++ b/python/src/phala_cloud/action_responses.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import Field
 
 from .models.apps import AppRevisionDetailResponse as AppRevisionDetailResponse
@@ -23,8 +25,18 @@ class WorkspaceResponse(CloudModel):
     id: str
     name: str
     slug: str | None = None
+    avatar_url: str | None = None
+    description: str | None = None
     tier: str | None = None
     role: str | None = None
+    is_default: bool | None = None
+    created_at: str | None = None
+    confidential_models_enabled: bool | None = None
+    # Billing lifecycle state. A suspended workspace still runs but owes money;
+    # an abandoned one is closed and read-only until its balance is settled.
+    billing_status: Literal["active", "suspended", "abandoned"] = "active"
+    # When the workspace was suspended. None unless billing_status is suspended.
+    suspended_at: str | None = None
 
 
 class ListWorkspacesResponse(CloudModel):

--- a/python/src/phala_cloud/actions.py
+++ b/python/src/phala_cloud/actions.py
@@ -53,6 +53,10 @@ __all__ = [
     "safe_update_pre_launch_script",
     "get_cvm_pre_launch_script",
     "safe_get_cvm_pre_launch_script",
+    "get_pre_launch_script_upgrade_status",
+    "safe_get_pre_launch_script_upgrade_status",
+    "upgrade_pre_launch_script",
+    "safe_upgrade_pre_launch_script",
     "start_cvm",
     "safe_start_cvm",
     "stop_cvm",
@@ -333,6 +337,22 @@ def get_cvm_pre_launch_script(client: Any, *args: Any, **kwargs: Any) -> Any:
 
 def safe_get_cvm_pre_launch_script(client: Any, *args: Any, **kwargs: Any) -> Any:
     return client.safe_get_cvm_pre_launch_script(*args, **kwargs)
+
+
+def get_pre_launch_script_upgrade_status(client: Any, *args: Any, **kwargs: Any) -> Any:
+    return client.get_pre_launch_script_upgrade_status(*args, **kwargs)
+
+
+def safe_get_pre_launch_script_upgrade_status(client: Any, *args: Any, **kwargs: Any) -> Any:
+    return client.safe_get_pre_launch_script_upgrade_status(*args, **kwargs)
+
+
+def upgrade_pre_launch_script(client: Any, *args: Any, **kwargs: Any) -> Any:
+    return client.upgrade_pre_launch_script(*args, **kwargs)
+
+
+def safe_upgrade_pre_launch_script(client: Any, *args: Any, **kwargs: Any) -> Any:
+    return client.safe_upgrade_pre_launch_script(*args, **kwargs)
 
 
 def start_cvm(client: Any, *args: Any, **kwargs: Any) -> Any:

--- a/python/src/phala_cloud/client.py
+++ b/python/src/phala_cloud/client.py
@@ -49,6 +49,9 @@ SUPPORTED_API_VERSIONS: tuple[ApiVersion, ...] = (
 )
 DEFAULT_API_VERSION: ApiVersion = "2026-06-23"
 DEFAULT_BASE_URL = "https://cloud-api.phala.com/api/v1"
+# Per-request HTTP timeout, matching the JS and Go SDKs. Provisioning and
+# attestation calls routinely exceed the previous 30s.
+DEFAULT_TIMEOUT = 60.0
 
 # The contract-centric KMS API exists from this version onward; the contract
 # methods pin it per request.
@@ -99,7 +102,7 @@ class AsyncPhalaCloud:
         api_key: str | None = None,
         base_url: str | None = None,
         version: ApiVersion = DEFAULT_API_VERSION,
-        timeout: float = 30.0,
+        timeout: float = DEFAULT_TIMEOUT,
         use_cookie_auth: bool = False,
         headers: Mapping[str, str] | None = None,
         http_client: httpx.AsyncClient | None = None,
@@ -380,7 +383,7 @@ class PhalaCloud:
         api_key: str | None = None,
         base_url: str | None = None,
         version: ApiVersion = DEFAULT_API_VERSION,
-        timeout: float = 30.0,
+        timeout: float = DEFAULT_TIMEOUT,
         use_cookie_auth: bool = False,
         headers: Mapping[str, str] | None = None,
         http_client: httpx.Client | None = None,

--- a/python/src/phala_cloud/full_client.py
+++ b/python/src/phala_cloud/full_client.py
@@ -417,7 +417,7 @@ class _ExtMixin:
             r"/cvms/[^/]+/pre-launch-script/upgrade-to-latest-official", path
         ):
             return InProgressResponse | ComposeHashPreconditionResponse
-        if m == "PATCH" and re.fullmatch(r"/cvms/[^/]+/(resources|os-image)", path):
+        if m == "PATCH" and re.fullmatch(r"/cvms/[^/]+/os-image", path):
             return type(None)
         if m == "PATCH" and re.fullmatch(r"/cvms/[^/]+/compose_file", path):
             return type(None)
@@ -896,9 +896,7 @@ class PhalaCloud(_SyncBase, _ExtMixin):
     ) -> SafeResult[Any]:
         return self.safe(self.get_cvm_attestation, request)
 
-    def update_cvm_resources(
-        self, request: UpdateResourcesRequest | Mapping[str, Any]
-    ) -> dict[str, str]:
+    def update_cvm_resources(self, request: UpdateResourcesRequest | Mapping[str, Any]) -> Any:
         req = UpdateResourcesRequest.model_validate(request)
         body = req.model_dump(exclude_none=True)
         body.pop("id", None)
@@ -911,7 +909,7 @@ class PhalaCloud(_SyncBase, _ExtMixin):
 
     def safe_update_cvm_resources(
         self, request: UpdateResourcesRequest | Mapping[str, Any]
-    ) -> SafeResult[dict[str, str]]:
+    ) -> SafeResult[Any]:
         return self.safe(self.update_cvm_resources, request)
 
     def update_cvm_visibility(self, request: UpdateVisibilityRequest | Mapping[str, Any]) -> Any:
@@ -1759,17 +1757,16 @@ class AsyncPhalaCloud(_AsyncBase, _ExtMixin):
 
     async def update_cvm_resources(
         self, request: UpdateResourcesRequest | Mapping[str, Any]
-    ) -> None:
+    ) -> Any:
         req = UpdateResourcesRequest.model_validate(request)
         body = req.model_dump(exclude_none=True)
         for k in ["id", "uuid", "app_id", "instance_id", "cvm_id", "cvmId"]:
             body.pop(k, None)
-        await self.request("PATCH", f"/cvms/{req.resolved}/resources", json=body)
-        return None
+        return await self.request("PATCH", f"/cvms/{req.resolved}", json=body)
 
     async def safe_update_cvm_resources(
         self, request: UpdateResourcesRequest | Mapping[str, Any]
-    ) -> SafeResult[None]:
+    ) -> SafeResult[Any]:
         return await self.safe(self.update_cvm_resources, request)
 
     async def update_cvm_visibility(

--- a/python/src/phala_cloud/full_client.py
+++ b/python/src/phala_cloud/full_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 import time
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
 
@@ -36,6 +36,7 @@ from .action_responses import (
     InstanceTypesFamilyResponse,
     ListWorkspacesResponse,
     NextAppIdsResponse,
+    PreLaunchScriptUpgradeStatus,
     ProvisionCvmComposeFileUpdateResult,
     ProvisionCvmResponse,
     RefreshInstanceIdResponseV20260121,
@@ -193,6 +194,27 @@ class StatusBatchRequest(_AliasModel):
 
 class RestartCvmRequest(CvmIdRequest):
     force: bool = False
+
+
+class UpgradePreLaunchScriptRequest(CvmIdRequest):
+    """Phase 2 fields are only needed for contract-owned KMS (ETHEREUM/BASE).
+
+    The first call returns precondition_required with a compose hash to
+    register on-chain; the retry carries that hash and the transaction that
+    registered it.
+    """
+
+    compose_hash: str | None = None
+    transaction_hash: str | None = None
+
+
+def _upgrade_pre_launch_script_headers(req: UpgradePreLaunchScriptRequest) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if req.compose_hash:
+        headers["X-Compose-Hash"] = req.compose_hash
+    if req.transaction_hash:
+        headers["X-Transaction-Hash"] = req.transaction_hash
+    return headers
 
 
 class ReplicateCvmRequest(CvmIdRequest):
@@ -388,6 +410,12 @@ class _ExtMixin:
         if m == "PATCH" and re.fullmatch(r"/cvms/[^/]+/docker-compose", path):
             return InProgressResponse | ComposeHashPreconditionResponse
         if m == "PATCH" and re.fullmatch(r"/cvms/[^/]+/pre-launch-script", path):
+            return InProgressResponse | ComposeHashPreconditionResponse
+        if m == "GET" and re.fullmatch(r"/cvms/[^/]+/pre-launch-script/upgrade-status", path):
+            return PreLaunchScriptUpgradeStatus
+        if m == "POST" and re.fullmatch(
+            r"/cvms/[^/]+/pre-launch-script/upgrade-to-latest-official", path
+        ):
             return InProgressResponse | ComposeHashPreconditionResponse
         if m == "PATCH" and re.fullmatch(r"/cvms/[^/]+/(resources|os-image)", path):
             return type(None)
@@ -751,6 +779,43 @@ class PhalaCloud(_SyncBase, _ExtMixin):
         self, request: CvmIdRequest | Mapping[str, Any]
     ) -> SafeResult[str]:
         return self.safe(self.get_cvm_pre_launch_script, request)
+
+    def get_pre_launch_script_upgrade_status(
+        self, request: CvmIdRequest | Mapping[str, Any]
+    ) -> PreLaunchScriptUpgradeStatus:
+        cvm_id = CvmIdRequest.model_validate(request).resolved
+        return cast(
+            PreLaunchScriptUpgradeStatus,
+            self._loose_validate(self.get(f"/cvms/{cvm_id}/pre-launch-script/upgrade-status")),
+        )
+
+    def safe_get_pre_launch_script_upgrade_status(
+        self, request: CvmIdRequest | Mapping[str, Any]
+    ) -> SafeResult[PreLaunchScriptUpgradeStatus]:
+        return self.safe(self.get_pre_launch_script_upgrade_status, request)
+
+    def upgrade_pre_launch_script(
+        self, request: UpgradePreLaunchScriptRequest | Mapping[str, Any]
+    ) -> Any:
+        req = UpgradePreLaunchScriptRequest.model_validate(request)
+        try:
+            return self._loose_validate(
+                self.request(
+                    "POST",
+                    f"/cvms/{req.resolved}/pre-launch-script/upgrade-to-latest-official",
+                    headers=_upgrade_pre_launch_script_headers(req),
+                ),
+            )
+        except Exception as exc:
+            fields = self._extract_465_fields(exc)
+            if fields is not None:
+                return self._loose_validate({"status": "precondition_required", **fields})
+            raise
+
+    def safe_upgrade_pre_launch_script(
+        self, request: UpgradePreLaunchScriptRequest | Mapping[str, Any]
+    ) -> SafeResult[Any]:
+        return self.safe(self.upgrade_pre_launch_script, request)
 
     def start_cvm(self, request: CvmIdRequest | Mapping[str, Any]) -> Any:
         cvm_id = CvmIdRequest.model_validate(request).resolved
@@ -1567,6 +1632,45 @@ class AsyncPhalaCloud(_AsyncBase, _ExtMixin):
         self, request: CvmIdRequest | Mapping[str, Any]
     ) -> SafeResult[str]:
         return await self.safe(self.get_cvm_pre_launch_script, request)
+
+    async def get_pre_launch_script_upgrade_status(
+        self, request: CvmIdRequest | Mapping[str, Any]
+    ) -> PreLaunchScriptUpgradeStatus:
+        cvm_id = CvmIdRequest.model_validate(request).resolved
+        return cast(
+            PreLaunchScriptUpgradeStatus,
+            self._loose_validate(
+                await self.get(f"/cvms/{cvm_id}/pre-launch-script/upgrade-status")
+            ),
+        )
+
+    async def safe_get_pre_launch_script_upgrade_status(
+        self, request: CvmIdRequest | Mapping[str, Any]
+    ) -> SafeResult[PreLaunchScriptUpgradeStatus]:
+        return await self.safe(self.get_pre_launch_script_upgrade_status, request)
+
+    async def upgrade_pre_launch_script(
+        self, request: UpgradePreLaunchScriptRequest | Mapping[str, Any]
+    ) -> Any:
+        req = UpgradePreLaunchScriptRequest.model_validate(request)
+        try:
+            return self._loose_validate(
+                await self.request(
+                    "POST",
+                    f"/cvms/{req.resolved}/pre-launch-script/upgrade-to-latest-official",
+                    headers=_upgrade_pre_launch_script_headers(req),
+                ),
+            )
+        except Exception as exc:
+            fields = self._extract_465_fields(exc)
+            if fields is not None:
+                return self._loose_validate({"status": "precondition_required", **fields})
+            raise
+
+    async def safe_upgrade_pre_launch_script(
+        self, request: UpgradePreLaunchScriptRequest | Mapping[str, Any]
+    ) -> SafeResult[Any]:
+        return await self.safe(self.upgrade_pre_launch_script, request)
 
     async def start_cvm(self, request: CvmIdRequest | Mapping[str, Any]) -> Any:
         cvm_id = CvmIdRequest.model_validate(request).resolved

--- a/python/src/phala_cloud/full_client.py
+++ b/python/src/phala_cloud/full_client.py
@@ -197,6 +197,7 @@ class RestartCvmRequest(CvmIdRequest):
 
 class ReplicateCvmRequest(CvmIdRequest):
     node_id: int | None = None
+    os_image: str | None = Field(default=None, min_length=1)
 
 
 class UpdateResourcesRequest(CvmIdRequest):
@@ -1162,7 +1163,10 @@ class PhalaCloud(_SyncBase, _ExtMixin):
     def replicate_cvm(self, request: ReplicateCvmRequest | Mapping[str, Any]) -> Any:
         req = ReplicateCvmRequest.model_validate(request)
         return self._loose_validate(
-            self.post(f"/cvms/{req.resolved}/replicas", json={"node_id": req.node_id})
+            self.post(
+                f"/cvms/{req.resolved}/replicas",
+                json={"node_id": req.node_id, "os_image": req.os_image},
+            )
         )
 
     def safe_replicate_cvm(
@@ -2000,7 +2004,10 @@ class AsyncPhalaCloud(_AsyncBase, _ExtMixin):
     async def replicate_cvm(self, request: ReplicateCvmRequest | Mapping[str, Any]) -> Any:
         req = ReplicateCvmRequest.model_validate(request)
         return self._loose_validate(
-            await self.post(f"/cvms/{req.resolved}/replicas", json={"node_id": req.node_id})
+            await self.post(
+                f"/cvms/{req.resolved}/replicas",
+                json={"node_id": req.node_id, "os_image": req.os_image},
+            )
         )
 
     async def safe_replicate_cvm(

--- a/python/src/phala_cloud/models/cvms.py
+++ b/python/src/phala_cloud/models/cvms.py
@@ -176,6 +176,7 @@ class CvmInfoV20260121(CloudModel):
     public_tcbinfo: bool | None = None
     gateway_enabled: bool | None = None
     secure_time: bool | None = None
+    managed_env: bool = False
     listed: bool = False
     storage_fs: str | None = None
     workspace: WorkspaceRef | None = None
@@ -232,6 +233,7 @@ class CvmInfoV20260522(CloudModel):
     public_tcbinfo: bool | None = None
     gateway_enabled: bool | None = None
     secure_time: bool | None = None
+    managed_env: bool = False
     listed: bool = False
     storage_fs: str | None = None
     workspace: WorkspaceRef | None = None

--- a/python/src/phala_cloud/models/cvms.py
+++ b/python/src/phala_cloud/models/cvms.py
@@ -433,6 +433,8 @@ class CvmResourceUsage(CloudModel):
     cpu_percent: float | None = None
     memory_used_bytes: int | None = None
     memory_total_bytes: int | None = None
+    disk_used_bytes: int | None = None
+    disk_total_bytes: int | None = None
     egress_bytes: int | None = None
 
 

--- a/python/src/phala_cloud/models/nodes.py
+++ b/python/src/phala_cloud/models/nodes.py
@@ -16,7 +16,6 @@ class AvailableOSImage(CloudModel):
 class DeviceIdEntry(CloudModel):
     device_id: str
     algorithm_version: str
-    os_image_ids: list[int] = Field(default_factory=list)
     enabled: bool
 
 

--- a/python/tests/test_js_parity_schemas.py
+++ b/python/tests/test_js_parity_schemas.py
@@ -6,6 +6,7 @@ drift from the wire contract again.
 
 from __future__ import annotations
 
+from phala_cloud.action_responses import WorkspaceResponse
 from phala_cloud.models.cvms import CvmInfoV20260121, CvmInfoV20260522, CvmResourceUsage
 
 
@@ -51,3 +52,36 @@ class TestCvmResourceUsageDisk:
         usage = CvmResourceUsage.model_validate({"cpu_percent": 1.5})
         assert usage.disk_used_bytes is None
         assert usage.disk_total_bytes is None
+
+
+class TestWorkspaceResponse:
+    def test_declares_the_full_js_field_set(self) -> None:
+        expected = {
+            "avatar_url",
+            "description",
+            "is_default",
+            "created_at",
+            "confidential_models_enabled",
+            "billing_status",
+            "suspended_at",
+        }
+        assert expected <= set(WorkspaceResponse.model_fields)
+
+    def test_billing_status_defaults_to_active(self) -> None:
+        workspace = WorkspaceResponse.model_validate({"id": "wks_1", "name": "acme"})
+        assert workspace.billing_status == "active"
+        assert workspace.suspended_at is None
+
+    def test_reads_suspended_state(self) -> None:
+        workspace = WorkspaceResponse.model_validate(
+            {
+                "id": "wks_1",
+                "name": "acme",
+                "avatar_url": "https://example.test/a.png",
+                "billing_status": "suspended",
+                "suspended_at": "2026-08-01T00:00:00Z",
+            }
+        )
+        assert workspace.billing_status == "suspended"
+        assert workspace.suspended_at == "2026-08-01T00:00:00Z"
+        assert workspace.avatar_url == "https://example.test/a.png"

--- a/python/tests/test_js_parity_schemas.py
+++ b/python/tests/test_js_parity_schemas.py
@@ -1,0 +1,37 @@
+"""Schema parity checks against the JS SDK.
+
+Each test pins a field the JS SDK exposes so the Python models cannot silently
+drift from the wire contract again.
+"""
+
+from __future__ import annotations
+
+from phala_cloud.models.cvms import CvmInfoV20260121, CvmInfoV20260522
+
+
+def _cvm_info(**overrides: object) -> dict:
+    payload: dict = {
+        "id": "cvm_ykL5lbAn",
+        "name": "cvm-1",
+        "resource": {"instance_type": "tdx.small", "vcpu": 1, "memory_in_gb": 1},
+        "status": "running",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestManagedEnv:
+    def test_is_a_declared_field(self) -> None:
+        # CloudModel allows extra keys, so attribute access alone would pass
+        # even if the field were missing from the model.
+        assert "managed_env" in CvmInfoV20260121.model_fields
+        assert "managed_env" in CvmInfoV20260522.model_fields
+
+    def test_defaults_to_false_when_absent(self) -> None:
+        assert CvmInfoV20260121.model_validate(_cvm_info()).managed_env is False
+        assert CvmInfoV20260522.model_validate(_cvm_info()).managed_env is False
+
+    def test_reads_wire_value(self) -> None:
+        payload = _cvm_info(managed_env=True)
+        assert CvmInfoV20260121.model_validate(payload).managed_env is True
+        assert CvmInfoV20260522.model_validate(payload).managed_env is True

--- a/python/tests/test_js_parity_schemas.py
+++ b/python/tests/test_js_parity_schemas.py
@@ -6,7 +6,9 @@ drift from the wire contract again.
 
 from __future__ import annotations
 
+from phala_cloud import AsyncPhalaCloud, PhalaCloud
 from phala_cloud.action_responses import WorkspaceResponse
+from phala_cloud.client import DEFAULT_TIMEOUT
 from phala_cloud.models.cvms import CvmInfoV20260121, CvmInfoV20260522, CvmResourceUsage
 from phala_cloud.models.nodes import DeviceIdEntry
 
@@ -101,3 +103,12 @@ class TestDeviceIdEntry:
         assert entry.device_id == "0xdev"
         assert entry.algorithm_version == "v1"
         assert entry.enabled is True
+
+
+class TestDefaultTimeout:
+    def test_matches_the_js_sixty_second_default(self) -> None:
+        assert DEFAULT_TIMEOUT == 60.0
+
+    def test_clients_apply_it(self) -> None:
+        assert PhalaCloud(api_key="k").config.timeout == 60.0
+        assert AsyncPhalaCloud(api_key="k").config.timeout == 60.0

--- a/python/tests/test_js_parity_schemas.py
+++ b/python/tests/test_js_parity_schemas.py
@@ -6,7 +6,7 @@ drift from the wire contract again.
 
 from __future__ import annotations
 
-from phala_cloud.models.cvms import CvmInfoV20260121, CvmInfoV20260522
+from phala_cloud.models.cvms import CvmInfoV20260121, CvmInfoV20260522, CvmResourceUsage
 
 
 def _cvm_info(**overrides: object) -> dict:
@@ -35,3 +35,19 @@ class TestManagedEnv:
         payload = _cvm_info(managed_env=True)
         assert CvmInfoV20260121.model_validate(payload).managed_env is True
         assert CvmInfoV20260522.model_validate(payload).managed_env is True
+
+
+class TestCvmResourceUsageDisk:
+    def test_disk_fields_are_declared(self) -> None:
+        assert "disk_used_bytes" in CvmResourceUsage.model_fields
+        assert "disk_total_bytes" in CvmResourceUsage.model_fields
+
+    def test_reads_wire_values(self) -> None:
+        usage = CvmResourceUsage.model_validate({"disk_used_bytes": 1024, "disk_total_bytes": 8192})
+        assert usage.disk_used_bytes == 1024
+        assert usage.disk_total_bytes == 8192
+
+    def test_defaults_to_none_when_absent(self) -> None:
+        usage = CvmResourceUsage.model_validate({"cpu_percent": 1.5})
+        assert usage.disk_used_bytes is None
+        assert usage.disk_total_bytes is None

--- a/python/tests/test_js_parity_schemas.py
+++ b/python/tests/test_js_parity_schemas.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from phala_cloud.action_responses import WorkspaceResponse
 from phala_cloud.models.cvms import CvmInfoV20260121, CvmInfoV20260522, CvmResourceUsage
+from phala_cloud.models.nodes import DeviceIdEntry
 
 
 def _cvm_info(**overrides: object) -> dict:
@@ -85,3 +86,18 @@ class TestWorkspaceResponse:
         assert workspace.billing_status == "suspended"
         assert workspace.suspended_at == "2026-08-01T00:00:00Z"
         assert workspace.avatar_url == "https://example.test/a.png"
+
+
+class TestDeviceIdEntry:
+    def test_no_longer_declares_os_image_ids(self) -> None:
+        # device_id is keyed by (physical node, KMS algorithm version) alone;
+        # the OS image list was dropped from the wire contract.
+        assert "os_image_ids" not in DeviceIdEntry.model_fields
+
+    def test_decodes_the_current_wire_shape(self) -> None:
+        entry = DeviceIdEntry.model_validate(
+            {"device_id": "0xdev", "algorithm_version": "v1", "enabled": True}
+        )
+        assert entry.device_id == "0xdev"
+        assert entry.algorithm_version == "v1"
+        assert entry.enabled is True

--- a/python/tests/test_prelaunch_script_upgrade.py
+++ b/python/tests/test_prelaunch_script_upgrade.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from phala_cloud import AsyncPhalaCloud, PhalaCloud
+from phala_cloud.action_responses import InProgressResponse, PreLaunchScriptUpgradeStatus
+
+_STATUS_PAYLOAD = {
+    "current_hash": "aaa",
+    "latest_official_hash": "bbb",
+    "is_official": True,
+    "is_latest": False,
+    "can_upgrade": True,
+}
+
+_UPGRADE_PATH = "/api/v1/cvms/cvm-123/pre-launch-script/upgrade-to-latest-official"
+
+
+def test_get_upgrade_status_sync() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v1/cvms/cvm-123/pre-launch-script/upgrade-status"
+        return httpx.Response(200, json=_STATUS_PAYLOAD)
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport, base_url="https://cloud-api.phala.com/api/v1") as raw:
+        client = PhalaCloud(http_client=raw)
+        status = client.get_pre_launch_script_upgrade_status({"cvm_id": "cvm-123"})
+
+    assert isinstance(status, PreLaunchScriptUpgradeStatus)
+    assert status.can_upgrade is True
+    assert status.is_latest is False
+    assert status.latest_official_hash == "bbb"
+
+
+@pytest.mark.asyncio
+async def test_get_upgrade_status_async() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v1/cvms/cvm-123/pre-launch-script/upgrade-status"
+        return httpx.Response(200, json=_STATUS_PAYLOAD)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://cloud-api.phala.com/api/v1"
+    ) as raw:
+        client = AsyncPhalaCloud(http_client=raw)
+        status = await client.get_pre_launch_script_upgrade_status({"cvm_id": "cvm-123"})
+
+    assert isinstance(status, PreLaunchScriptUpgradeStatus)
+    assert status.can_upgrade is True
+
+
+def test_upgrade_phase_one_sends_no_verification_headers() -> None:
+    seen: list[httpx.Headers] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == _UPGRADE_PATH
+        seen.append(request.headers)
+        return httpx.Response(
+            202, json={"status": "in_progress", "message": "queued", "correlation_id": "corr-1"}
+        )
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport, base_url="https://cloud-api.phala.com/api/v1") as raw:
+        client = PhalaCloud(http_client=raw)
+        result = client.upgrade_pre_launch_script({"cvm_id": "cvm-123"})
+
+    assert isinstance(result, InProgressResponse)
+    assert result.correlation_id == "corr-1"
+    assert "X-Compose-Hash" not in seen[0]
+    assert "X-Transaction-Hash" not in seen[0]
+
+
+def test_upgrade_phase_two_forwards_verification_headers() -> None:
+    seen: list[httpx.Headers] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request.headers)
+        return httpx.Response(
+            202, json={"status": "in_progress", "message": "queued", "correlation_id": "corr-2"}
+        )
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport, base_url="https://cloud-api.phala.com/api/v1") as raw:
+        client = PhalaCloud(http_client=raw)
+        client.upgrade_pre_launch_script(
+            {"cvm_id": "cvm-123", "compose_hash": "hash-1", "transaction_hash": "0xtx"}
+        )
+
+    assert seen[0]["X-Compose-Hash"] == "hash-1"
+    assert seen[0]["X-Transaction-Hash"] == "0xtx"
+
+
+def test_upgrade_maps_465_to_precondition_required() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            465,
+            json={
+                "message": "Compose hash verification required",
+                "details": [
+                    {"field": "compose_hash", "value": "hash-1"},
+                    {"field": "app_id", "value": "app-1"},
+                    {"field": "device_id", "value": "device-1"},
+                    {"field": "kms_info", "value": {"id": "kms-1"}},
+                ],
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport, base_url="https://cloud-api.phala.com/api/v1") as raw:
+        client = PhalaCloud(http_client=raw)
+        result = client.upgrade_pre_launch_script({"cvm_id": "cvm-123"})
+
+    # Mirrors update_cvm_envs / update_docker_compose: the synthesised 465 body
+    # comes back as a loose model, discriminated by status.
+    assert result.status == "precondition_required"
+    assert result.compose_hash == "hash-1"
+    assert result.app_id == "app-1"
+    assert result.device_id == "device-1"
+
+
+@pytest.mark.asyncio
+async def test_upgrade_maps_465_to_precondition_required_async() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            465,
+            json={
+                "message": "Compose hash verification required",
+                "details": [
+                    {"field": "compose_hash", "value": "hash-1"},
+                    {"field": "app_id", "value": "app-1"},
+                ],
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://cloud-api.phala.com/api/v1"
+    ) as raw:
+        client = AsyncPhalaCloud(http_client=raw)
+        result = await client.upgrade_pre_launch_script({"cvm_id": "cvm-123"})
+
+    assert result.status == "precondition_required"
+    assert result.compose_hash == "hash-1"

--- a/python/tests/test_provision_compose_update.py
+++ b/python/tests/test_provision_compose_update.py
@@ -83,3 +83,15 @@ async def test_provision_cvm_compose_file_update_async() -> None:
         assert isinstance(result, ProvisionCvmComposeFileUpdateResult)
         assert result.compose_hash_registered is False
         assert result.device_id is None
+
+
+def test_provision_cvm_compose_file_update_result_compose_unchanged() -> None:
+    default = ProvisionCvmComposeFileUpdateResult.model_validate(
+        {"app_id": "app-123", "compose_hash": "abc123"}
+    )
+    assert default.compose_unchanged is False
+
+    unchanged = ProvisionCvmComposeFileUpdateResult.model_validate(
+        {"app_id": "app-123", "compose_hash": "abc123", "compose_unchanged": True}
+    )
+    assert unchanged.compose_unchanged is True

--- a/python/tests/test_replicate_cvm.py
+++ b/python/tests/test_replicate_cvm.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from phala_cloud import AsyncPhalaCloud, PhalaCloud
+
+_REPLICA_RESPONSE = {
+    "id": "cvm_ykL5lbAn",
+    "name": "cvm-1",
+    "status": "starting",
+    "app_id": "app-1",
+}
+
+
+def _capturing_transport(captured: list[dict]) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v1/cvms/cvm-123/replicas"
+        captured.append(json.loads(request.content))
+        return httpx.Response(200, json=_REPLICA_RESPONSE)
+
+    return httpx.MockTransport(handler)
+
+
+def test_replicate_cvm_forwards_os_image_sync() -> None:
+    captured: list[dict] = []
+    transport = _capturing_transport(captured)
+    with httpx.Client(transport=transport, base_url="https://cloud-api.phala.com/api/v1") as raw:
+        client = PhalaCloud(http_client=raw)
+        client.replicate_cvm({"cvm_id": "cvm-123", "node_id": 42, "os_image": "dstack-0.5.4"})
+
+    assert captured == [{"node_id": 42, "os_image": "dstack-0.5.4"}]
+
+
+@pytest.mark.asyncio
+async def test_replicate_cvm_forwards_os_image_async() -> None:
+    captured: list[dict] = []
+    transport = _capturing_transport(captured)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://cloud-api.phala.com/api/v1"
+    ) as raw:
+        client = AsyncPhalaCloud(http_client=raw)
+        await client.replicate_cvm({"cvm_id": "cvm-123", "os_image": "dstack-0.5.4"})
+
+    assert captured == [{"node_id": None, "os_image": "dstack-0.5.4"}]
+
+
+def test_replicate_cvm_rejects_empty_os_image() -> None:
+    from pydantic import ValidationError
+
+    from phala_cloud.full_client import ReplicateCvmRequest
+
+    with pytest.raises(ValidationError):
+        ReplicateCvmRequest.model_validate({"cvm_id": "cvm-123", "os_image": ""})

--- a/python/tests/test_update_cvm_resources.py
+++ b/python/tests/test_update_cvm_resources.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from phala_cloud import AsyncPhalaCloud, PhalaCloud
+
+_RESPONSE = {"message": "queued", "correlation_id": "corr-1", "status": "in_progress"}
+
+
+def _handler(seen: list[tuple[str, str, dict]]) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append((request.method, request.url.path, json.loads(request.content)))
+        return httpx.Response(200, json=_RESPONSE)
+
+    return httpx.MockTransport(handler)
+
+
+def test_update_cvm_resources_uses_the_unified_patch_endpoint_sync() -> None:
+    seen: list[tuple[str, str, dict]] = []
+    with httpx.Client(
+        transport=_handler(seen), base_url="https://cloud-api.phala.com/api/v1"
+    ) as raw:
+        client = PhalaCloud(http_client=raw)
+        result = client.update_cvm_resources({"cvm_id": "cvm-123", "vcpu": 4})
+
+    assert seen[0][0] == "PATCH"
+    assert seen[0][1] == "/api/v1/cvms/cvm-123"
+    assert seen[0][2] == {"vcpu": 4}
+    assert result.correlation_id == "corr-1"
+
+
+@pytest.mark.asyncio
+async def test_update_cvm_resources_uses_the_unified_patch_endpoint_async() -> None:
+    seen: list[tuple[str, str, dict]] = []
+    async with httpx.AsyncClient(
+        transport=_handler(seen), base_url="https://cloud-api.phala.com/api/v1"
+    ) as raw:
+        client = AsyncPhalaCloud(http_client=raw)
+        result = await client.update_cvm_resources({"cvm_id": "cvm-123", "vcpu": 4})
+
+    assert seen[0][0] == "PATCH"
+    assert seen[0][1] == "/api/v1/cvms/cvm-123"
+    assert seen[0][2] == {"vcpu": 4}
+    # The async client used to swallow the body and return None, so callers had
+    # no correlation ID to follow the resize with.
+    assert result.correlation_id == "corr-1"


### PR DESCRIPTION
## What

Audits every `js/src` change from `js-v0.2.9` to `main` (65 commits) and syncs what never reached the Python and Go SDKs.

## Why

The three SDKs are supposed to expose the same API surface, but drift accumulated silently: fields that only ever landed in JS decode to nothing in Python and Go, so callers on those SDKs either cannot see the data at all or reach for untyped extra keys. Two of the gaps are outright defects rather than missing surface — see the last two commits.

## Commits

Each commit is one gap, with the originating JS commit named in its message.

| Commit | Gap | Python | Go |
|---|---|:-:|:-:|
| `managed_env` on CVM detail schemas | 5159a7e | yes | yes |
| `disk_used_bytes` / `disk_total_bytes` on CVM resource usage | 5d5d385 | yes | yes |
| Full workspace response schema | 35236c5 / 2fd4205 / 79b582b | yes | yes |
| Replica OS image selection (`os_image`) | eae695b | yes | yes |
| `compose_unchanged` on compose-file-update provisioning | 33699d8 | yes | yes |
| Update results discriminated by `status` | 33699d8 | n/a | yes |
| Pre-launch script upgrade actions | dd5dbb3 | yes | yes |
| Drop `os_image_ids` from `DeviceIdEntry` | 8509162 | yes | yes |
| Default request timeout at 60s | 0b6e022 | yes | yes |
| Finish the unified PATCH migration in the async Python client | c881889 | yes | n/a |

## Defects fixed, not just surface

- **Async Python `update_cvm_resources` called a retired endpoint.** `c881889` moved resource updates to the unified `PATCH /cvms/{id}`. Go and the sync Python client followed; the async client was missed and kept calling `PATCH /cvms/{id}/resources`. It also discarded the response body, so callers had no `correlation_id` to follow the resize with.
- **Go could not tell `no_change` from an accepted update.** `UpdateResult` had no `status` field, so a `no_change` response decoded to a zero-valued struct identical to a queued update — callers reported a redeploy that never happened.

## Breaking change

`DeviceIdEntry.os_image_ids` (Python) and `DeviceIDEntry.OSImageIDs` (Go) are removed. The backend's `DeviceIdEntryOut` stopped emitting the key, so both had been decoding an empty list for every node. No caller in this repo referenced either.

## Also corrected

Go's `Workspace.Avatar` is renamed to `AvatarURL` and its JSON tag fixed from `avatar` to `avatar_url`. `GET /workspaces/{slug}` returns `avatar_url`, so the old tag never decoded anything. The `/auth/me` `WorkspaceInfo` struct, which genuinely uses `avatar`, is untouched.

## Not included

Go's `AppCompose` comes from the external `dstack-sdk-go` dependency and has no `port_policy`. That is fixed separately in the dstack repo, since it needs a dependency bump here afterwards.

## Verification

```
python: ruff format --check . && ruff check . && pytest    -> 99 passed, 3 skipped
go:     gofmt -l . && go build ./... && go vet ./... && go test ./...  -> ok
```

New tests assert at the wire level (mock transport / `httptest` server) wherever a field has to reach a request body or an endpoint has to be correct — a declared-but-not-forwarded field is exactly the failure mode being fixed. `python/tests/test_js_parity_schemas.py` asserts fields are present in `model_fields` rather than via attribute access, since `CloudModel` allows extra keys and attribute access would pass even for an undeclared field.