### PR TITLE
fix(cli): deploy env encrypt pubkey for current API schema

### DIFF
--- a/cli/src/commands/deploy/handler.ts
+++ b/cli/src/commands/deploy/handler.ts
@@ -1,7 +1,12 @@
 import path from "node:path";
 import os from "node:os";
 import type { CommandContext } from "@/src/core/types";
-import { resolveAuthForContext } from "@/src/lib/client";
+import {
+	getClient,
+	getClientWithKey,
+	resolveAuthForContext,
+	type CliApiClient,
+} from "@/src/lib/client";
 import { logger } from "@/src/utils/logger";
 import {
 	CLOUD_URL,
@@ -15,12 +20,10 @@ import { detectFileInCurrentDir, promptForFile } from "@/src/utils/prompts";
 import { dedupeEnvVars, parseEnvInputs } from "@/src/utils/env-parsing";
 import { parseDiskSizeInput, parseMemoryInput } from "@/src/utils/units";
 import {
-	type Client,
 	type EnvVar,
 	CvmIdSchema,
 	MAX_COMPOSE_PAYLOAD_BYTES,
 	SUPPORTED_CHAINS,
-	createClient,
 	encryptEnvVars,
 	parseEnvVars,
 	safeAddComposeHash,
@@ -48,7 +51,10 @@ import fs from "fs-extra";
 import inquirer from "inquirer";
 import type { DeployCommandInput } from "./command";
 import type { RuntimeProjectConfig } from "@/src/utils/project-config";
-import { verifyAndExtractEnvEncryptPubkey } from "@/src/commands/envs/get-encrypt-pubkey";
+import {
+	getEncryptPubkey,
+	verifyAndExtractEnvEncryptPubkey,
+} from "@/src/commands/envs/get-encrypt-pubkey";
 
 type PrivacyConfig = Pick<
 	RuntimeProjectConfig,
@@ -111,8 +117,6 @@ export function applyForceStopOption(
 	patchBody.allow_force_stop = true;
 }
 
-const API_VERSION = "2026-05-22" as const;
-
 async function getApiClient({
 	context,
 	apiToken,
@@ -121,14 +125,11 @@ async function getApiClient({
 	Pick<Options, "apiToken" | "interactive"> & {
 		context?: Pick<CommandContext, "env" | "projectConfig" | "globalOptions">;
 	}
->): Promise<Client<typeof API_VERSION>> {
+>): Promise<CliApiClient> {
 	const resolved = resolveAuthForContext(context, { apiToken });
 	if (resolved.apiKey) {
-		return createClient({
-			apiKey: resolved.apiKey,
-			baseURL: resolved.baseURL,
-			version: API_VERSION,
-		});
+		// Honors global --api-version via getClient (no hardcoded version).
+		return getClient(context, { apiToken });
 	}
 
 	if (interactive) {
@@ -141,11 +142,7 @@ async function getApiClient({
 					input.trim() ? true : "API token is required",
 			},
 		]);
-		return createClient({
-			apiKey: promptedToken,
-			baseURL: resolved.baseURL,
-			version: API_VERSION,
-		});
+		return getClientWithKey(promptedToken, { baseURL: resolved.baseURL });
 	}
 
 	throw new Error(
@@ -674,7 +671,7 @@ const deployNewCvm = async (
 	validatedOptions: Options,
 	docker_compose_yml: string,
 	envs: EnvVar[],
-	client: Client<typeof API_VERSION>,
+	client: CliApiClient,
 	stdout: NodeJS.WriteStream,
 	stderr: NodeJS.WriteStream,
 	projectConfig?: PrivacyConfig,
@@ -864,7 +861,7 @@ const updateCvm = async (
 	validatedOptions: Options,
 	docker_compose_yml: string,
 	envs: EnvVar[] | undefined,
-	client: Client<typeof API_VERSION>,
+	client: CliApiClient,
 	stdout: NodeJS.WriteStream,
 	context?: Pick<CommandContext, "env" | "projectConfig" | "globalOptions">,
 	preLaunchScriptContent?: string,
@@ -878,37 +875,12 @@ const updateCvm = async (
 	// biome-ignore lint/suspicious/noExplicitAny: type inference issue with @phala/cloud library
 	const cvm = cvm_result.data as any;
 
-	// Encrypt env vars before patching (backend stores the full body in Redis for two-phase)
+	// Encrypt env vars before patching (backend stores the full body in Redis for two-phase).
+	// getEncryptPubkey handles current (kms_info.*) and legacy top-level shapes.
 	let encrypted_env: string | undefined;
 	if (envs && envs.length > 0) {
-		if (cvm.kms_info?.chain_id) {
-			// On-chain KMS: fetch encrypt pubkey from API
-			const kmsSlug = cvm.kms_info?.slug || cvm.kms_info?.id;
-			if (!kmsSlug) {
-				throw new Error("KMS slug or id is required for decentralized KMS");
-			}
-			const resp = await safeGetAppEnvEncryptPubKey(client, {
-				app_id: cvm.app_id,
-				kms: kmsSlug,
-			});
-			if (!resp.success) {
-				throw resp.error;
-			}
-			const pubkey = verifyAndExtractEnvEncryptPubkey(
-				resp.data,
-				cvm.app_id,
-				cvm.kms_info.k256_pubkey,
-			);
-			encrypted_env = await encryptEnvVars(envs, pubkey);
-		} else {
-			// Centralized KMS: use pubkey from CVM info
-			if (!cvm.encrypted_env_pubkey) {
-				throw new Error(
-					"CVM encrypted_env_pubkey is required for centralized KMS",
-				);
-			}
-			encrypted_env = await encryptEnvVars(envs, cvm.encrypted_env_pubkey);
-		}
+		const pubkey = await getEncryptPubkey(client, cvm);
+		encrypted_env = await encryptEnvVars(envs, pubkey);
 	}
 
 	// Build unified patch request
@@ -1214,7 +1186,7 @@ const updateCvm = async (
  */
 const commitCvmUpdate = async (
 	validatedOptions: Options,
-	client: Client<typeof API_VERSION>,
+	client: CliApiClient,
 	stdout: NodeJS.WriteStream,
 ) => {
 	if (!validatedOptions.token) {
@@ -1279,14 +1251,8 @@ export async function runDeploy(
 		// commit-update endpoint is token-based (no API key required),
 		// but we still need a client with the correct base URL.
 		if (input.commit) {
-			const resolved = resolveAuthForContext(context, {
-				apiToken: input.apiToken,
-			});
-			const client = createClient({
-				apiKey: resolved.apiKey,
-				baseURL: resolved.baseURL,
-				version: API_VERSION,
-			});
+			// Token-based commit still needs the correct base URL / API version.
+			const client = await getClient(context, { apiToken: input.apiToken });
 
 			const uuid = context.cvmId
 				? CvmIdSchema.parse(context.cvmId).cvmId

--- a/cli/src/commands/envs/get-encrypt-pubkey.test.ts
+++ b/cli/src/commands/envs/get-encrypt-pubkey.test.ts
@@ -48,6 +48,36 @@ describe("getEncryptPubkey", () => {
 			expect(result).toBe("some_pubkey");
 		});
 
+		test("falls back to legacy top-level encrypted_env_pubkey", async () => {
+			const cvm = {
+				app_id: "abc123",
+				kms_type: "phala",
+				encrypted_env_pubkey: "legacy_top_level_pubkey",
+				kms_info: {
+					chain_id: null,
+					encrypted_env_pubkey: null,
+				},
+			};
+
+			const result = await getEncryptPubkey(mockClient, cvm);
+			expect(result).toBe("legacy_top_level_pubkey");
+		});
+
+		test("prefers kms_info.encrypted_env_pubkey over top-level", async () => {
+			const cvm = {
+				app_id: "abc123",
+				kms_type: "phala",
+				encrypted_env_pubkey: "legacy_top_level_pubkey",
+				kms_info: {
+					chain_id: null,
+					encrypted_env_pubkey: "nested_pubkey",
+				},
+			};
+
+			const result = await getEncryptPubkey(mockClient, cvm);
+			expect(result).toBe("nested_pubkey");
+		});
+
 		test("throws when encrypted_env_pubkey is missing", async () => {
 			const cvm = {
 				app_id: "abc123",
@@ -63,7 +93,7 @@ describe("getEncryptPubkey", () => {
 			);
 		});
 
-		test("throws when kms_info is null", async () => {
+		test("throws when kms_info is null and top-level is missing", async () => {
 			const cvm = {
 				app_id: "abc123",
 				kms_type: "phala",
@@ -73,6 +103,18 @@ describe("getEncryptPubkey", () => {
 			await expect(getEncryptPubkey(mockClient, cvm)).rejects.toThrow(
 				"CVM does not have an encryption public key",
 			);
+		});
+
+		test("returns top-level pubkey when kms_info is null", async () => {
+			const cvm = {
+				app_id: "abc123",
+				kms_type: "phala",
+				encrypted_env_pubkey: "legacy_only_pubkey",
+				kms_info: null,
+			};
+
+			const result = await getEncryptPubkey(mockClient, cvm);
+			expect(result).toBe("legacy_only_pubkey");
 		});
 	});
 

--- a/cli/src/commands/envs/get-encrypt-pubkey.ts
+++ b/cli/src/commands/envs/get-encrypt-pubkey.ts
@@ -50,7 +50,10 @@ export function verifyAndExtractEnvEncryptPubkey(
 /**
  * Resolve the encryption public key for a CVM.
  *
- * Centralized KMS (phala/legacy): uses kms_info.encrypted_env_pubkey directly.
+ * Centralized KMS (phala/legacy):
+ * - 2026-01-21+: kms_info.encrypted_env_pubkey
+ * - 2025-10-28: top-level encrypted_env_pubkey
+ *
  * Decentralized KMS (ethereum/base): fetches from KMS endpoint.
  */
 export async function getEncryptPubkey(
@@ -58,17 +61,24 @@ export async function getEncryptPubkey(
 	cvm: {
 		app_id?: string | null;
 		kms_type?: string | null;
+		/** Legacy top-level field from API version 2025-10-28. */
+		encrypted_env_pubkey?: string | null;
 		kms_info?: {
 			chain_id?: number | null;
 			encrypted_env_pubkey?: string | null;
 			k256_pubkey?: string | null;
+			slug?: string | null;
+			id?: string | number | null;
 		} | null;
 	},
 ): Promise<string> {
 	const isDecentralized = cvm.kms_info?.chain_id != null;
 
 	if (isDecentralized) {
-		const kmsSlug = cvm.kms_type;
+		const kmsSlug =
+			cvm.kms_type ||
+			cvm.kms_info?.slug ||
+			(cvm.kms_info?.id != null ? String(cvm.kms_info.id) : null);
 		if (!kmsSlug) {
 			throw new Error("KMS type is required for decentralized KMS");
 		}
@@ -92,8 +102,9 @@ export async function getEncryptPubkey(
 		);
 	}
 
-	// Centralized KMS
-	const pubkey = cvm.kms_info?.encrypted_env_pubkey;
+	// Centralized KMS: nested field first (current schema), then legacy top-level.
+	const pubkey =
+		cvm.kms_info?.encrypted_env_pubkey ?? cvm.encrypted_env_pubkey ?? null;
 	if (!pubkey) {
 		throw new Error(
 			"CVM does not have an encryption public key. The CVM may not support encrypted environment variables.",

--- a/cli/test/interface-compat/command-existence.test.ts
+++ b/cli/test/interface-compat/command-existence.test.ts
@@ -35,23 +35,28 @@ describe("CLI Interface Compatibility - Command Existence (v1.0.40 baseline)", (
 		);
 	}
 
-	test("command aliases still work", async () => {
-		// Test known aliases from v1.0.40
-		const aliases = [
-			{ command: "cvms ls", original: "cvms list" },
-			{ command: "nodes ls", original: "nodes list" },
-			{ command: "config ls", original: "config list" },
-		];
+	// Six CLI help spawns; stay above the default 5s suite timeout under load.
+	test(
+		"command aliases still work",
+		async () => {
+			// Test known aliases from v1.0.40
+			const aliases = [
+				{ command: "cvms ls", original: "cvms list" },
+				{ command: "nodes ls", original: "nodes list" },
+				{ command: "config ls", original: "config list" },
+			];
 
-		for (const { command, original } of aliases) {
-			const aliasHelp = await getHelpText(command);
-			const originalHelp = await getHelpText(original);
+			for (const { command, original } of aliases) {
+				const aliasHelp = await getHelpText(command);
+				const originalHelp = await getHelpText(original);
 
-			// Aliases should show the same help as the original
-			expect(aliasHelp.length).toBeGreaterThan(0);
-			expect(originalHelp.length).toBeGreaterThan(0);
-		}
-	});
+				// Aliases should show the same help as the original
+				expect(aliasHelp.length).toBeGreaterThan(0);
+				expect(originalHelp.length).toBeGreaterThan(0);
+			}
+		},
+		{ timeout: 30_000 },
+	);
 
 	test("all commands respond to --help", async () => {
 		const allCommands = getAllCommands();

--- a/cli/test/interface-compat/flag-compatibility.test.ts
+++ b/cli/test/interface-compat/flag-compatibility.test.ts
@@ -136,23 +136,28 @@ describe("CLI Interface Compatibility - Flag Support (v1.0.40 baseline)", () => 
 			expect(hasFlag(helpText, "-j")).toBe(true);
 		});
 
-		test("all JSON-capable commands support both -j and --json", async () => {
-			const jsonCommands = [
-				"status",
-				"cvms list",
-				"cvms get",
-				"cvms attestation",
-				"cvms resize",
-				"nodes list",
-				"config list",
-			];
+		// Spawns one CLI process per command; keep above the default 5s suite timeout.
+		test(
+			"all JSON-capable commands support both -j and --json",
+			async () => {
+				const jsonCommands = [
+					"status",
+					"cvms list",
+					"cvms get",
+					"cvms attestation",
+					"cvms resize",
+					"nodes list",
+					"config list",
+				];
 
-			for (const cmd of jsonCommands) {
-				const helpText = await getHelpText(cmd);
+				for (const cmd of jsonCommands) {
+					const helpText = await getHelpText(cmd);
 
-				expect(hasFlag(helpText, "--json")).toBe(true);
-				expect(hasFlag(helpText, "-j")).toBe(true);
-			}
-		});
+					expect(hasFlag(helpText, "--json")).toBe(true);
+					expect(hasFlag(helpText, "-j")).toBe(true);
+				}
+			},
+			{ timeout: 30_000 },
+		);
 	});
 });


### PR DESCRIPTION
## Summary
- `phala deploy -e ...` failed on centralized KMS with `CVM encrypted_env_pubkey is required` because deploy still read the legacy top-level field while current `getCvmInfo` puts the pubkey under `kms_info`.
- deploy also hard-coded API version `2026-05-22`, so global `--api-version` was ignored.
- Route deploy clients through `getClient` / `getClientWithKey`, reuse `getEncryptPubkey` (nested first, legacy top-level fallback), and raise timeouts on multi-spawn interface-compat tests that were flaking pre-commit under load.

## Test plan
- [x] `bun test src/commands/envs/get-encrypt-pubkey.test.ts src/commands/deploy/handler.test.ts`
- [x] `bun run type-check` / `bun run lint` in `cli`
- [x] full CLI pre-commit suite
- [ ] manual: `phala deploy -c docker-compose.yml --cvm-id <app_id> -e FOO=hi` on a centralized KMS CVM
- [ ] manual: `phala deploy --api-version 2025-10-28 ...` still works via legacy top-level fallback