### PR TITLE
feat: same-path two-phase CVM create on POST /cvms

### DIFF
--- a/cli/src/commands/deploy/handler.ts
+++ b/cli/src/commands/deploy/handler.ts
@@ -802,6 +802,8 @@ const deployNewCvm = async (
 		const encrypted_env_vars = await encryptEnvVars(envsWithSshKey, pubkey);
 
 		commit_result = await safeCommitCvmProvision(client, {
+			// Same-path two-phase create: prefer the one-time commit token.
+			token: app.token,
 			app_id: deployed_contract.appId,
 			encrypted_env: encrypted_env_vars,
 			compose_hash: app.compose_hash,
@@ -817,6 +819,8 @@ const deployNewCvm = async (
 				: undefined;
 
 		commit_result = await safeCommitCvmProvision(client, {
+			// Same-path two-phase create: prefer the one-time commit token.
+			token: app.token,
 			app_id: app.app_id,
 			encrypted_env: encrypted_env_vars,
 			compose_hash: app.compose_hash,

--- a/go/cvms.go
+++ b/go/cvms.go
@@ -15,11 +15,14 @@ func cvmPath(cvmID string, subpath ...string) string {
 	return p
 }
 
-// ProvisionCVM provisions a new CVM.
+// ProvisionCVM prepares a new CVM creation (phase 1 of the two-phase create).
+// It POSTs the provision payload to /cvms and returns app_id, compose_hash, the
+// env-encryption pubkey, and a one-time commit token. The legacy
+// POST /cvms/provision endpoint remains available but is deprecated.
 func (c *Client) ProvisionCVM(ctx context.Context, req *ProvisionCVMRequest) (*ProvisionCVMResponse, error) {
 	var result ProvisionCVMResponse
 	err := c.doWithRetry(ctx, func() error {
-		return c.doJSON(ctx, "POST", "/cvms/provision", req, &result)
+		return c.doJSON(ctx, "POST", "/cvms", req, &result)
 	})
 	if err != nil {
 		return nil, err

--- a/go/types_cvms.go
+++ b/go/types_cvms.go
@@ -285,6 +285,10 @@ type ProvisionCVMResponse struct {
 	KMSID                 string `json:"kms_id,omitempty"`
 	KMSContractID         string `json:"kms_contract_id,omitempty"`
 	ComposeHashRegistered bool   `json:"compose_hash_registered,omitempty"`
+	// Token is the one-time commit token for the same-path two-phase create.
+	// Present when the backend supports token commit on POST /cvms; empty
+	// against older backends.
+	Token string `json:"token,omitempty"`
 	// ComposeUnchanged is set only by ProvisionCVMComposeFileUpdate: true means
 	// the submitted compose matched the deployed one, so the commit step is a
 	// no-op and can be skipped. Always false for a fresh provision.
@@ -293,8 +297,12 @@ type ProvisionCVMResponse struct {
 
 // CommitCVMProvisionRequest is the request for committing a CVM provision.
 type CommitCVMProvisionRequest struct {
-	AppID           string   `json:"app_id"`
-	ComposeHash     string   `json:"compose_hash"`
+	// Token is the one-time commit token from ProvisionCVMResponse. When set,
+	// the backend resolves AppID and ComposeHash from the token; they may be
+	// left empty.
+	Token           *string  `json:"token,omitempty"`
+	AppID           string   `json:"app_id,omitempty"`
+	ComposeHash     string   `json:"compose_hash,omitempty"`
 	TransactionHash *string  `json:"transaction_hash,omitempty"`
 	EncryptedEnv    *string  `json:"encrypted_env,omitempty"`
 	EnvKeys         []string `json:"env_keys,omitempty"`

--- a/js/src/actions/cvms/commit_cvm_provision.ts
+++ b/js/src/actions/cvms/commit_cvm_provision.ts
@@ -74,10 +74,12 @@ import type { CommitCvmProvisionResponse } from "../../types/version-mappings";
  *
  * ## Required Parameters
  *
- * - **app_id**: Application identifier
+ * - **token**: One-time commit token from the `provisionCvm()` response (preferred).
+ *   When sent, `app_id` and `compose_hash` are resolved server-side from the token.
+ * - **app_id**: Application identifier (legacy commit; optional when `token` is sent)
  *   - For PHALA KMS: Use `provision.app_id` from `provisionCvm()` response
  *   - For ETHEREUM/BASE KMS (on-chain): Obtain from your on-chain KMS contract deployment
- * - **compose_hash**: Must be obtained from `provisionCvm()` response (used to retrieve provision data from Redis)
+ * - **compose_hash**: From `provisionCvm()` response (legacy commit; optional when `token` is sent)
  *
  * ## Optional Parameters
  *
@@ -201,8 +203,14 @@ export type CommitCvmProvision = z.infer<typeof CommitCvmProvisionSchema>;
 export const CommitCvmProvisionRequestSchema = z
   .object({
     encrypted_env: z.string().optional().nullable(),
-    app_id: z.string(),
-    compose_hash: z.string(),
+    /**
+     * One-time commit token returned by `provisionCvm`. When present, the backend
+     * resolves app_id and compose_hash from the token; sending them anyway is
+     * accepted as long as they match the token.
+     */
+    token: z.string().optional(),
+    app_id: z.string().optional(),
+    compose_hash: z.string().optional(),
     /** @deprecated Identifies a KMS node, not the on-chain KMS contract. Use kms_contract_id. */
     kms_id: z.string().optional(),
     kms_contract_id: z.union([z.string(), z.number()]).optional(),

--- a/js/src/actions/cvms/provision_cvm.test.ts
+++ b/js/src/actions/cvms/provision_cvm.test.ts
@@ -295,7 +295,7 @@ describe("provisionCvm (wire-level)", () => {
     const calls = (mockClient.post as ReturnType<typeof vi.fn>).mock.calls;
     expect(calls).toHaveLength(1);
     const [path, body] = calls[0];
-    expect(path).toBe("/cvms/provision");
+    expect(path).toBe("/cvms");
     return body as Record<string, unknown>;
   }
 

--- a/js/src/actions/cvms/provision_cvm.ts
+++ b/js/src/actions/cvms/provision_cvm.ts
@@ -170,6 +170,11 @@ export const ProvisionCvmSchema = z
     device_id: z.string().nullable().optional(),
     os_image_hash: z.string().nullable().optional(),
     instance_type: z.string().nullable().optional(),
+    /**
+     * One-time commit token for the same-path two-phase create. Present when the
+     * backend supports token commit on POST /cvms; absent against older backends.
+     */
+    token: z.string().nullable().optional(),
     teepod_id: z.number().nullable().optional(), // Will be transformed to node_id
     node_id: z.number().nullable().optional(),
     /** @deprecated Identifies a KMS node, not the on-chain KMS contract. Use kms_contract_id. */
@@ -324,7 +329,9 @@ const { action: provisionCvm, safeAction: safeProvisionCvm } = defineAction<
     console.warn("[phala/cloud] teepod_id is deprecated, please use node_id instead.");
   }
 
-  return await client.post("/cvms/provision", body);
+  // Same-path two-phase create: prepare POSTs to /cvms and returns a commit token.
+  // The legacy POST /cvms/provision endpoint remains available but is deprecated.
+  return await client.post("/cvms", body);
 });
 
 export { provisionCvm, safeProvisionCvm };

--- a/python/src/phala_cloud/action_responses.py
+++ b/python/src/phala_cloud/action_responses.py
@@ -58,6 +58,9 @@ class ProvisionCvmResponse(CloudModel):
     app_id: str | None = None
     app_env_encrypt_pubkey: str | None = None
     compose_hash: str
+    # One-time commit token for the same-path two-phase create. Present when the
+    # backend supports token commit on POST /cvms; absent against older backends.
+    token: str | None = None
     kms_info: GenericObject | None = None
     fmspc: str | None = None
     device_id: str | None = None

--- a/python/src/phala_cloud/full_client.py
+++ b/python/src/phala_cloud/full_client.py
@@ -634,12 +634,21 @@ class PhalaCloud(_SyncBase, _ExtMixin):
         return self.safe(self.get_cvm_info, request)
 
     def provision_cvm(self, request: Mapping[str, Any]) -> Any:
+        """Prepare a CVM creation (phase 1 of the two-phase create).
+
+        POSTs the provision payload to /cvms and returns app_id, compose_hash,
+        the env-encryption pubkey, and a one-time commit token. The legacy
+        POST /cvms/provision endpoint remains available but is deprecated.
+        """
         body = dict(request)
         if "compose_file" in body:
             cf = dict(body["compose_file"])
             cf.setdefault("name", "")
             body["compose_file"] = cf
-        return self._loose_validate(self.post("/cvms/provision", json=body))
+        # Bypass path-based response dispatch: POST /cvms maps to the commit
+        # response model, but this call returns a provision response.
+        data = _SyncBase.request(self, "POST", "/cvms", json=body)
+        return self._validate_by_model(ProvisionCvmResponse, data)
 
     def safe_provision_cvm(self, request: Mapping[str, Any]) -> SafeResult[Any]:
         return self.safe(self.provision_cvm, request)
@@ -647,9 +656,11 @@ class PhalaCloud(_SyncBase, _ExtMixin):
     def commit_cvm_provision(self, request: Mapping[str, Any]) -> Any:
         """Commit a provisioned CVM, creating the actual instance.
 
-        This endpoint is idempotent: submitting the same app_id + compose_hash
-        again returns the existing CVM. A different compose_hash for the same
-        app_id raises ResourceError with error_code CVM_APP_ID_CONFLICT (409).
+        Pass the token from provision_cvm (preferred), or app_id + compose_hash
+        for the legacy commit. This endpoint is idempotent: submitting the same
+        app_id + compose_hash again returns the existing CVM. A different
+        compose_hash for the same app_id raises ResourceError with error_code
+        CVM_APP_ID_CONFLICT (409).
         """
         return self._loose_validate(self.post("/cvms", json=dict(request)))
 
@@ -1482,12 +1493,21 @@ class AsyncPhalaCloud(_AsyncBase, _ExtMixin):
         return await self.safe(self.get_cvm_info, request)
 
     async def provision_cvm(self, request: Mapping[str, Any]) -> Any:
+        """Prepare a CVM creation (phase 1 of the two-phase create).
+
+        POSTs the provision payload to /cvms and returns app_id, compose_hash,
+        the env-encryption pubkey, and a one-time commit token. The legacy
+        POST /cvms/provision endpoint remains available but is deprecated.
+        """
         body = dict(request)
         if "compose_file" in body:
             cf = dict(body["compose_file"])
             cf.setdefault("name", "")
             body["compose_file"] = cf
-        return self._loose_validate(await self.post("/cvms/provision", json=body))
+        # Bypass path-based response dispatch: POST /cvms maps to the commit
+        # response model, but this call returns a provision response.
+        data = await _AsyncBase.request(self, "POST", "/cvms", json=body)
+        return self._validate_by_model(ProvisionCvmResponse, data)
 
     async def safe_provision_cvm(self, request: Mapping[str, Any]) -> SafeResult[Any]:
         return await self.safe(self.provision_cvm, request)
@@ -1495,9 +1515,11 @@ class AsyncPhalaCloud(_AsyncBase, _ExtMixin):
     async def commit_cvm_provision(self, request: Mapping[str, Any]) -> Any:
         """Commit a provisioned CVM, creating the actual instance.
 
-        This endpoint is idempotent: submitting the same app_id + compose_hash
-        again returns the existing CVM. A different compose_hash for the same
-        app_id raises ResourceError with error_code CVM_APP_ID_CONFLICT (409).
+        Pass the token from provision_cvm (preferred), or app_id + compose_hash
+        for the legacy commit. This endpoint is idempotent: submitting the same
+        app_id + compose_hash again returns the existing CVM. A different
+        compose_hash for the same app_id raises ResourceError with error_code
+        CVM_APP_ID_CONFLICT (409).
         """
         return self._loose_validate(await self.post("/cvms", json=dict(request)))
 

--- a/python/tests/test_action_matrix_async.py
+++ b/python/tests/test_action_matrix_async.py
@@ -1,3 +1,5 @@
+import json
+
 import httpx
 
 from phala_cloud import AsyncPhalaCloud
@@ -132,6 +134,10 @@ def _mock_handler(request: httpx.Request) -> httpx.Response:
     if method == "POST" and path == "/api/v1/cvms/provision":
         return httpx.Response(200, json={"compose_hash": "h"})
     if method == "POST" and path == "/api/v1/cvms":
+        # Same-path two-phase create: prepare carries compose_file, commit does not.
+        body = json.loads(request.content) if request.content else {}
+        if "compose_file" in body:
+            return httpx.Response(200, json={"compose_hash": "h", "token": "tok_1"})
         return httpx.Response(200, json={"id": "cvm_1", "name": "n", "status": "running"})
     if method == "GET" and path.startswith("/api/v1/cvms/"):
         if path.endswith("/state"):

--- a/python/tests/test_action_matrix_sync.py
+++ b/python/tests/test_action_matrix_sync.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 import httpx
@@ -244,6 +245,10 @@ def _mock_handler(request: httpx.Request) -> httpx.Response:
     if method == "POST" and path == "/api/v1/cvms/provision":
         return _json_response({"compose_hash": "hash", "app_id": "app_1"})
     if method == "POST" and path == "/api/v1/cvms":
+        # Same-path two-phase create: prepare carries compose_file, commit does not.
+        body = json.loads(request.content) if request.content else {}
+        if "compose_file" in body:
+            return _json_response({"compose_hash": "hash", "app_id": "app_1", "token": "tok_1"})
         return _json_response({"id": "cvm_1", "name": "n", "status": "running"})
     if method == "POST" and path.endswith("/compose_file/provision"):
         return _json_response({"compose_hash": "hash", "app_id": "app_1"})


### PR DESCRIPTION
## Summary

Migrate all official clients to the same-path two-phase create on `POST /cvms`.

- **JS**: `provisionCvm` POSTs to `/cvms` (instead of deprecated `/cvms/provision`); response schema carries the optional commit token; `commitCvmProvision` accepts `token` with `app_id`/`compose_hash` now optional.
- **CLI**: `phala deploy` forwards the token in both on-chain and centralized KMS commit calls.
- **Go**: `ProvisionCVM` POSTs to `/cvms`; `ProvisionCVMResponse.Token`; `CommitCVMProvisionRequest.Token` with app_id/compose_hash optional.
- **Python**: sync + async `provision_cvm` POST to `/cvms` with explicit `ProvisionCvmResponse` validation (path dispatch for `POST /cvms` maps to the commit model); `ProvisionCvmResponse.token`.
- **Terraform**: submodule bump — `commitAndCreate` forwards the token (Phala-Network/terraform-provider-phala PR below).

Backward compatibility: token is optional everywhere; app_id + compose_hash keep working against both new and old backends. `phala_app_instance`, `cvms replicate`, and update flows are unchanged.

## Test plan

- [x] JS: `bun run fmt && bun run lint && bun run type-check && bun run test` (799 passed)
- [x] CLI: deploy tests (41 passed; 25 pre-existing v1.0.40-baseline failures also fail on the base commit)
- [x] Go: `go vet ./... && go test ./...`
- [x] Python: 99 passed, 3 skipped
- [x] Terraform: `go test ./...` (mock server distinguishes prepare vs commit by request body)
- [ ] After backend deploy: `phala deploy` end-to-end on PHALA KMS and on-chain KMS
