### PR TITLE
feat: API token self-revoke for JS SDK and CLI

### DIFF
--- a/cli/docs/logout.md
+++ b/cli/docs/logout.md
@@ -2,6 +2,10 @@
 
 Remove stored API key from the current profile.
 
+Before removing the profile locally, the CLI asks the server to revoke the
+profile's API token (best effort: if the token is already invalid or the
+server does not support revocation, the logout still succeeds).
+
 ## Usage
 
 ```bash

--- a/cli/docs/profiles.md
+++ b/cli/docs/profiles.md
@@ -70,6 +70,22 @@ $ phala profiles delete work personal
 If the deleted profile was active, the CLI switches to one of the remaining
 profiles.
 
+### Refresh a profile
+
+Use `phala profiles refresh <name>` when a profile's token stopped working
+(for example `phala whoami` reports "Invalid API key"). The CLI first tries
+to revoke the old token on the server, then re-authenticates via the device
+flow (or `--manual` to paste a new API key) and stores the fresh token under
+the same profile name.
+
+```bash
+$ phala profiles refresh work
+To authenticate, visit:
+https://cloud.phala.network/device?user_code=XXXX-XXXX
+...
+✓ Profile "work" refreshed (user: alice)
+```
+
 ## Profile Storage
 
 Profiles are stored in `~/.phala-cloud/credentials.json`

--- a/cli/docs/profiles.md
+++ b/cli/docs/profiles.md
@@ -51,17 +51,28 @@ $ phala switch work
 ✓ Switched to profile: work
 ```
 
-### Delete a profile
+### Delete profiles
 
-Manually remove the profile file:
+Use `phala profiles delete <name> [more-names...]` (alias: `rm`). Deleting a
+profile also asks the server to revoke its API token; if the token is already
+invalid or the server does not support revocation, the profile is still
+removed locally.
 
 ```bash
-$ rm ~/.phala-cloud/profiles/work.json
+$ phala profiles delete work
+✓ Deleted profile "work"
+
+$ phala profiles delete work personal
+✓ Deleted profile "work"
+✓ Deleted profile "personal"
 ```
+
+If the deleted profile was active, the CLI switches to one of the remaining
+profiles.
 
 ## Profile Storage
 
-Profiles are stored in `~/.phala-cloud/profiles/<name>.json`
+Profiles are stored in `~/.phala-cloud/credentials.json`
 
 Each profile contains:
 - API key

--- a/cli/src/commands/auth/login/command.ts
+++ b/cli/src/commands/auth/login/command.ts
@@ -3,7 +3,7 @@ import type { CommandMeta } from "@/src/core/types";
 
 export const loginCommandMeta: CommandMeta = {
 	name: "login",
-	description: "Authenticate with Phala Cloud (use 'phala login' instead)",
+	description: "Removed. Use 'phala login' instead.",
 	stability: "deprecated",
 	arguments: [
 		{

--- a/cli/src/commands/auth/login/index.ts
+++ b/cli/src/commands/auth/login/index.ts
@@ -1,147 +1,17 @@
-import prompts from "prompts";
-import { safeGetCurrentUser } from "@phala/cloud";
 import { defineCommand } from "@/src/core/define-command";
-import type { CommandContext } from "@/src/core/types";
-import { getClientWithKey } from "@/src/lib/client";
-import { DEFAULT_API_PREFIX, upsertProfile } from "@/src/utils/credentials";
-import { CLOUD_URL } from "@/src/utils/constants";
-
 import { logger } from "@/src/utils/logger";
 import { loginCommandMeta, loginCommandSchema } from "./command";
-import type { LoginCommandInput } from "./command";
-
-interface CurrentUserInfo {
-	username: string;
-	email?: string;
-	workspace_name?: string;
-	workspace_slug?: string;
-}
-
-async function validateApiKey(options: {
-	apiKey: string;
-	baseURL: string;
-}): Promise<CurrentUserInfo> {
-	const client = await getClientWithKey(options.apiKey, {
-		baseURL: options.baseURL,
-	});
-	const result = await safeGetCurrentUser(client);
-
-	if (!result.success || !result.data?.user.username) {
-		throw new Error("Invalid API key");
-	}
-
-	return {
-		username: result.data.user.username,
-		email: result.data.user.email,
-		workspace_name: result.data.workspace.name,
-		workspace_slug: result.data.workspace.slug || undefined,
-	};
-}
-
-async function promptForApiKey(options: {
-	baseURL: string;
-}): Promise<{ apiKey: string; user: CurrentUserInfo }> {
-	let cachedUser: CurrentUserInfo | undefined;
-	const response = await prompts({
-		type: "password",
-		name: "apiKey",
-		message: "Enter your API key:",
-		validate: async (value: string) => {
-			if (!value || value.trim().length === 0) {
-				return "API key cannot be empty";
-			}
-			try {
-				cachedUser = await validateApiKey({
-					apiKey: value,
-					baseURL: options.baseURL,
-				});
-				return true;
-			} catch (error) {
-				return error instanceof Error ? error.message : "Invalid API key";
-			}
-		},
-	});
-
-	if (!response.apiKey) {
-		throw new Error("API key input cancelled");
-	}
-
-	if (!cachedUser) {
-		cachedUser = await validateApiKey({
-			apiKey: response.apiKey,
-			baseURL: options.baseURL,
-		});
-	}
-
-	return { apiKey: response.apiKey, user: cachedUser };
-}
-
-async function runLoginCommand(
-	input: LoginCommandInput,
-	context: CommandContext,
-): Promise<number> {
-	// Show deprecation warning
-	logger.warn(
-		'The "phala auth login" command is deprecated and will be removed in a future version.',
-	);
-	logger.info('Please use "phala login" instead for a better experience.');
-	logger.break();
-
-	try {
-		const baseURL = context.env.PHALA_CLOUD_API_PREFIX || DEFAULT_API_PREFIX;
-
-		let apiKey = input.apiKey;
-		let user: CurrentUserInfo | undefined;
-
-		if (!apiKey) {
-			const result = await promptForApiKey({ baseURL });
-			apiKey = result.apiKey;
-			user = result.user;
-		} else {
-			user = await validateApiKey({ apiKey, baseURL });
-		}
-
-		if (!user) {
-			throw new Error("Failed to validate API key");
-		}
-
-		const workspaceName = user.workspace_name || "default";
-		const workspaceSlug = user.workspace_slug;
-		const profileName = workspaceSlug || "default";
-
-		upsertProfile({
-			profileName,
-			token: apiKey,
-			apiPrefix: baseURL,
-			workspaceName,
-			workspaceSlug,
-			user: {
-				username: user.username,
-				email: user.email,
-			},
-			setCurrent: true,
-		});
-
-		logger.success(
-			`Welcome ${user.username}! Credentials saved successfully (profile: ${profileName})`,
-		);
-		logger.break();
-		logger.info(`Open in Web UI at ${CLOUD_URL}/dashboard/`);
-		return 0;
-	} catch (error) {
-		context.failWithError(error, {
-			operation: "Login",
-			debug: Boolean((input as { debug?: boolean }).debug),
-		});
-		return 1;
-	}
-}
 
 export const loginCommand = defineCommand({
 	path: ["auth", "login"],
 	meta: loginCommandMeta,
 	schema: loginCommandSchema,
-	handler: runLoginCommand,
+	handler: async () => {
+		logger.error(
+			'The "phala auth login" command has been removed. Use "phala login" instead.',
+		);
+		return 1;
+	},
 });
 
 export default loginCommand;

--- a/cli/src/commands/auth/logout/command.ts
+++ b/cli/src/commands/auth/logout/command.ts
@@ -3,7 +3,7 @@ import type { CommandMeta } from "@/src/core/types";
 
 export const logoutCommandMeta: CommandMeta = {
 	name: "logout",
-	description: "Remove stored API key (use 'phala logout' instead)",
+	description: "Removed. Use 'phala logout' instead.",
 	stability: "deprecated",
 };
 

--- a/cli/src/commands/auth/logout/index.ts
+++ b/cli/src/commands/auth/logout/index.ts
@@ -1,54 +1,17 @@
 import { defineCommand } from "@/src/core/define-command";
-import type { CommandContext } from "@/src/core/types";
-import { loadCredentialsFile, removeProfile } from "@/src/utils/credentials";
-
 import { logger } from "@/src/utils/logger";
-import {
-	logoutCommandMeta,
-	logoutCommandSchema,
-	type LogoutCommandInput,
-} from "./command";
-
-async function runLogoutCommand(
-	_input: LogoutCommandInput,
-	context: CommandContext,
-): Promise<number> {
-	// Show deprecation warning
-	logger.warn(
-		'The "phala auth logout" command is deprecated and will be removed in a future version.',
-	);
-	logger.info('Please use "phala logout" instead.');
-	logger.break();
-
-	try {
-		const current = loadCredentialsFile();
-		const profile = current?.current_profile;
-		removeProfile();
-		const message = profile
-			? `Credentials removed successfully (profile: ${profile})`
-			: "Credentials removed successfully";
-		if (context.globalOptions?.json) {
-			context.success({ message, profile: profile || null });
-			return 0;
-		}
-		logger.success(message);
-		return 0;
-	} catch (error) {
-		if (context.globalOptions?.json) {
-			context.fail("Failed to remove credentials");
-			return 1;
-		}
-		logger.error("Failed to remove credentials");
-		logger.logDetailedError(error);
-		return 1;
-	}
-}
+import { logoutCommandMeta, logoutCommandSchema } from "./command";
 
 export const logoutCommand = defineCommand({
 	path: ["auth", "logout"],
 	meta: logoutCommandMeta,
 	schema: logoutCommandSchema,
-	handler: runLogoutCommand,
+	handler: async () => {
+		logger.error(
+			'The "phala auth logout" command has been removed. Use "phala logout" instead.',
+		);
+		return 1;
+	},
 });
 
 export default logoutCommand;

--- a/cli/src/commands/auth/status/command.ts
+++ b/cli/src/commands/auth/status/command.ts
@@ -8,7 +8,7 @@ import {
 
 export const authStatusCommandMeta: CommandMeta = {
 	name: "status",
-	description: "Check auth status (use 'phala status' instead)",
+	description: "Removed. Use 'phala status' instead.",
 	stability: "deprecated",
 	options: [...commonAuthOptions, jsonOption, debugOption],
 };

--- a/cli/src/commands/auth/status/index.ts
+++ b/cli/src/commands/auth/status/index.ts
@@ -1,7 +1,4 @@
 import { defineCommand } from "@/src/core/define-command";
-import type { CommandContext } from "@/src/core/types";
-import { runStatusCommand } from "@/src/commands/status";
-import type { StatusCommandInput } from "@/src/commands/status/command";
 import { logger } from "@/src/utils/logger";
 import { authStatusCommandMeta, authStatusCommandSchema } from "./command";
 
@@ -9,16 +6,11 @@ export const authStatusCommand = defineCommand({
 	path: ["auth", "status"],
 	meta: authStatusCommandMeta,
 	schema: authStatusCommandSchema,
-	handler: async (input: StatusCommandInput, context: CommandContext) => {
-		// Show deprecation warning (unless in JSON mode)
-		if (!input.json) {
-			logger.warn(
-				'The "phala auth status" command is deprecated and will be removed in a future version.',
-			);
-			logger.info('Please use "phala status" instead.');
-			logger.break();
-		}
-		return runStatusCommand(input, context);
+	handler: async () => {
+		logger.error(
+			'The "phala auth status" command has been removed. Use "phala status" instead.',
+		);
+		return 1;
 	},
 });
 

--- a/cli/src/commands/login/index.ts
+++ b/cli/src/commands/login/index.ts
@@ -40,7 +40,7 @@ function writeLine(stream: NodeJS.WriteStream, message = ""): void {
 	stream.write(`${message}\n`);
 }
 
-async function validateApiKey(options: {
+export async function validateApiKey(options: {
 	apiKey: string;
 	baseURL: string;
 }): Promise<AuthResponse> {
@@ -56,7 +56,7 @@ async function validateApiKey(options: {
 	return result.data;
 }
 
-async function promptForApiKey(options: {
+export async function promptForApiKey(options: {
 	baseURL: string;
 }): Promise<{ apiKey: string; user: AuthResponse }> {
 	let cachedUser: AuthResponse | undefined;
@@ -94,7 +94,7 @@ async function promptForApiKey(options: {
 	return { apiKey: response.apiKey, user: cachedUser };
 }
 
-async function runDeviceAuthFlow(
+export async function runDeviceAuthFlow(
 	context: CommandContext,
 	options: {
 		noOpen?: boolean;

--- a/cli/src/commands/logout/index.test.ts
+++ b/cli/src/commands/logout/index.test.ts
@@ -1,0 +1,144 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { CommandContext } from "@/src/core/types";
+import type { RevokeTokenResult } from "@/src/lib/client";
+
+const mockTryRevokeApiToken = mock(
+	(): Promise<RevokeTokenResult> => Promise.resolve({ outcome: "revoked" }),
+);
+
+mock.module("@/src/lib/client", () => ({
+	tryRevokeApiToken: mockTryRevokeApiToken,
+}));
+
+const noop = () => {};
+mock.module("@/src/utils/logger", () => ({
+	logger: {
+		info: noop,
+		warn: noop,
+		error: noop,
+		success: noop,
+		break: noop,
+		logDetailedError: noop,
+	},
+}));
+
+const { logoutCommand } = await import("./index");
+const { saveCredentialsFile, loadCredentialsFile } = await import(
+	"@/src/utils/credentials"
+);
+
+function makeContext(json = false): CommandContext {
+	return {
+		argv: [],
+		rawFlags: {},
+		rawPositionals: [],
+		cwd: process.cwd(),
+		env: process.env,
+		stdout: process.stdout,
+		stderr: process.stderr,
+		stdin: process.stdin,
+		projectConfig: {},
+		globalOptions: { json },
+		success() {},
+		fail() {},
+		failWithError() {},
+	} as unknown as CommandContext;
+}
+
+function profile(token: string) {
+	return {
+		token,
+		api_prefix: "https://example.test/api/v1",
+		workspace: { name: "W" },
+		user: { username: "u" },
+		updated_at: "2026-01-01T00:00:00.000Z",
+	};
+}
+
+describe("logout command", () => {
+	let tempDir: string;
+	let oldDir: string | undefined;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "phala-cli-test-"));
+		oldDir = process.env.PHALA_CLOUD_DIR;
+		process.env.PHALA_CLOUD_DIR = tempDir;
+		mockTryRevokeApiToken.mockClear();
+		mockTryRevokeApiToken.mockImplementation(() =>
+			Promise.resolve({ outcome: "revoked" }),
+		);
+	});
+
+	afterEach(() => {
+		if (oldDir === undefined) {
+			process.env.PHALA_CLOUD_DIR = undefined;
+		} else {
+			process.env.PHALA_CLOUD_DIR = oldDir;
+		}
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test("revokes the current profile token before removing it locally", async () => {
+		saveCredentialsFile({
+			schema_version: 1,
+			current_profile: "alpha",
+			profiles: { alpha: profile("phak_alpha"), beta: profile("phak_beta") },
+		});
+
+		const code = await logoutCommand.run({}, makeContext());
+
+		expect(code).toBe(0);
+		expect(mockTryRevokeApiToken).toHaveBeenCalledTimes(1);
+		expect(mockTryRevokeApiToken).toHaveBeenCalledWith({
+			apiKey: "phak_alpha",
+			baseURL: "https://example.test/api/v1",
+		});
+
+		// Only the current profile was removed
+		const remaining = loadCredentialsFile();
+		expect(Object.keys(remaining?.profiles ?? {})).toEqual(["beta"]);
+		expect(remaining?.current_profile).toBe("beta");
+	});
+
+	test("revoke failure still removes the profile locally", async () => {
+		mockTryRevokeApiToken.mockImplementation(() =>
+			Promise.resolve({ outcome: "failed", message: "boom" }),
+		);
+		saveCredentialsFile({
+			schema_version: 1,
+			current_profile: "alpha",
+			profiles: { alpha: profile("phak_alpha") },
+		});
+
+		const code = await logoutCommand.run({}, makeContext());
+
+		expect(code).toBe(0);
+		expect(loadCredentialsFile()).toBeNull();
+	});
+
+	test("json output reports whether the token was revoked", async () => {
+		saveCredentialsFile({
+			schema_version: 1,
+			current_profile: "alpha",
+			profiles: { alpha: profile("phak_alpha") },
+		});
+
+		let payload: unknown;
+		const context = makeContext(true);
+		context.success = ((data: unknown) => {
+			payload = data;
+		}) as CommandContext["success"];
+
+		const code = await logoutCommand.run({}, context);
+
+		expect(code).toBe(0);
+		expect(payload).toEqual({
+			message: "Credentials removed successfully (profile: alpha)",
+			profile: "alpha",
+			revoked: true,
+		});
+	});
+});

--- a/cli/src/commands/logout/index.ts
+++ b/cli/src/commands/logout/index.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from "@/src/core/define-command";
 import type { CommandContext } from "@/src/core/types";
+import { tryRevokeApiToken } from "@/src/lib/client";
 import { loadCredentialsFile, removeProfile } from "@/src/utils/credentials";
 
 import { logger } from "@/src/utils/logger";
@@ -13,21 +14,45 @@ async function runLogoutCommand(
 	_input: LogoutCommandInput,
 	context: CommandContext,
 ): Promise<number> {
+	const isJson = context.globalOptions?.json === true;
+
 	try {
 		const current = loadCredentialsFile();
 		const profile = current?.current_profile;
+		const info = profile ? current?.profiles[profile] : undefined;
+
+		// Best-effort server-side revocation before removing the profile
+		// locally. Failures never block the local removal: the token may
+		// already be invalid (401) or the server may predate self-revoke (404).
+		let revoked = false;
+		if (info?.token) {
+			const result = await tryRevokeApiToken({
+				apiKey: info.token,
+				baseURL: info.api_prefix,
+			});
+			revoked = result.outcome === "revoked";
+			if (!isJson && result.outcome === "failed") {
+				logger.warn(
+					`Could not revoke the API token on the server: ${result.message}`,
+				);
+			}
+		}
+
 		removeProfile();
 		const message = profile
 			? `Credentials removed successfully (profile: ${profile})`
 			: "Credentials removed successfully";
-		if (context.globalOptions?.json) {
-			context.success({ message, profile: profile || null });
+		if (isJson) {
+			context.success({ message, profile: profile || null, revoked });
 			return 0;
 		}
 		logger.success(message);
+		if (revoked) {
+			logger.info("API token revoked on the server");
+		}
 		return 0;
 	} catch (error) {
-		if (context.globalOptions?.json) {
+		if (isJson) {
 			context.fail("Failed to remove credentials");
 			return 1;
 		}

--- a/cli/src/commands/profiles/delete/command.ts
+++ b/cli/src/commands/profiles/delete/command.ts
@@ -4,22 +4,33 @@ import type { CommandMeta } from "@/src/core/types";
 export const profilesDeleteCommandMeta: CommandMeta = {
 	name: "delete",
 	category: "profile",
-	description: "Delete an auth profile",
+	description: "Delete one or more auth profiles",
 	stability: "stable",
 	arguments: [
 		{
-			name: "profile-name",
-			description: "Profile name",
+			name: "profile-names...",
+			description: "Profile name(s) to delete",
 			required: true,
-			target: "profileName",
+			variadic: true,
+			target: "profileNames",
 		},
 	],
 	options: [],
 	aliases: ["rm"],
+	examples: [
+		{
+			name: "Delete a single profile",
+			value: "phala profiles delete my-profile",
+		},
+		{
+			name: "Delete multiple profiles",
+			value: "phala profiles delete profile-a profile-b",
+		},
+	],
 };
 
 export const profilesDeleteCommandSchema = z.object({
-	profileName: z.string().min(1),
+	profileNames: z.array(z.string().min(1)).min(1),
 });
 
 export type ProfilesDeleteCommandInput = z.infer<

--- a/cli/src/commands/profiles/delete/index.test.ts
+++ b/cli/src/commands/profiles/delete/index.test.ts
@@ -1,0 +1,183 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { CommandContext } from "@/src/core/types";
+import type { RevokeTokenResult } from "@/src/lib/client";
+
+const mockTryRevokeApiToken = mock(
+	(): Promise<RevokeTokenResult> => Promise.resolve({ outcome: "revoked" }),
+);
+
+mock.module("@/src/lib/client", () => ({
+	tryRevokeApiToken: mockTryRevokeApiToken,
+}));
+
+const noop = () => {};
+mock.module("@/src/utils/logger", () => ({
+	logger: {
+		info: noop,
+		warn: noop,
+		error: noop,
+		success: noop,
+		break: noop,
+		logDetailedError: noop,
+	},
+}));
+
+const { profilesDeleteCommand } = await import("./index");
+const { saveCredentialsFile, loadCredentialsFile } = await import(
+	"@/src/utils/credentials"
+);
+
+function makeContext(json = false): CommandContext {
+	return {
+		argv: [],
+		rawFlags: {},
+		rawPositionals: [],
+		cwd: process.cwd(),
+		env: process.env,
+		stdout: process.stdout,
+		stderr: process.stderr,
+		stdin: process.stdin,
+		projectConfig: {},
+		globalOptions: { json },
+		success() {},
+		fail() {},
+		failWithError() {},
+	} as unknown as CommandContext;
+}
+
+function profile(token: string) {
+	return {
+		token,
+		api_prefix: "https://example.test/api/v1",
+		workspace: { name: "W" },
+		user: { username: "u" },
+		updated_at: "2026-01-01T00:00:00.000Z",
+	};
+}
+
+describe("profiles delete command", () => {
+	let tempDir: string;
+	let oldDir: string | undefined;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "phala-cli-test-"));
+		oldDir = process.env.PHALA_CLOUD_DIR;
+		process.env.PHALA_CLOUD_DIR = tempDir;
+		mockTryRevokeApiToken.mockClear();
+		mockTryRevokeApiToken.mockImplementation(() =>
+			Promise.resolve({ outcome: "revoked" }),
+		);
+	});
+
+	afterEach(() => {
+		if (oldDir === undefined) {
+			process.env.PHALA_CLOUD_DIR = undefined;
+		} else {
+			process.env.PHALA_CLOUD_DIR = oldDir;
+		}
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test("deletes multiple profiles and reports the active switch", async () => {
+		saveCredentialsFile({
+			schema_version: 1,
+			current_profile: "alpha",
+			profiles: {
+				alpha: profile("phak_alpha"),
+				beta: profile("phak_beta"),
+				gamma: profile("phak_gamma"),
+			},
+		});
+
+		const code = await profilesDeleteCommand.run(
+			{ profileNames: ["alpha", "beta"] },
+			makeContext(),
+		);
+
+		expect(code).toBe(0);
+		const remaining = loadCredentialsFile();
+		expect(Object.keys(remaining?.profiles ?? {})).toEqual(["gamma"]);
+		expect(remaining?.current_profile).toBe("gamma");
+
+		// Revocation attempted once per deleted profile with its own token
+		expect(mockTryRevokeApiToken).toHaveBeenCalledTimes(2);
+		expect(mockTryRevokeApiToken).toHaveBeenCalledWith({
+			apiKey: "phak_alpha",
+			baseURL: "https://example.test/api/v1",
+		});
+		expect(mockTryRevokeApiToken).toHaveBeenCalledWith({
+			apiKey: "phak_beta",
+			baseURL: "https://example.test/api/v1",
+		});
+	});
+
+	test("fails fast when any name is unknown and deletes nothing", async () => {
+		saveCredentialsFile({
+			schema_version: 1,
+			current_profile: "alpha",
+			profiles: { alpha: profile("phak_alpha"), beta: profile("phak_beta") },
+		});
+
+		const code = await profilesDeleteCommand.run(
+			{ profileNames: ["alpha", "nope"] },
+			makeContext(),
+		);
+
+		expect(code).toBe(1);
+		const remaining = loadCredentialsFile();
+		expect(Object.keys(remaining?.profiles ?? {})).toEqual(["alpha", "beta"]);
+		expect(remaining?.current_profile).toBe("alpha");
+		expect(mockTryRevokeApiToken).not.toHaveBeenCalled();
+	});
+
+	test("revoke failure still removes the profile locally", async () => {
+		mockTryRevokeApiToken.mockImplementation(() =>
+			Promise.resolve({ outcome: "failed", message: "boom" }),
+		);
+		saveCredentialsFile({
+			schema_version: 1,
+			current_profile: "alpha",
+			profiles: { alpha: profile("phak_alpha"), beta: profile("phak_beta") },
+		});
+
+		const code = await profilesDeleteCommand.run(
+			{ profileNames: ["alpha"] },
+			makeContext(),
+		);
+
+		expect(code).toBe(0);
+		const remaining = loadCredentialsFile();
+		expect(Object.keys(remaining?.profiles ?? {})).toEqual(["beta"]);
+	});
+
+	test("json output reports deleted and revoked sets", async () => {
+		saveCredentialsFile({
+			schema_version: 1,
+			current_profile: "alpha",
+			profiles: { alpha: profile("phak_alpha"), beta: profile("phak_beta") },
+		});
+
+		let payload: unknown;
+		const context = makeContext(true);
+		context.success = ((data: unknown) => {
+			payload = data;
+		}) as CommandContext["success"];
+
+		const code = await profilesDeleteCommand.run(
+			{ profileNames: ["alpha", "beta"] },
+			context,
+		);
+
+		expect(code).toBe(0);
+		expect(payload).toEqual({
+			deleted: ["alpha", "beta"],
+			revoked: ["alpha", "beta"],
+			revokeSkipped: [],
+			wasActive: true,
+			currentProfile: null,
+		});
+	});
+});

--- a/cli/src/commands/profiles/delete/index.ts
+++ b/cli/src/commands/profiles/delete/index.ts
@@ -1,9 +1,11 @@
 import { defineCommand } from "@/src/core/define-command";
 import type { CommandContext } from "@/src/core/types";
+import { tryRevokeApiToken } from "@/src/lib/client";
 import {
 	removeProfile,
 	getCurrentProfile,
 	listProfiles,
+	loadCredentialsFile,
 } from "@/src/utils/credentials";
 import { logger } from "@/src/utils/logger";
 import {
@@ -16,32 +18,75 @@ async function runProfilesDeleteCommand(
 	input: ProfilesDeleteCommandInput,
 	context: CommandContext,
 ): Promise<number> {
+	const isJson = context.globalOptions?.json === true;
+
 	try {
-		const wasActive = getCurrentProfile()?.name === input.profileName;
+		const credentials = loadCredentialsFile();
 		const profilesBefore = listProfiles();
 
-		if (!profilesBefore.includes(input.profileName)) {
-			if (context.globalOptions?.json) {
-				context.fail(`Profile "${input.profileName}" not found`);
+		// Fail fast: refuse to delete anything if any name is unknown.
+		const missing = input.profileNames.filter(
+			(name) => !profilesBefore.includes(name),
+		);
+		if (missing.length > 0) {
+			const message =
+				missing.length === 1
+					? `Profile "${missing[0]}" not found`
+					: `Profiles not found: ${missing.map((name) => `"${name}"`).join(", ")}`;
+			if (isJson) {
+				context.fail(message);
 				return 1;
 			}
-			logger.error(`Profile "${input.profileName}" not found`);
+			logger.error(message);
 			return 1;
 		}
 
-		removeProfile(input.profileName);
+		const currentBefore = getCurrentProfile()?.name;
+		const wasActive =
+			currentBefore !== undefined && input.profileNames.includes(currentBefore);
+
+		// Best-effort server-side revocation before removing each profile
+		// locally. Failures never block the local delete: the token may already
+		// be invalid (401) or the server may predate self-revoke (404).
+		const revoked: string[] = [];
+		const revokeSkipped: string[] = [];
+		for (const name of input.profileNames) {
+			const info = credentials?.profiles[name];
+			if (info?.token) {
+				const result = await tryRevokeApiToken({
+					apiKey: info.token,
+					baseURL: info.api_prefix,
+				});
+				if (result.outcome === "revoked") {
+					revoked.push(name);
+				} else {
+					revokeSkipped.push(name);
+					if (!isJson && result.outcome === "failed") {
+						logger.warn(
+							`Could not revoke token for profile "${name}" on the server: ${result.message}`,
+						);
+					}
+				}
+			}
+			removeProfile(name);
+			if (!isJson) {
+				logger.success(`Deleted profile "${name}"`);
+			}
+		}
+
 		const newCurrent = getCurrentProfile();
 
-		if (context.globalOptions?.json) {
+		if (isJson) {
 			context.success({
-				deleted: input.profileName,
+				deleted: input.profileNames,
+				revoked,
+				revokeSkipped,
 				wasActive,
 				currentProfile: newCurrent?.name || null,
 			});
 			return 0;
 		}
 
-		logger.success(`Deleted profile "${input.profileName}"`);
 		if (wasActive) {
 			if (newCurrent) {
 				logger.info(`Switched to profile "${newCurrent.name}"`);
@@ -53,7 +98,7 @@ async function runProfilesDeleteCommand(
 		return 0;
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-		if (context.globalOptions?.json) {
+		if (isJson) {
 			context.fail(message);
 			return 1;
 		}

--- a/cli/src/commands/profiles/index.ts
+++ b/cli/src/commands/profiles/index.ts
@@ -79,5 +79,6 @@ export const profilesCommand = defineCommand({
 export { profilesUseCommand } from "./use";
 export { profilesRenameCommand } from "./rename";
 export { profilesDeleteCommand } from "./delete";
+export { profilesRefreshCommand } from "./refresh";
 
 export default profilesCommand;

--- a/cli/src/commands/profiles/refresh/command.ts
+++ b/cli/src/commands/profiles/refresh/command.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import type { CommandMeta } from "@/src/core/types";
+
+export const profilesRefreshCommandMeta: CommandMeta = {
+	name: "refresh",
+	category: "profile",
+	description: "Re-authenticate a profile with a fresh API token",
+	stability: "stable",
+	arguments: [
+		{
+			name: "profile-name",
+			description: "Profile name",
+			required: true,
+			target: "profileName",
+		},
+	],
+	options: [
+		{
+			name: "manual",
+			description: "Enter API key manually (skip device flow)",
+			type: "boolean",
+		},
+		{
+			name: "no-open",
+			description: "Skip browser launch",
+			type: "boolean",
+			target: "noOpen",
+		},
+	],
+	examples: [
+		{
+			name: "Refresh a profile via device flow",
+			value: "phala profiles refresh my-profile",
+		},
+		{
+			name: "Refresh a profile by pasting a new API key",
+			value: "phala profiles refresh my-profile --manual",
+		},
+	],
+};
+
+export const profilesRefreshCommandSchema = z.object({
+	profileName: z.string().min(1),
+	manual: z.boolean().optional(),
+	noOpen: z.boolean().optional(),
+});
+
+export type ProfilesRefreshCommandInput = z.infer<
+	typeof profilesRefreshCommandSchema
+>;

--- a/cli/src/commands/profiles/refresh/index.test.ts
+++ b/cli/src/commands/profiles/refresh/index.test.ts
@@ -1,0 +1,206 @@
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { CommandContext } from "@/src/core/types";
+import type { RevokeTokenResult } from "@/src/lib/client";
+
+const mockTryRevokeApiToken = mock(
+	(): Promise<RevokeTokenResult> => Promise.resolve({ outcome: "revoked" }),
+);
+const mockRunDeviceAuthFlow = mock(() => Promise.resolve("phak_newtoken"));
+const mockValidateApiKey = mock(() =>
+	Promise.resolve({
+		user: { username: "alice", email: "alice@example.test" },
+		workspace: { name: "Alpha WS", slug: "alpha-ws" },
+	}),
+);
+const mockPromptForApiKey = mock(() =>
+	Promise.resolve({
+		apiKey: "phak_manualtoken",
+		user: {
+			user: { username: "alice", email: "alice@example.test" },
+			workspace: { name: "Alpha WS", slug: "alpha-ws" },
+		},
+	}),
+);
+
+mock.module("@/src/lib/client", () => ({
+	tryRevokeApiToken: mockTryRevokeApiToken,
+}));
+
+mock.module("@/src/commands/login", () => ({
+	runDeviceAuthFlow: mockRunDeviceAuthFlow,
+	validateApiKey: mockValidateApiKey,
+	promptForApiKey: mockPromptForApiKey,
+}));
+
+const noop = () => {};
+mock.module("@/src/utils/logger", () => ({
+	logger: {
+		info: noop,
+		warn: noop,
+		error: noop,
+		success: noop,
+		break: noop,
+		logDetailedError: noop,
+	},
+}));
+
+const { profilesRefreshCommand } = await import("./index");
+const { saveCredentialsFile, loadCredentialsFile } = await import(
+	"@/src/utils/credentials"
+);
+
+function makeContext(json = false): CommandContext {
+	return {
+		argv: [],
+		rawFlags: {},
+		rawPositionals: [],
+		cwd: process.cwd(),
+		env: process.env,
+		stdout: process.stdout,
+		stderr: process.stderr,
+		stdin: process.stdin,
+		projectConfig: {},
+		globalOptions: { json },
+		success() {},
+		fail() {},
+		failWithError() {},
+	} as unknown as CommandContext;
+}
+
+function profile(token: string) {
+	return {
+		token,
+		api_prefix: "https://example.test/api/v1",
+		workspace: { name: "Alpha WS", slug: "alpha-ws" },
+		user: { username: "alice" },
+		updated_at: "2026-01-01T00:00:00.000Z",
+	};
+}
+
+describe("profiles refresh command", () => {
+	let tempDir: string;
+	let oldDir: string | undefined;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "phala-cli-test-"));
+		oldDir = process.env.PHALA_CLOUD_DIR;
+		process.env.PHALA_CLOUD_DIR = tempDir;
+		mockTryRevokeApiToken.mockClear();
+		mockTryRevokeApiToken.mockImplementation(() =>
+			Promise.resolve({ outcome: "revoked" }),
+		);
+		mockRunDeviceAuthFlow.mockClear();
+		mockValidateApiKey.mockClear();
+		mockPromptForApiKey.mockClear();
+	});
+
+	afterEach(() => {
+		if (oldDir === undefined) {
+			process.env.PHALA_CLOUD_DIR = undefined;
+		} else {
+			process.env.PHALA_CLOUD_DIR = oldDir;
+		}
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test("fails when the profile does not exist", async () => {
+		const code = await profilesRefreshCommand.run(
+			{ profileName: "nope" },
+			makeContext(),
+		);
+
+		expect(code).toBe(1);
+		expect(mockRunDeviceAuthFlow).not.toHaveBeenCalled();
+	});
+
+	test("revokes the old token, then stores the new one", async () => {
+		saveCredentialsFile({
+			schema_version: 1,
+			current_profile: "alpha",
+			profiles: { alpha: profile("phak_oldtoken") },
+		});
+
+		const code = await profilesRefreshCommand.run(
+			{ profileName: "alpha" },
+			makeContext(),
+		);
+
+		expect(code).toBe(0);
+
+		// Old token revoked first
+		expect(mockTryRevokeApiToken).toHaveBeenCalledTimes(1);
+		expect(mockTryRevokeApiToken).toHaveBeenCalledWith({
+			apiKey: "phak_oldtoken",
+			baseURL: "https://example.test/api/v1",
+		});
+		expect(mockTryRevokeApiToken.mock.invocationCallOrder[0]).toBeLessThan(
+			mockRunDeviceAuthFlow.mock.invocationCallOrder[0],
+		);
+
+		const saved = loadCredentialsFile();
+		expect(saved?.profiles.alpha.token).toBe("phak_newtoken");
+		expect(saved?.profiles.alpha.user.username).toBe("alice");
+		expect(saved?.current_profile).toBe("alpha");
+	});
+
+	test("refreshing a non-current profile keeps the current profile", async () => {
+		saveCredentialsFile({
+			schema_version: 1,
+			current_profile: "beta",
+			profiles: { alpha: profile("phak_oldtoken"), beta: profile("phak_beta") },
+		});
+
+		const code = await profilesRefreshCommand.run(
+			{ profileName: "alpha" },
+			makeContext(),
+		);
+
+		expect(code).toBe(0);
+		const saved = loadCredentialsFile();
+		expect(saved?.profiles.alpha.token).toBe("phak_newtoken");
+		expect(saved?.profiles.beta.token).toBe("phak_beta");
+		expect(saved?.current_profile).toBe("beta");
+	});
+
+	test("proceeds even when the old token is already invalid", async () => {
+		mockTryRevokeApiToken.mockImplementation(() =>
+			Promise.resolve({ outcome: "already-invalid" }),
+		);
+		saveCredentialsFile({
+			schema_version: 1,
+			current_profile: "alpha",
+			profiles: { alpha: profile("phak_deadtoken") },
+		});
+
+		const code = await profilesRefreshCommand.run(
+			{ profileName: "alpha" },
+			makeContext(),
+		);
+
+		expect(code).toBe(0);
+		expect(loadCredentialsFile()?.profiles.alpha.token).toBe("phak_newtoken");
+	});
+
+	test("--manual uses the prompt instead of the device flow", async () => {
+		saveCredentialsFile({
+			schema_version: 1,
+			current_profile: "alpha",
+			profiles: { alpha: profile("phak_oldtoken") },
+		});
+
+		const code = await profilesRefreshCommand.run(
+			{ profileName: "alpha", manual: true },
+			makeContext(),
+		);
+
+		expect(code).toBe(0);
+		expect(mockPromptForApiKey).toHaveBeenCalledTimes(1);
+		expect(mockRunDeviceAuthFlow).not.toHaveBeenCalled();
+		expect(loadCredentialsFile()?.profiles.alpha.token).toBe(
+			"phak_manualtoken",
+		);
+	});
+});

--- a/cli/src/commands/profiles/refresh/index.ts
+++ b/cli/src/commands/profiles/refresh/index.ts
@@ -1,0 +1,120 @@
+import { defineCommand } from "@/src/core/define-command";
+import type { CommandContext } from "@/src/core/types";
+import { tryRevokeApiToken } from "@/src/lib/client";
+import {
+	DEFAULT_API_PREFIX,
+	loadCredentialsFile,
+	upsertProfile,
+} from "@/src/utils/credentials";
+import {
+	promptForApiKey,
+	runDeviceAuthFlow,
+	validateApiKey,
+} from "@/src/commands/login";
+import { logger } from "@/src/utils/logger";
+import {
+	profilesRefreshCommandMeta,
+	profilesRefreshCommandSchema,
+	type ProfilesRefreshCommandInput,
+} from "./command";
+
+async function runProfilesRefreshCommand(
+	input: ProfilesRefreshCommandInput,
+	context: CommandContext,
+): Promise<number> {
+	const isJson = context.globalOptions?.json === true;
+
+	try {
+		const credentials = loadCredentialsFile();
+		const existing = credentials?.profiles[input.profileName];
+
+		if (!existing) {
+			const message = `Profile "${input.profileName}" not found`;
+			if (isJson) {
+				context.fail(message);
+				return 1;
+			}
+			logger.error(message);
+			return 1;
+		}
+
+		const baseURL =
+			context.env.PHALA_CLOUD_API_PREFIX ||
+			existing.api_prefix ||
+			DEFAULT_API_PREFIX;
+
+		// Best-effort revoke of the old token first. The common case for a
+		// refresh is that the old token is already invalid server-side (401),
+		// in which case this is a no-op.
+		if (existing.token) {
+			const result = await tryRevokeApiToken({
+				apiKey: existing.token,
+				baseURL,
+			});
+			if (!isJson && result.outcome === "revoked") {
+				logger.info("Previous API token revoked on the server");
+			}
+			if (!isJson && result.outcome === "failed") {
+				logger.warn(
+					`Could not revoke the previous token on the server: ${result.message}`,
+				);
+			}
+		}
+
+		let apiKey: string;
+		let user;
+		if (input.manual) {
+			const result = await promptForApiKey({ baseURL });
+			apiKey = result.apiKey;
+			user = result.user;
+		} else {
+			apiKey = await runDeviceAuthFlow(context, {
+				noOpen: input.noOpen,
+				baseURL,
+			});
+			user = await validateApiKey({ apiKey, baseURL });
+		}
+
+		upsertProfile({
+			profileName: input.profileName,
+			token: apiKey,
+			apiPrefix: baseURL,
+			workspaceName: user.workspace.name || existing.workspace.name,
+			workspaceSlug: user.workspace.slug || existing.workspace.slug,
+			user: {
+				username: user.user.username,
+				email: user.user.email,
+			},
+			// Keep the current profile unchanged unless the refreshed profile
+			// is the current one.
+			setCurrent: credentials?.current_profile === input.profileName,
+		});
+
+		if (isJson) {
+			context.success({
+				refreshed: input.profileName,
+				username: user.user.username,
+			});
+			return 0;
+		}
+		logger.success(
+			`Profile "${input.profileName}" refreshed (user: ${user.user.username})`,
+		);
+		return 0;
+	} catch (error) {
+		context.failWithError(error, {
+			operation: "Refresh profile",
+			debug: Boolean((input as { debug?: boolean }).debug),
+		});
+		return 1;
+	}
+}
+
+export const profilesRefreshCommand = defineCommand({
+	path: ["profiles", "refresh"],
+	meta: profilesRefreshCommandMeta,
+	schema: profilesRefreshCommandSchema,
+	handler: runProfilesRefreshCommand,
+});
+
+export default profilesRefreshCommand;

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -26,6 +26,7 @@ import {
 	profilesUseCommand,
 	profilesRenameCommand,
 	profilesDeleteCommand,
+	profilesRefreshCommand,
 } from "./commands/profiles";
 import { switchCommand } from "./commands/switch";
 import { completionCommand } from "./commands/completion";
@@ -81,6 +82,7 @@ registry.registerCommand(profilesCommand);
 registry.registerCommand(profilesUseCommand);
 registry.registerCommand(profilesRenameCommand);
 registry.registerCommand(profilesDeleteCommand);
+registry.registerCommand(profilesRefreshCommand);
 registry.registerCommand(switchCommand);
 registry.registerCommand(apiCommand);
 registry.registerCommand(statusCommand);

--- a/cli/src/lib/client.ts
+++ b/cli/src/lib/client.ts
@@ -1,4 +1,8 @@
-import { createClient, type Client } from "@phala/cloud";
+import {
+	createClient,
+	safeRevokeCurrentApiToken,
+	type Client,
+} from "@phala/cloud";
 import { getApiVersionOverride } from "@/src/core/api-version";
 import type { CommandContext } from "@/src/core/types";
 import { getProjectConfig } from "@/src/utils/project-config";
@@ -93,4 +97,55 @@ export async function getClientWithKey(
 		baseURL: options?.baseURL,
 		version,
 	}) as CliApiClient;
+}
+
+export type RevokeTokenOutcome =
+	| "revoked"
+	| "already-invalid"
+	| "unsupported"
+	| "failed";
+
+export interface RevokeTokenResult {
+	readonly outcome: RevokeTokenOutcome;
+	readonly message?: string;
+}
+
+/**
+ * Best-effort server-side revocation of an API token via DELETE /tokens/self.
+ *
+ * Never throws — callers (logout / profiles delete / profiles refresh) treat
+ * every outcome as non-fatal:
+ * - "already-invalid" (401): the token was already revoked or expired
+ * - "unsupported" (404): the server predates the self-revoke endpoint
+ * - "failed": network or unexpected error
+ */
+export async function tryRevokeApiToken(options: {
+	apiKey: string;
+	baseURL: string;
+}): Promise<RevokeTokenResult> {
+	try {
+		const client = await getClientWithKey(options.apiKey, {
+			baseURL: options.baseURL,
+		});
+		const result = await safeRevokeCurrentApiToken(client);
+		if (result.success) {
+			return { outcome: "revoked" };
+		}
+		const status =
+			"status" in result.error && typeof result.error.status === "number"
+				? result.error.status
+				: undefined;
+		if (status === 401) {
+			return { outcome: "already-invalid" };
+		}
+		if (status === 404) {
+			return { outcome: "unsupported" };
+		}
+		return { outcome: "failed", message: result.error.message };
+	} catch (error) {
+		return {
+			outcome: "failed",
+			message: error instanceof Error ? error.message : String(error),
+		};
+	}
 }

--- a/js/src/actions/api_tokens/revoke_current_api_token.test.ts
+++ b/js/src/actions/api_tokens/revoke_current_api_token.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  revokeCurrentApiToken,
+  safeRevokeCurrentApiToken,
+} from "./revoke_current_api_token";
+import type { Client } from "../../client";
+
+describe("revokeCurrentApiToken", () => {
+  let mockClient: Client;
+
+  beforeEach(() => {
+    mockClient = {
+      delete: vi.fn(),
+    } as unknown as Client;
+  });
+
+  describe("revokeCurrentApiToken", () => {
+    it("should call DELETE /tokens/self", async () => {
+      vi.mocked(mockClient.delete).mockResolvedValue(undefined);
+
+      const result = await revokeCurrentApiToken(mockClient);
+
+      expect(mockClient.delete).toHaveBeenCalledWith("/tokens/self");
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("safeRevokeCurrentApiToken", () => {
+    it("should return success result", async () => {
+      vi.mocked(mockClient.delete).mockResolvedValue(undefined);
+
+      const result = await safeRevokeCurrentApiToken(mockClient);
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should return error result on failure", async () => {
+      const requestError = Object.assign(new Error("Unauthorized"), { status: 401 });
+      vi.mocked(mockClient.delete).mockRejectedValue(requestError);
+
+      const result = await safeRevokeCurrentApiToken(mockClient);
+
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/js/src/actions/api_tokens/revoke_current_api_token.ts
+++ b/js/src/actions/api_tokens/revoke_current_api_token.ts
@@ -1,0 +1,40 @@
+import { z } from "zod";
+import { defineSimpleAction } from "../../utils/define-action";
+
+/**
+ * Revoke the API token used to authenticate this client
+ *
+ * Permanently revokes the token presented in the request (self-revoke).
+ * The target token is resolved server-side from the presented credential —
+ * one token can never revoke another. This operation cannot be undone:
+ * the client's API key stops working immediately.
+ *
+ * @example
+ * ```typescript
+ * import { createClient, revokeCurrentApiToken } from '@phala/cloud'
+ *
+ * const client = createClient({ apiKey: 'your-api-key' })
+ * await revokeCurrentApiToken(client)
+ * console.log('Token revoked')
+ * ```
+ *
+ * ## Safe Version
+ *
+ * ```typescript
+ * const result = await safeRevokeCurrentApiToken(client)
+ * if (result.success) {
+ *   console.log('Token revoked')
+ * } else {
+ *   console.error(result.error.message)
+ * }
+ * ```
+ */
+const { action: revokeCurrentApiToken, safeAction: safeRevokeCurrentApiToken } = defineSimpleAction(
+  z.void(),
+  async (client) => {
+    await client.delete("/tokens/self");
+    return undefined;
+  },
+);
+
+export { revokeCurrentApiToken, safeRevokeCurrentApiToken };

--- a/js/src/actions/index.ts
+++ b/js/src/actions/index.ts
@@ -639,6 +639,11 @@ export {
   type SyncGithubSshKeysResponse,
 } from "./ssh_keys/sync_github_ssh_keys";
 
+export {
+  revokeCurrentApiToken,
+  safeRevokeCurrentApiToken,
+} from "./api_tokens/revoke_current_api_token";
+
 // CVM Is-Allowed Check
 export {
   checkCvmIsAllowed,


### PR DESCRIPTION
## Summary

Client-side support for the new `DELETE /tokens/self` endpoint (backend PR in phala-cloud-monorepo): the server resolves the target token from the presented credential, so one token can never revoke another.

- **feat(js)**: add `revokeCurrentApiToken` / `safeRevokeCurrentApiToken` action wrapping `DELETE /tokens/self`
- **feat(cli)**: `phala logout` and `phala profiles delete` now revoke the profile's API token server-side before removing it locally; `profiles delete` accepts multiple profile names (fail-fast on any unknown name)
- **feat(cli)**: new `phala profiles refresh <name>` — re-authenticates a profile whose token stopped working (whoami 401), revoking the old token first, then the device flow (or `--manual`); non-current profiles keep `current_profile` untouched
- **feat(cli)**: remove deprecated `phala auth login/logout/status` implementations; each subcommand remains as a stub printing a one-line removal notice pointing at its top-level replacement (help output and the v1.0.40 interface baseline unchanged)

All server-side revocation is best-effort: 401 (token already invalid), 404 (server predates the endpoint), and network errors never block local credential removal, so the CLI keeps working against older servers.

## Test plan

- JS SDK: 799 unit tests pass, including the new action's tests
- CLI: 482 tests pass (12 new: delete multi/revoke, logout revoke, refresh flow); 48 interface-compat tests against the v1.0.40 baseline pass
- Smoke-tested: `auth login` removal notice, multi-delete with active-profile switch, fail-fast on unknown profile, JSON output shapes, logout revocation fallback