### PR TITLE
fix(cli): flush piped stdout before process exit

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { once } from "node:events";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -157,6 +158,21 @@ for (const command of allowDevicesCommands.commands) {
 process.on("SIGINT", () => process.exit(0));
 process.on("SIGTERM", () => process.exit(0));
 
+// Piped stdout is async in Node.js. Calling process.exit() before the stream
+// drains discards everything still in the user-space buffer — with the default
+// 64KB kernel pipe buffer, output to a pipe truncates at exactly 65536 bytes
+// while output to a file (synchronous) is complete. Wait for the buffer to
+// flush first; the timeout only caps a wedged reader, it never speeds up exit.
+async function flushStream(stream: NodeJS.WriteStream): Promise<void> {
+	if (stream.destroyed || stream.writableLength === 0) {
+		return;
+	}
+	await Promise.race([
+		once(stream, "drain"),
+		new Promise((resolve) => setTimeout(resolve, 5000)),
+	]);
+}
+
 async function main(): Promise<void> {
 	await migrateStorage({ env: process.env, stderr: process.stderr });
 
@@ -175,10 +191,12 @@ async function main(): Promise<void> {
 		stdin: process.stdin,
 	});
 
+	await Promise.all([flushStream(process.stdout), flushStream(process.stderr)]);
 	process.exit(exitCode);
 }
 
-main().catch((error) => {
+main().catch(async (error) => {
 	console.error("An error occurred:", error);
+	await Promise.all([flushStream(process.stdout), flushStream(process.stderr)]);
 	process.exit(1);
 });


### PR DESCRIPTION
## Problem

`phala` truncates stdout at exactly **65536 bytes** whenever stdout is a pipe:

```bash
phala api '/admin/audit/user-activity?...' | wc -c   # 65536 (truncated)
phala api '/admin/audit/user-activity?...' > out.json # 71251 (complete)
```

## Root cause

Piped stdout is asynchronous in Node.js: `write()` queues data in the user-space buffer and returns immediately. `main()` in `cli/src/index.ts` called `process.exit(exitCode)` right after `dispatchCommand()` finished, discarding everything the kernel had not accepted yet. With the default 64KB kernel pipe buffer, anything beyond the first 64KB never reaches the reader. Output to a regular file is synchronous, which is why redirecting to a file always worked.

Minimal repro of the mechanism:

```bash
node -e "process.stdout.write(Buffer.alloc(204800, 65)); process.exit(0);" | wc -c
# 65536
```

## Fix

Wait for `stdout`/`stderr` to drain before exiting, on both the success path and the `main().catch` path. A 5s timeout caps a wedged reader; it never speeds up normal exit. `process.exit` semantics are kept so lingering keep-alive handles cannot hang the CLI.

## Verification

- Same large `phala api` query through a pipe: 65536 -> full payload
- `bun run fmt` / `lint` / `type-check` clean
- `bun test`: 470 pass, 0 fail
- Pre-commit hooks (Biome, TypeScript, Build, CLI tests) all pass