### PR TITLE
feat(cli): show SSH key fingerprints in runtime-config

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,4 @@
+## [](https://github.com/Phala-Network/phala-cloud/compare/cli-v1.1.21-beta.2...cli-v) (2026-08-14)
 ## [](https://github.com/Phala-Network/phala-cloud/compare/cli-v1.1.20...cli-v) (2026-08-13)
 
 ### feat

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,27 @@
+## [](https://github.com/Phala-Network/phala-cloud/compare/cli-v1.1.20...cli-v) (2026-08-13)
+
+### feat
+
+* **cli:** add `phala docs` — explore live docs from the terminal (agent-friendly) (#485) ([d8da13c](https://github.com/Phala-Network/phala-cloud/commit/d8da13c5d3fdd5737db68923e609e4ded3d53d31)), closes [#485](https://github.com/Phala-Network/phala-cloud/issues/485)
+* **cli:** add profiles refresh command ([4020c3d](https://github.com/Phala-Network/phala-cloud/commit/4020c3d7f66905c4ca8384d8985690c6b4106f3c))
+* **cli:** remove deprecated auth subcommands ([53a265e](https://github.com/Phala-Network/phala-cloud/commit/53a265ee3b9809f155bc441386002a95509812b1))
+* **cli:** revoke API tokens server-side on logout and profiles delete ([e5ff349](https://github.com/Phala-Network/phala-cloud/commit/e5ff349fd035ea51ac4b656b9556c604ff76482f))
+* **cli:** show SSH key fingerprints in runtime-config ([272560d](https://github.com/Phala-Network/phala-cloud/commit/272560d365195120984da84d2253daa83cd2bf3b))
+
+### fix
+
+* **cli:** add request timeout to docs MCP calls ([db34bf9](https://github.com/Phala-Network/phala-cloud/commit/db34bf9d72cef4ea4d7c4a363e65ddd535d9a37d))
+* **cli:** flush piped stdout before process exit ([2362e23](https://github.com/Phala-Network/phala-cloud/commit/2362e232eb67716bc0e24ded81b02b4c00147d7f))
+* **cli:** pass docs grep pattern via -e to rg ([b06e5e2](https://github.com/Phala-Network/phala-cloud/commit/b06e5e20c7e5bbcb60b934281b870768a01fcadf))
+* **cli:** pin workspace and default to current profile in profiles refresh ([644ccbc](https://github.com/Phala-Network/phala-cloud/commit/644ccbc837fc107771c053d50871dac6616b23df))
+* **cli:** preserve binary bodies in phala api ([43fd62a](https://github.com/Phala-Network/phala-cloud/commit/43fd62a6bc47a5e0ca0566992db337afcc46d4ca))
+* **cli:** preserve repeated API query parameters ([fcd2bcc](https://github.com/Phala-Network/phala-cloud/commit/fcd2bcc9255ea43a395b5778478eee440be09e5d))
+* **cli:** read env encrypt pubkey from current CVM schema on deploy ([a057b41](https://github.com/Phala-Network/phala-cloud/commit/a057b4151d2c7500dda1aadcdd78781bd78f1d49))
+* **cli:** send phala-cli/{version} User-Agent on all HTTP clients ([31f4a45](https://github.com/Phala-Network/phala-cloud/commit/31f4a454b86c35530bbb4230216ebca4148b145a))
+
+### refactor
+
+* **cli:** centralize API error presentation ([abad667](https://github.com/Phala-Network/phala-cloud/commit/abad667702e8ad380e3c4d10305429f29d34c3c7))
 ## [](https://github.com/Phala-Network/phala-cloud/compare/cli-v1.1.20...cli-v) (2026-08-06)
 
 ### feat

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "phala",
-	"version": "1.1.21-beta.2",
+	"version": "1.1.21",
 	"description": "CLI for Managing Phala Cloud Services",
 	"author": {
 		"name": "Phala Network",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "phala",
-	"version": "1.1.21-beta.1",
+	"version": "1.1.21-beta.2",
 	"description": "CLI for Managing Phala Cloud Services",
 	"author": {
 		"name": "Phala Network",

--- a/cli/src/commands/cvms/runtime-config/index.ts
+++ b/cli/src/commands/cvms/runtime-config/index.ts
@@ -3,6 +3,7 @@ import { defineCommand } from "@/src/core/define-command";
 import { isInJsonMode } from "@/src/core/json-mode";
 import type { CommandContext } from "@/src/core/types";
 import { getClient } from "@/src/lib/client";
+import { sshKeyFingerprint } from "@/src/utils/ssh-utils";
 import {
 	cvmsRuntimeConfigCommandMeta,
 	cvmsRuntimeConfigCommandSchema,
@@ -49,7 +50,10 @@ async function runCvmsRuntimeConfigCommand(
 			console.log();
 			console.log("SSH Authorized Keys:");
 			for (const key of config.ssh_authorized_keys) {
-				console.log(`  ${key}`);
+				// The fingerprint is what `phala ssh-keys list`, GitHub, and the
+				// CVM boot log all show, so print it above the key it belongs to.
+				console.log(`  ${sshKeyFingerprint(key) ?? "SHA256:<unrecognized>"}`);
+				console.log(`    ${key}`);
 			}
 		}
 

--- a/cli/src/utils/ssh-utils.test.ts
+++ b/cli/src/utils/ssh-utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { sshKeyFingerprint } from "./ssh-utils";
+
+// Expected values are the output of `ssh-keygen -lf` on these keys.
+const ED25519_KEY =
+	"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH7vLrIFkHq5zjUNZ/I4j6/2vDx7owNsNUiqAp6tPJ18 test@example.com";
+const ED25519_FINGERPRINT =
+	"SHA256:6OKoIHh0+L2URA+iptwZ1EF3NlwXZ6o0BW9/bnoR7ds";
+
+const RSA_KEY =
+	"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDM3iYNhA9nVhgNeGMEkL/rLQ2L6eQclAAvtBeElRGBBzKRO+DvmCUS57CNwjVHoJyMgirSx8y6w0YD4swQSgQgF4p64z6FMwQN4c11OHlF0Wz1G507svHHkl7Xlt9idVoxoyaCCAQ3syfe/UH6KnOO7Jh20BNMOAZgWgQPs6AphRG33pjoWs7aacj2tN11JaKjWCRD2quNJ9UNjLLkfEFkbhZXYmATMWLRaoW+GZt3/FNIZkOlQYM/RnVZDtVlUNogXMXIFqu54FbnWJ4Siqw97RYvQkvVFSf55pxl6Db7oBjMqOAcesTtg6TRsgHpYttss1ysP5NdNt3UNxEUi+C9 test@example.com";
+const RSA_FINGERPRINT = "SHA256:LxIr2ZUyQLBZtTcELwmpjnhrYTYL/4ZUhXb2ngIo0RU";
+
+const ECDSA_KEY =
+	"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBF0o88ifz1VGALnUksu7dS/DcErWjT33SF1kx9ZtCoZ8lEo0wlGnD84sMgdlbJwi8BuH8L2rNGFhXtmbdccTs9Q= test@example.com";
+const ECDSA_FINGERPRINT = "SHA256:9jqE2lho2dCTmQlTBVOtpgSAqi7wFgjrbVStzvDZx+M";
+
+describe("sshKeyFingerprint", () => {
+	test("matches ssh-keygen -lf for ed25519, rsa and ecdsa", () => {
+		expect(sshKeyFingerprint(ED25519_KEY)).toBe(ED25519_FINGERPRINT);
+		expect(sshKeyFingerprint(RSA_KEY)).toBe(RSA_FINGERPRINT);
+		expect(sshKeyFingerprint(ECDSA_KEY)).toBe(ECDSA_FINGERPRINT);
+	});
+
+	test("ignores the comment and surrounding whitespace", () => {
+		const [keyType, blob] = ED25519_KEY.split(" ");
+		expect(sshKeyFingerprint(`  ${keyType} ${blob}  `)).toBe(
+			ED25519_FINGERPRINT,
+		);
+		expect(sshKeyFingerprint(`${keyType} ${blob} someone-else@laptop`)).toBe(
+			ED25519_FINGERPRINT,
+		);
+	});
+
+	test("returns undefined instead of a fingerprint for a malformed line", () => {
+		expect(sshKeyFingerprint("")).toBeUndefined();
+		expect(sshKeyFingerprint("ssh-ed25519")).toBeUndefined();
+		expect(sshKeyFingerprint("ssh-ed25519 not-base64")).toBeUndefined();
+	});
+
+	test("rejects a blob whose algorithm disagrees with the line", () => {
+		const blob = ED25519_KEY.split(" ")[1];
+		expect(sshKeyFingerprint(`ssh-rsa ${blob}`)).toBeUndefined();
+	});
+});

--- a/cli/src/utils/ssh-utils.ts
+++ b/cli/src/utils/ssh-utils.ts
@@ -1,10 +1,44 @@
 import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { basename, join } from "node:path";
 import type { ApiVersion, Client } from "@phala/cloud";
 import chalk from "chalk";
 import { logger } from "./logger";
+
+/**
+ * SHA256 fingerprint of an OpenSSH public key line, in the format
+ * `ssh-keygen -lf` and GitHub display.
+ *
+ * The fingerprint covers the base64-decoded wire-format key blob, not the
+ * textual line, so it is independent of the trailing comment. Returns
+ * undefined when the line is not a well-formed public key: the blob carries
+ * its own algorithm name, and a blob whose name disagrees with the line's
+ * first field is not something we should print a fingerprint for.
+ */
+export function sshKeyFingerprint(publicKeyLine: string): string | undefined {
+	const [keyType, blob] = publicKeyLine.trim().split(/\s+/);
+	if (!keyType || !blob) {
+		return undefined;
+	}
+
+	const decoded = Buffer.from(blob, "base64");
+	if (decoded.length < 4) {
+		return undefined;
+	}
+
+	const nameLength = decoded.readUInt32BE(0);
+	if (nameLength === 0 || decoded.length < 4 + nameLength) {
+		return undefined;
+	}
+	if (decoded.subarray(4, 4 + nameLength).toString("utf-8") !== keyType) {
+		return undefined;
+	}
+
+	const digest = createHash("sha256").update(decoded).digest("base64");
+	return `SHA256:${digest.replace(/=+$/, "")}`;
+}
 
 /**
  * Custom error for CVM not running


### PR DESCRIPTION
## Why

`phala runtime-config` is the one SSH surface in the CLI with no fingerprint — it prints the raw `authorized_keys` lines. `phala ssh-keys list` and `phala ssh-keys remove -i` both render the server-side `fingerprint` field. So there was no way to tell whether the key injected into a CVM is the key the account holds without hashing the line by hand.

This came out of investigating a CVM whose boot log said `total 0 keys` while `runtime-config` reported one key. Companion changes in the monorepo fix the fingerprint algorithm server-side and make the CVM boot log print the same values (Phala-Network/phala-cloud-monorepo#1995).

## What changed

The fingerprint is printed above each key, matching the format `ssh-keygen -lf`, GitHub, and the CVM boot log use:

```
SSH Authorized Keys:
  SHA256:0Ra8tETl2PA6VfmyV2ll3ca1mPB/OTa68HtMhR1X+eM
    ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINg1qjCBnCE6Vr8ng9XBU7hthT9cGX9njY3bUPqjcurO
```

It is computed locally because the runtime-config endpoint returns key strings only. `sshKeyFingerprint` covers the base64-decoded wire-format blob, not the textual line, so it is independent of the trailing comment.

A blob carries its own algorithm name; when that disagrees with the line's first field, the line is not a well-formed public key and renders as `SHA256:<unrecognized>` rather than a plausible-looking hash of whatever bytes fell out of the decoder.

JSON mode output is unchanged.

`phala ssh-keys list` needs no change here — its column comes from the API and picks up the corrected values once the server-side fix and backfill land.

## Verification

Expected values in the tests are the output of `ssh-keygen -lf`, covering ed25519, RSA-2048 and ECDSA P-256, plus the comment-independence and malformed-line cases.

Run against a real CVM:

```
$ phala runtime-config f5d7f30b-90be-491b-b670-50f3bb970768
Hostname:       glm5-2
Gateway Domain: dstack-pha-usc3.phala.network
SSH Keys:       1 key(s)

SSH Authorized Keys:
  SHA256:0Ra8tETl2PA6VfmyV2ll3ca1mPB/OTa68HtMhR1X+eM
    ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINg1qjCBnCE6Vr8ng9XBU7hthT9cGX9njY3bUPqjcurO
```

That fingerprint matches `ssh-keygen -lf` on the same key.

`bun run fmt && bun run lint && bun run type-check && bun test` all pass (497 tests).