### PR TITLE
fix(sdk): stop pinning the pubkey request to the node-keyed API

### DIFF
--- a/go/kms.go
+++ b/go/kms.go
@@ -68,11 +68,12 @@ func (c *Client) NextAppIDs(ctx context.Context) (*NextAppIDsResponse, error) {
 
 // GetAppEnvEncryptPubKey returns the environment encryption public key for an app.
 //
-// Pinned to the node-keyed shape: kmsType is a KMS node id/slug.
+// kmsType accepts a contract slug, a kms_type, or a kms_ node id: the server
+// resolves node-era identifiers onto their contract.
 func (c *Client) GetAppEnvEncryptPubKey(ctx context.Context, kmsType, appID string) (*AppEnvPubKeyResponse, error) {
 	var result AppEnvPubKeyResponse
 	path := fmt.Sprintf("/kms/%s/pubkey/%s", kmsType, appID)
-	if err := c.doJSONVersioned(ctx, "GET", path, "2026-05-22", nil, &result); err != nil {
+	if err := c.doJSON(ctx, "GET", path, nil, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil

--- a/js/src/actions/kms/get_app_env_encrypt_pubkey.test.ts
+++ b/js/src/actions/kms/get_app_env_encrypt_pubkey.test.ts
@@ -39,7 +39,7 @@ describe("getAppEnvEncryptPubKey", () => {
 
       const result = await getAppEnvEncryptPubKey(client, mockRequest);
 
-      expect(mockGet).toHaveBeenCalledWith(`/kms/${mockRequest.kms}/pubkey/${mockRequest.app_id}`, { headers: { "X-Phala-Version": "2026-05-22" } });
+      expect(mockGet).toHaveBeenCalledWith(`/kms/${mockRequest.kms}/pubkey/${mockRequest.app_id}`);
       expect(result).toEqual(mockAppEnvEncryptPubKeyData);
       expect((result as GetAppEnvEncryptPubKey).public_key).toBe(mockAppEnvEncryptPubKeyData.public_key);
     });
@@ -77,7 +77,7 @@ describe("getAppEnvEncryptPubKey", () => {
 
       await getAppEnvEncryptPubKey(client, differentRequest);
 
-      expect(mockGet).toHaveBeenCalledWith(`/kms/${differentRequest.kms}/pubkey/${differentRequest.app_id}`, { headers: { "X-Phala-Version": "2026-05-22" } });
+      expect(mockGet).toHaveBeenCalledWith(`/kms/${differentRequest.kms}/pubkey/${differentRequest.app_id}`);
     });
 
     it("should handle special characters in KMS ID", async () => {
@@ -90,7 +90,7 @@ describe("getAppEnvEncryptPubKey", () => {
 
       await getAppEnvEncryptPubKey(client, specialRequest);
 
-      expect(mockGet).toHaveBeenCalledWith(`/kms/${specialRequest.kms}/pubkey/${specialRequest.app_id}`, { headers: { "X-Phala-Version": "2026-05-22" } });
+      expect(mockGet).toHaveBeenCalledWith(`/kms/${specialRequest.kms}/pubkey/${specialRequest.app_id}`);
     });
 
     it("should handle long public key and signature", async () => {
@@ -113,7 +113,7 @@ describe("getAppEnvEncryptPubKey", () => {
 
       const result = await safeGetAppEnvEncryptPubKey(client, mockRequest);
 
-      expect(mockGet).toHaveBeenCalledWith(`/kms/${mockRequest.kms}/pubkey/${mockRequest.app_id}`, { headers: { "X-Phala-Version": "2026-05-22" } });
+      expect(mockGet).toHaveBeenCalledWith(`/kms/${mockRequest.kms}/pubkey/${mockRequest.app_id}`);
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data).toEqual(mockAppEnvEncryptPubKeyData);

--- a/js/src/actions/kms/get_app_env_encrypt_pubkey.ts
+++ b/js/src/actions/kms/get_app_env_encrypt_pubkey.ts
@@ -30,11 +30,10 @@ const { action: getAppEnvEncryptPubKey, safeAction: safeGetAppEnvEncryptPubKey }
   typeof GetAppEnvEncryptPubKeySchema
 >(GetAppEnvEncryptPubKeySchema, async (client, payload) => {
   const validatedRequest = GetAppEnvEncryptPubKeyRequestSchema.parse(payload);
-  // Pinned to the node-keyed shape: {kms} is a KMS node id/slug, and the
-  // endpoint serves the env pubkey for that node (not a contract slug).
-  return await client.get(`/kms/${validatedRequest.kms}/pubkey/${validatedRequest.app_id}`, {
-    headers: { "X-Phala-Version": "2026-05-22" },
-  });
+  // {kms} accepts a contract slug, a kms_type, or a kms_ node id: the server
+  // resolves node-era identifiers onto their contract. Callers holding a
+  // cvm.kms_type keep working without translating it first.
+  return await client.get(`/kms/${validatedRequest.kms}/pubkey/${validatedRequest.app_id}`);
 });
 
 export { getAppEnvEncryptPubKey, safeGetAppEnvEncryptPubKey };

--- a/python/src/phala_cloud/full_client.py
+++ b/python/src/phala_cloud/full_client.py
@@ -1044,11 +1044,12 @@ class PhalaCloud(_SyncBase, _ExtMixin):
 
     def get_app_env_encrypt_pub_key(self, request: KmsPubkeyRequest | Mapping[str, Any]) -> Any:
         req = KmsPubkeyRequest.model_validate(request)
+        # `kms` accepts a contract slug, a kms_type, or a kms_ node id: the
+        # server resolves node-era identifiers onto their contract.
         return self._loose_validate(
             self.request(
                 "GET",
                 f"/kms/{req.kms}/pubkey/{req.app_id}",
-                headers={"X-Phala-Version": "2026-05-22"},
             )
         )
 
@@ -1874,11 +1875,12 @@ class AsyncPhalaCloud(_AsyncBase, _ExtMixin):
         self, request: KmsPubkeyRequest | Mapping[str, Any]
     ) -> Any:
         req = KmsPubkeyRequest.model_validate(request)
+        # `kms` accepts a contract slug, a kms_type, or a kms_ node id: the
+        # server resolves node-era identifiers onto their contract.
         return self._loose_validate(
             await self.request(
                 "GET",
                 f"/kms/{req.kms}/pubkey/{req.app_id}",
-                headers={"X-Phala-Version": "2026-05-22"},
             )
         )
 


### PR DESCRIPTION
## Problem

`get_app_env_encrypt_pubkey` sent `X-Phala-Version: 2026-05-22` on every request. That version predates the contract-centric KMS API (2026-06-23), so the request always resolved through the node namespace.

The CLI passes `cvm.kms_type` as the path segment (`cli/src/commands/envs/get-encrypt-pubkey.ts:71`), which is `"ethereum"` for on-chain KMS. Combined, every call landed on the server's `kms_type` fallback, which returned a replica **regardless of whether an operator had disabled it**.

In production that fallback consistently selected `kms-eth-prod6` (`enabled=false`), a node that accepts TCP but never answers HTTP. Every affected CLI command hung for the full 30s server-side RPC timeout and then reported an error with an empty message:

- `phala cvms replicate`
- `phala instances add`
- `phala deploy` / `phala cvms upgrade` on the encrypted-env path

Measured 5/5 failures at ~30s each against an Ethereum KMS.

## Change

Drop the pin so the request uses the current API version. The server-side change resolves node-era identifiers (a `kms_type` or a `kms_` node id) onto their contract, so callers holding a `cvm.kms_type` keep working without translating it first — and now get the contract API's health filtering, which excludes disabled replicas.

Applied across all three SDKs. JS, Python, and Go each carried the same pin and the same `"pinned to the node-keyed shape"` comment:

- `js/src/actions/kms/get_app_env_encrypt_pubkey.ts`
- `python/src/phala_cloud/full_client.py` (sync + async)
- `go/kms.go`

## Scope note

Only the pubkey request is unpinned. `get_kms_info` and `get_kms_list` keep their `2026-05-22` pin on purpose — those return the node-shaped payload and coexist with the contract-shaped `get_kms_contract` / `list_kms_contracts`. Unpinning them would change their response structure.

## Dependency

**Requires the server-side compatibility layer to be deployed first** (Phala-Network/phala-cloud-monorepo#1952). Without it, every released client that passes a `kms_type` starts returning 404 the moment this ships.

## Verification

- JS SDK: 796 tests passed (61 files); pin assertions in `get_app_env_encrypt_pubkey.test.ts` updated.
- Go SDK: `go build`, `go vet`, `go test ./...` all pass.
- CLI: 458 passed / 0 failed after building `dist/` (the suite runs against the build artifact).
- Full `pre-commit` run green: ruff-format, ruff, gofmt, go vet, go test, biome, tsc, JS SDK build and tests.