### PR TITLE
feat(js): expose requires_gpu in available OS image variants

### DIFF
--- a/js/src/actions/cvms/get_available_os_images.test.ts
+++ b/js/src/actions/cvms/get_available_os_images.test.ts
@@ -10,6 +10,7 @@ describe("GetAvailableOSImagesResponseSchema", () => {
           name: "dstack-0.5.8",
           slug: "dstack-0.5.8-target",
           os_image_hash: "0x1234",
+          requires_gpu: false,
           is_current: false,
           enabled: false,
         },
@@ -19,5 +20,6 @@ describe("GetAvailableOSImagesResponseSchema", () => {
 
     expect(result[0]?.prod?.slug).toBe("dstack-0.5.8-target");
     expect(result[0]?.prod?.enabled).toBe(false);
+    expect(result[0]?.prod?.requires_gpu).toBe(false);
   });
 });

--- a/js/src/actions/cvms/get_available_os_images.ts
+++ b/js/src/actions/cvms/get_available_os_images.ts
@@ -9,6 +9,7 @@ export const OSImageVariantSchema = z.object({
   name: z.string(),
   slug: z.string(),
   os_image_hash: z.string().nullable(),
+  requires_gpu: z.boolean(),
   is_current: z.boolean(),
   enabled: z.boolean(),
 });


### PR DESCRIPTION
## Summary
- add `requires_gpu` to the `OSImageVariantSchema` in `getAvailableOsImages`
- pin the field in the schema test fixture

The monorepo backend (phala-cloud-monorepo PR pending) now returns `requires_gpu` per prod/dev variant on `GET /cvms/{id}/available-os-images`, so SDK clients can render GPU/CPU capability without inferring it from the image name.

Python SDK loose-validates responses and Go returns GenericObject — no typed-surface change needed there.

## Test plan
- [x] `bun run test` in sdks/js (62 files, 799 tests)
- [x] fmt / lint / type-check