### PR TITLE
fix(cli): include Request ID guidance on new CVM deploys

### DIFF
--- a/cli/src/commands/deploy/handler.ts
+++ b/cli/src/commands/deploy/handler.ts
@@ -1401,7 +1401,7 @@ export async function runDeploy(
 			debug: input.debug,
 			guidance: isUpdate
 				? "Check the CVM status before retrying. Include the Request ID when contacting support."
-				: undefined,
+				: "Include the Request ID when contacting support.",
 		});
 		return 1;
 	}


### PR DESCRIPTION
## Summary

- `phala deploy` already prints `request_id` on structured API errors.
- The human-readable footer only asked users to include it when updating an existing CVM.
- New deployments now get the same guidance so support tickets are not just an error code.

## Test plan

- [x] CLI pre-commit tests (Biome, tsc, build, bun test)
- Failed create path: stderr includes `Request ID` and `Include the Request ID when contacting support.`