### PR TITLE
fix(cli): pin workspace and default to current profile in profiles refresh

### DIFF
--- a/cli/docs/profiles.md
+++ b/cli/docs/profiles.md
@@ -72,11 +72,15 @@ profiles.
 
 ### Refresh a profile
 
-Use `phala profiles refresh <name>` when a profile's token stopped working
-(for example `phala whoami` reports "Invalid API key"). The CLI first tries
-to revoke the old token on the server, then re-authenticates via the device
-flow (or `--manual` to paste a new API key) and stores the fresh token under
-the same profile name.
+Use `phala profiles refresh [name]` when a profile's token stopped working
+(for example `phala whoami` reports "Invalid API key"). Without a name it
+refreshes the current profile. The CLI first tries to revoke the old token on
+the server, then re-authenticates via the device flow (or `--manual` to paste
+a new API key) and stores the fresh token under the same profile name.
+
+The verification page is opened with the profile's workspace pinned, so a
+refresh cannot accidentally move the profile to another workspace; if the new
+token ends up bound to a different workspace, the CLI refuses to save it.
 
 ```bash
 $ phala profiles refresh work

--- a/cli/src/commands/login/index.ts
+++ b/cli/src/commands/login/index.ts
@@ -100,6 +100,13 @@ export async function runDeviceAuthFlow(
 		noOpen?: boolean;
 		printToken?: boolean;
 		baseURL: string;
+		/**
+		 * Workspace slug to pre-bind on the verification page. Used by
+		 * `profiles refresh` so the page locks workspace selection to the
+		 * profile's existing workspace. The page treats it as a hint; the
+		 * backend re-validates workspace access at token issue time.
+		 */
+		workspaceSlug?: string;
 	},
 ): Promise<string> {
 	const client = createClient({
@@ -124,6 +131,10 @@ export async function runDeviceAuthFlow(
 		expires_in,
 	} = codeResponse;
 
+	const verificationUrl = options.workspaceSlug
+		? `${verification_uri_complete}&workspace=${encodeURIComponent(options.workspaceSlug)}`
+		: verification_uri_complete;
+
 	// Polling interval - can be increased on slow_down per RFC 8628
 	let pollingInterval = initialInterval;
 
@@ -131,7 +142,7 @@ export async function runDeviceAuthFlow(
 	const infoStream = options.printToken ? context.stderr : context.stdout;
 	writeLine(infoStream);
 	writeLine(infoStream, chalk.bold("To authenticate, visit:"));
-	writeLine(infoStream, chalk.cyan(verification_uri_complete));
+	writeLine(infoStream, chalk.cyan(verificationUrl));
 	writeLine(infoStream);
 	writeLine(
 		infoStream,
@@ -142,7 +153,7 @@ export async function runDeviceAuthFlow(
 	// Step 3: Open browser (optional)
 	if (!options.noOpen) {
 		try {
-			await open(verification_uri_complete);
+			await open(verificationUrl);
 			writeLine(infoStream, "Opening browser automatically...");
 		} catch {
 			writeLine(

--- a/cli/src/commands/profiles/refresh/command.ts
+++ b/cli/src/commands/profiles/refresh/command.ts
@@ -9,8 +9,8 @@ export const profilesRefreshCommandMeta: CommandMeta = {
 	arguments: [
 		{
 			name: "profile-name",
-			description: "Profile name",
-			required: true,
+			description: "Profile name (defaults to the current profile)",
+			required: false,
 			target: "profileName",
 		},
 	],
@@ -29,7 +29,11 @@ export const profilesRefreshCommandMeta: CommandMeta = {
 	],
 	examples: [
 		{
-			name: "Refresh a profile via device flow",
+			name: "Refresh the current profile via device flow",
+			value: "phala profiles refresh",
+		},
+		{
+			name: "Refresh a specific profile",
 			value: "phala profiles refresh my-profile",
 		},
 		{
@@ -40,7 +44,7 @@ export const profilesRefreshCommandMeta: CommandMeta = {
 };
 
 export const profilesRefreshCommandSchema = z.object({
-	profileName: z.string().min(1),
+	profileName: z.string().min(1).optional(),
 	manual: z.boolean().optional(),
 	noOpen: z.boolean().optional(),
 });

--- a/cli/src/commands/profiles/refresh/index.test.ts
+++ b/cli/src/commands/profiles/refresh/index.test.ts
@@ -116,6 +116,71 @@ describe("profiles refresh command", () => {
 		expect(mockRunDeviceAuthFlow).not.toHaveBeenCalled();
 	});
 
+	test("defaults to the current profile when no name is given", async () => {
+		saveCredentialsFile({
+			schema_version: 1,
+			current_profile: "alpha",
+			profiles: { alpha: profile("phak_oldtoken"), beta: profile("phak_beta") },
+		});
+
+		const code = await profilesRefreshCommand.run({}, makeContext());
+
+		expect(code).toBe(0);
+		const saved = loadCredentialsFile();
+		expect(saved?.profiles.alpha.token).toBe("phak_newtoken");
+		expect(saved?.profiles.beta.token).toBe("phak_beta");
+		expect(saved?.current_profile).toBe("alpha");
+	});
+
+	test("fails when no name is given and there is no current profile", async () => {
+		const code = await profilesRefreshCommand.run({}, makeContext());
+
+		expect(code).toBe(1);
+		expect(mockRunDeviceAuthFlow).not.toHaveBeenCalled();
+	});
+
+	test("passes the profile workspace slug to the device flow", async () => {
+		saveCredentialsFile({
+			schema_version: 1,
+			current_profile: "alpha",
+			profiles: { alpha: profile("phak_oldtoken") },
+		});
+
+		const code = await profilesRefreshCommand.run(
+			{ profileName: "alpha" },
+			makeContext(),
+		);
+
+		expect(code).toBe(0);
+		expect(mockRunDeviceAuthFlow).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ workspaceSlug: "alpha-ws" }),
+		);
+	});
+
+	test("refuses to save a token bound to a different workspace", async () => {
+		mockValidateApiKey.mockImplementationOnce(() =>
+			Promise.resolve({
+				user: { username: "alice", email: "alice@example.test" },
+				workspace: { name: "Other WS", slug: "other-ws" },
+			}),
+		);
+		saveCredentialsFile({
+			schema_version: 1,
+			current_profile: "alpha",
+			profiles: { alpha: profile("phak_oldtoken") },
+		});
+
+		const code = await profilesRefreshCommand.run(
+			{ profileName: "alpha" },
+			makeContext(),
+		);
+
+		expect(code).toBe(1);
+		// Profile untouched: still holds the old token
+		expect(loadCredentialsFile()?.profiles.alpha.token).toBe("phak_oldtoken");
+	});
+
 	test("revokes the old token, then stores the new one", async () => {
 		saveCredentialsFile({
 			schema_version: 1,

--- a/cli/src/commands/profiles/refresh/index.ts
+++ b/cli/src/commands/profiles/refresh/index.ts
@@ -26,10 +26,25 @@ async function runProfilesRefreshCommand(
 
 	try {
 		const credentials = loadCredentialsFile();
-		const existing = credentials?.profiles[input.profileName];
+
+		// Default to the current profile when no name is given.
+		const profileName =
+			input.profileName ?? credentials?.current_profile ?? undefined;
+		if (!profileName) {
+			const message =
+				"No profile specified and no current profile. Please login first.";
+			if (isJson) {
+				context.fail(message);
+				return 1;
+			}
+			logger.error(message);
+			return 1;
+		}
+
+		const existing = credentials?.profiles[profileName];
 
 		if (!existing) {
-			const message = `Profile "${input.profileName}" not found`;
+			const message = `Profile "${profileName}" not found`;
 			if (isJson) {
 				context.fail(message);
 				return 1;
@@ -71,12 +86,22 @@ async function runProfilesRefreshCommand(
 			apiKey = await runDeviceAuthFlow(context, {
 				noOpen: input.noOpen,
 				baseURL,
+				workspaceSlug: existing.workspace.slug,
 			});
 			user = await validateApiKey({ apiKey, baseURL });
 		}
 
+		// A refresh must not silently move the profile to another workspace.
+		const previousSlug = existing.workspace.slug;
+		const newSlug = user.workspace.slug;
+		if (previousSlug && newSlug && previousSlug !== newSlug) {
+			throw new Error(
+				`Workspace mismatch: profile "${profileName}" belongs to workspace "${previousSlug}", but the new token is bound to "${newSlug}". Run the refresh again and authorize against "${previousSlug}".`,
+			);
+		}
+
 		upsertProfile({
-			profileName: input.profileName,
+			profileName,
 			token: apiKey,
 			apiPrefix: baseURL,
 			workspaceName: user.workspace.name || existing.workspace.name,
@@ -87,18 +112,18 @@ async function runProfilesRefreshCommand(
 			},
 			// Keep the current profile unchanged unless the refreshed profile
 			// is the current one.
-			setCurrent: credentials?.current_profile === input.profileName,
+			setCurrent: credentials?.current_profile === profileName,
 		});
 
 		if (isJson) {
 			context.success({
-				refreshed: input.profileName,
+				refreshed: profileName,
 				username: user.user.username,
 			});
 			return 0;
 		}
 		logger.success(
-			`Profile "${input.profileName}" refreshed (user: ${user.user.username})`,
+			`Profile "${profileName}" refreshed (user: ${user.user.username})`,
 		);
 		return 0;
 	} catch (error) {


### PR DESCRIPTION
## Summary

Fixes from testing feedback on #495:

- **Workspace pinning**: `phala profiles refresh` now appends the profile's workspace slug to the device-flow verification URL (`?workspace=<slug>`). The `/cli/verify` page (companion PR in phala-cloud-monorepo) locks workspace selection when the param matches one of the user's workspaces, so a refresh can no longer be authorized against a different workspace. As a second line of defense the CLI validates the new token's workspace against the profile's existing one and refuses to save on mismatch — this covers `--manual` and pages without the lock.
- **Default profile**: the profile name argument is now optional and defaults to the current profile. Omitting it with no current profile errors out pointing at login.

## Test plan

- 5 new refresh tests: default-to-current, no-profile error, workspace slug passed to device flow, workspace mismatch refusal (profile untouched), plus existing manual/device paths
- Full CLI suite: 486 tests pass; interface-compat baseline unchanged
- Smoke: `profiles refresh` with empty credentials errors correctly; help shows optional `[<profile-name>]`
