### PR TITLE
fix(cli): send phala-cli/{version} User-Agent on all HTTP clients

### DIFF
--- a/cli/src/commands/api/index.ts
+++ b/cli/src/commands/api/index.ts
@@ -1,25 +1,12 @@
 import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { createClient } from "@phala/cloud";
 import { defineCommand } from "@/src/core/define-command";
 import type { CommandContext } from "@/src/core/types";
 import { resolveAuthForContext } from "@/src/lib/client";
+import { CLI_USER_AGENT } from "@/src/utils/cli-version";
 import { applyJqFilter, formatJqOutput } from "./jq-filter";
 import { apiCommandMeta, apiCommandSchema, HTTP_METHODS } from "./command";
 import type { ApiCommandInput } from "./command";
-
-// Get CLI version for User-Agent
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const packageJsonPath = join(__dirname, "../../../package.json");
-let CLI_VERSION = "unknown";
-try {
-	const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-	CLI_VERSION = packageJson.version || "unknown";
-} catch {
-	// Ignore errors reading package.json
-}
 
 /**
  * Read content from file or stdin.
@@ -317,7 +304,7 @@ export async function runApiCommand(
 		apiKey: auth.apiKey,
 		baseURL: auth.baseURL,
 		headers: {
-			"User-Agent": `phala-cli/${CLI_VERSION}`,
+			"User-Agent": CLI_USER_AGENT,
 		},
 	});
 

--- a/cli/src/commands/login/index.ts
+++ b/cli/src/commands/login/index.ts
@@ -15,6 +15,7 @@ import {
 import { defineCommand } from "@/src/core/define-command";
 import type { CommandContext } from "@/src/core/types";
 import { getClientWithKey } from "@/src/lib/client";
+import { CLI_USER_AGENT } from "@/src/utils/cli-version";
 import { DEFAULT_API_PREFIX, upsertProfile } from "@/src/utils/credentials";
 
 import { loginCommandMeta, loginCommandSchema } from "./command";
@@ -112,6 +113,9 @@ export async function runDeviceAuthFlow(
 	const client = createClient({
 		useCookieAuth: true,
 		baseURL: options.baseURL,
+		headers: {
+			"User-Agent": CLI_USER_AGENT,
+		},
 	});
 
 	// Step 1: Request device authorization codes

--- a/cli/src/core/migrate-storage.ts
+++ b/cli/src/core/migrate-storage.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { createClient, safeGetCurrentUser } from "@phala/cloud";
+import { CLI_USER_AGENT } from "@/src/utils/cli-version";
 
 import {
 	DEFAULT_API_PREFIX,
@@ -107,7 +108,11 @@ export type FetchCurrentUser = (options: {
 
 function defaultFetchCurrentUser(): FetchCurrentUser {
 	return async ({ token, baseURL }) => {
-		const client = createClient({ apiKey: token, baseURL });
+		const client = createClient({
+			apiKey: token,
+			baseURL,
+			headers: { "User-Agent": CLI_USER_AGENT },
+		});
 		const result = await safeGetCurrentUser(client);
 		if (!result.success) return { success: false };
 		return {

--- a/cli/src/lib/client.ts
+++ b/cli/src/lib/client.ts
@@ -7,6 +7,7 @@ import { getApiVersionOverride } from "@/src/core/api-version";
 import type { CommandContext } from "@/src/core/types";
 import { getProjectConfig } from "@/src/utils/project-config";
 import { resolveAuth, type ResolvedAuth } from "@/src/utils/credentials";
+import { CLI_USER_AGENT } from "@/src/utils/cli-version";
 
 const API_VERSION = "2026-06-23" as const;
 
@@ -68,6 +69,9 @@ export async function getClient(
 		baseURL: auth.baseURL,
 		version,
 		timeout: timeoutSeconds * 1000,
+		headers: {
+			"User-Agent": CLI_USER_AGENT,
+		},
 	}) as CliApiClient;
 }
 
@@ -96,6 +100,9 @@ export async function getClientWithKey(
 		apiKey,
 		baseURL: options?.baseURL,
 		version,
+		headers: {
+			"User-Agent": CLI_USER_AGENT,
+		},
 	}) as CliApiClient;
 }
 

--- a/cli/src/lib/client.user-agent.test.ts
+++ b/cli/src/lib/client.user-agent.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const createClientMock = mock((config: Record<string, unknown>) => config);
+
+mock.module("@phala/cloud", () => ({
+	createClient: createClientMock,
+	safeRevokeCurrentApiToken: mock(() => Promise.resolve({ success: true })),
+}));
+
+mock.module("@/src/utils/credentials", () => ({
+	resolveAuth: () => ({
+		apiKey: "phak_test",
+		baseURL: "https://cloud-api.phala.com/api/v1",
+		profile: "default",
+	}),
+}));
+
+mock.module("@/src/core/api-version", () => ({
+	getApiVersionOverride: () => undefined,
+}));
+
+mock.module("@/src/utils/project-config", () => ({
+	getProjectConfig: () => ({}),
+}));
+
+describe("CLI client User-Agent", () => {
+	beforeEach(() => {
+		createClientMock.mockClear();
+	});
+
+	test("getClient sets phala-cli User-Agent", async () => {
+		const { getClient } = await import("./client");
+		const { CLI_USER_AGENT } = await import("@/src/utils/cli-version");
+		await getClient({
+			env: process.env,
+			projectConfig: {},
+			globalOptions: {},
+		} as never);
+		expect(createClientMock).toHaveBeenCalled();
+		const config = createClientMock.mock.calls[0]?.[0] as {
+			headers?: { "User-Agent"?: string };
+		};
+		expect(config.headers?.["User-Agent"]).toBe(CLI_USER_AGENT);
+	});
+
+	test("getClientWithKey sets phala-cli User-Agent", async () => {
+		const { getClientWithKey } = await import("./client");
+		const { CLI_USER_AGENT } = await import("@/src/utils/cli-version");
+		await getClientWithKey("phak_other");
+		const config = createClientMock.mock.calls.at(-1)?.[0] as {
+			headers?: { "User-Agent"?: string };
+		};
+		expect(config.headers?.["User-Agent"]).toBe(CLI_USER_AGENT);
+	});
+});

--- a/cli/src/utils/cli-version.test.ts
+++ b/cli/src/utils/cli-version.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { CLI_PACKAGE_VERSION, CLI_USER_AGENT } from "./cli-version";
+
+describe("cli-version", () => {
+	test("reads version from cli package.json", () => {
+		const pkgPath = join(
+			dirname(fileURLToPath(import.meta.url)),
+			"../../package.json",
+		);
+		const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+			version: string;
+		};
+		expect(CLI_PACKAGE_VERSION).toBe(pkg.version);
+		expect(CLI_USER_AGENT).toBe(`phala-cli/${pkg.version}`);
+	});
+
+	test("user-agent uses phala-cli product token", () => {
+		expect(CLI_USER_AGENT.startsWith("phala-cli/")).toBe(true);
+		expect(CLI_USER_AGENT.includes(" ")).toBe(false);
+	});
+});

--- a/cli/src/utils/cli-version.ts
+++ b/cli/src/utils/cli-version.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Resolve the published CLI package version for outbound identification.
+ *
+ * Source layout:  cli/src/utils -> ../../package.json
+ * Built layout:   cli/dist/utils -> ../../package.json
+ */
+function readPackageVersion(): string {
+	const here = dirname(fileURLToPath(import.meta.url));
+	const candidates = [
+		join(here, "../../package.json"),
+		join(here, "../package.json"),
+	];
+	for (const path of candidates) {
+		try {
+			const pkg = JSON.parse(readFileSync(path, "utf-8")) as {
+				version?: string;
+			};
+			if (pkg.version) {
+				return pkg.version;
+			}
+		} catch {
+			// try next candidate
+		}
+	}
+	return "unknown";
+}
+
+/** Package version from cli/package.json (e.g. 1.1.21-beta.1). */
+export const CLI_PACKAGE_VERSION = readPackageVersion();
+
+/**
+ * User-Agent sent on every CLI HTTP request so backend activity logs can
+ * distinguish phala CLI traffic from bare Node/SDK clients.
+ */
+export const CLI_USER_AGENT = `phala-cli/${CLI_PACKAGE_VERSION}`;


### PR DESCRIPTION
## Summary

Backend `user_activity_logs.user_agent` could not reliably identify Phala CLI traffic.

- `phala api` already sent `User-Agent: phala-cli/{version}`
- Most other commands use `getClient()` / `getClientWithKey()` with **no** User-Agent, so requests looked like bare Node/runtime defaults

## Change

- Add `cli/src/utils/cli-version.ts` exporting `CLI_PACKAGE_VERSION` and `CLI_USER_AGENT` (`phala-cli/{version}` from `cli/package.json`)
- Attach that header in:
  - `getClient` / `getClientWithKey` (shared path for nearly all commands)
  - `phala api` (reuse shared constant; drop local package.json read)
  - device-login `createClient`
  - storage-migration `createClient`

## Test plan

- [x] `bun test src/utils/cli-version.test.ts src/lib/client.user-agent.test.ts`
- [x] pre-commit: Biome / tsc / build / CLI tests
- [ ] After release: confirm a non-`api` command (e.g. `phala whoami`) shows `phala-cli/<version>` in admin user-activity

## Impact

- Outbound CLI HTTP only; no API contract change
- Backend activity logs gain a stable CLI product token for detection/ops