### PR TITLE
fix: use Phala Discord redirect

### DIFF
--- a/cli/test/e2e-full/README.md
+++ b/cli/test/e2e-full/README.md
@@ -425,7 +425,7 @@ To run in CI/CD:
 
 - **Documentation**: [docs.phala.network](https://docs.phala.network)
 - **Issues**: [github.com/Phala-Network/phala-cloud/issues](https://github.com/Phala-Network/phala-cloud/issues)
-- **Discord**: [Phala Network Discord](https://discord.gg/phala)
+- **Discord**: [Phala Network Discord](https://phala.com/discord)
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- replace the expired Discord invite with the stable `phala.com/discord` entrypoint

## Verification

- exact one-line documentation change
- `phala.com/discord` returns the verified official Phala guild invite