### PR TITLE
fix(cli): keep unit tests isolated from inherited Cloud env

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [](https://github.com/Phala-Network/phala-cloud/compare/cli-v1.1.22-beta.1...cli-v) (2026-09-06)
+
+### feat
+
+* **cli:** add ssh-keys show, grant, and revoke ([12a9c58](https://github.com/Phala-Network/phala-cloud/commit/12a9c58ac4b1ffe0d4a6f4aad2b24cf2aa339bf6))
+* **cli:** deprecate deploy --ssh-pubkey and hint on ssh 255 ([ba97785](https://github.com/Phala-Network/phala-cloud/commit/ba977856096e2b5231a8c312f69bee962a8dee73))
+* **cli:** report the MrConfigV3 measurement after deploy ([567d73d](https://github.com/Phala-Network/phala-cloud/commit/567d73d8a9db5b27f668803064d80c1db052b513))
+
+### fix
+
+* **cli:** include Request ID guidance on new CVM deploys ([6165d19](https://github.com/Phala-Network/phala-cloud/commit/6165d19d0ba0858bfe5e440fe4aae74f00b0b08c))
+* **cli:** keep unit tests isolated from inherited Cloud env ([4ff72a6](https://github.com/Phala-Network/phala-cloud/commit/4ff72a6551b1fb33d349da9417d322d11d1a4527))
+* **cli:** tighten CVM SSH key command output ([f969882](https://github.com/Phala-Network/phala-cloud/commit/f96988275d7d489439d1457d7c90825574912722))
+* **cli:** typecheck CVM SSH key tests with bun:test ([e97eb44](https://github.com/Phala-Network/phala-cloud/commit/e97eb44c73c52acbc62f3118b553d4e7cbbd696d))
+* use Phala Discord redirect ([b6f176c](https://github.com/Phala-Network/phala-cloud/commit/b6f176cc4eeb57a394b6964adf0c5554573beabc))
 ## [](https://github.com/Phala-Network/phala-cloud/compare/cli-v1.1.21...cli-v) (2026-08-15)
 
 ### feat

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "phala",
-	"version": "1.1.22-beta.1",
+	"version": "1.1.22",
 	"description": "CLI for Managing Phala Cloud Services",
 	"author": {
 		"name": "Phala Network",

--- a/cli/package.json
+++ b/cli/package.json
@@ -29,7 +29,7 @@
 	"scripts": {
 		"build": "bun run gen:help && tsup && bun link",
 		"gen:help": "bun run scripts/gen-help-topics.ts",
-		"test": "bun test",
+		"test": "bun test --path-ignore-patterns=test/e2e-full/**",
 		"test:e2e": "bun test test/e2e-full/",
 		"test:interface": "bun test test/interface-compat/",
 		"test:all": "bun run test:interface && bun run test:e2e",

--- a/cli/src/commands/logout/index.test.ts
+++ b/cli/src/commands/logout/index.test.ts
@@ -58,14 +58,22 @@ function profile(token: string) {
 	};
 }
 
+function setEnv(key: string, value: string | undefined): void {
+	if (value === undefined) delete process.env[key];
+	else process.env[key] = value;
+}
+
 describe("logout command", () => {
 	let tempDir: string;
 	let oldDir: string | undefined;
+	let oldPrefix: string | undefined;
 
 	beforeEach(() => {
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "phala-cli-test-"));
 		oldDir = process.env.PHALA_CLOUD_DIR;
+		oldPrefix = process.env.PHALA_CLOUD_API_PREFIX;
 		process.env.PHALA_CLOUD_DIR = tempDir;
+		setEnv("PHALA_CLOUD_API_PREFIX", undefined);
 		mockTryRevokeApiToken.mockClear();
 		mockTryRevokeApiToken.mockImplementation(() =>
 			Promise.resolve({ outcome: "revoked" }),
@@ -73,11 +81,8 @@ describe("logout command", () => {
 	});
 
 	afterEach(() => {
-		if (oldDir === undefined) {
-			process.env.PHALA_CLOUD_DIR = undefined;
-		} else {
-			process.env.PHALA_CLOUD_DIR = oldDir;
-		}
+		setEnv("PHALA_CLOUD_DIR", oldDir);
+		setEnv("PHALA_CLOUD_API_PREFIX", oldPrefix);
 		fs.rmSync(tempDir, { recursive: true, force: true });
 	});
 

--- a/cli/src/commands/profiles/delete/index.test.ts
+++ b/cli/src/commands/profiles/delete/index.test.ts
@@ -58,14 +58,22 @@ function profile(token: string) {
 	};
 }
 
+function setEnv(key: string, value: string | undefined): void {
+	if (value === undefined) delete process.env[key];
+	else process.env[key] = value;
+}
+
 describe("profiles delete command", () => {
 	let tempDir: string;
 	let oldDir: string | undefined;
+	let oldPrefix: string | undefined;
 
 	beforeEach(() => {
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "phala-cli-test-"));
 		oldDir = process.env.PHALA_CLOUD_DIR;
+		oldPrefix = process.env.PHALA_CLOUD_API_PREFIX;
 		process.env.PHALA_CLOUD_DIR = tempDir;
+		setEnv("PHALA_CLOUD_API_PREFIX", undefined);
 		mockTryRevokeApiToken.mockClear();
 		mockTryRevokeApiToken.mockImplementation(() =>
 			Promise.resolve({ outcome: "revoked" }),
@@ -73,11 +81,8 @@ describe("profiles delete command", () => {
 	});
 
 	afterEach(() => {
-		if (oldDir === undefined) {
-			process.env.PHALA_CLOUD_DIR = undefined;
-		} else {
-			process.env.PHALA_CLOUD_DIR = oldDir;
-		}
+		setEnv("PHALA_CLOUD_DIR", oldDir);
+		setEnv("PHALA_CLOUD_API_PREFIX", oldPrefix);
 		fs.rmSync(tempDir, { recursive: true, force: true });
 	});
 

--- a/cli/src/commands/profiles/refresh/index.test.ts
+++ b/cli/src/commands/profiles/refresh/index.test.ts
@@ -80,14 +80,22 @@ function profile(token: string) {
 	};
 }
 
+function setEnv(key: string, value: string | undefined): void {
+	if (value === undefined) delete process.env[key];
+	else process.env[key] = value;
+}
+
 describe("profiles refresh command", () => {
 	let tempDir: string;
 	let oldDir: string | undefined;
+	let oldPrefix: string | undefined;
 
 	beforeEach(() => {
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "phala-cli-test-"));
 		oldDir = process.env.PHALA_CLOUD_DIR;
+		oldPrefix = process.env.PHALA_CLOUD_API_PREFIX;
 		process.env.PHALA_CLOUD_DIR = tempDir;
+		setEnv("PHALA_CLOUD_API_PREFIX", undefined);
 		mockTryRevokeApiToken.mockClear();
 		mockTryRevokeApiToken.mockImplementation(() =>
 			Promise.resolve({ outcome: "revoked" }),
@@ -98,11 +106,8 @@ describe("profiles refresh command", () => {
 	});
 
 	afterEach(() => {
-		if (oldDir === undefined) {
-			process.env.PHALA_CLOUD_DIR = undefined;
-		} else {
-			process.env.PHALA_CLOUD_DIR = oldDir;
-		}
+		setEnv("PHALA_CLOUD_DIR", oldDir);
+		setEnv("PHALA_CLOUD_API_PREFIX", oldPrefix);
 		fs.rmSync(tempDir, { recursive: true, force: true });
 	});
 

--- a/cli/src/commands/switch/index.test.ts
+++ b/cli/src/commands/switch/index.test.ts
@@ -18,6 +18,11 @@ function cleanupDir(dir: string): void {
 	}
 }
 
+function setEnv(key: string, value: string | undefined): void {
+	if (value === undefined) delete process.env[key];
+	else process.env[key] = value;
+}
+
 function makeContext(): CommandContext {
 	return {
 		argv: [],
@@ -51,20 +56,15 @@ describe("switch command", () => {
 		tempHome = makeTempHome();
 		process.env.HOME = tempHome;
 		process.env.PHALA_CLOUD_DIR = path.join(tempHome, ".phala-cloud");
-		process.env.PHALA_CLOUD_API_KEY = undefined;
-		process.env.PHALA_CLOUD_API_PREFIX = undefined;
+		setEnv("PHALA_CLOUD_API_KEY", undefined);
+		setEnv("PHALA_CLOUD_API_PREFIX", undefined);
 	});
 
 	afterEach(() => {
-		if (oldHome !== undefined) process.env.HOME = oldHome;
-		else process.env.HOME = undefined;
-		if (oldApiKey !== undefined) process.env.PHALA_CLOUD_API_KEY = oldApiKey;
-		else process.env.PHALA_CLOUD_API_KEY = undefined;
-		if (oldApiPrefix !== undefined)
-			process.env.PHALA_CLOUD_API_PREFIX = oldApiPrefix;
-		else process.env.PHALA_CLOUD_API_PREFIX = undefined;
-		if (oldCloudDir !== undefined) process.env.PHALA_CLOUD_DIR = oldCloudDir;
-		else process.env.PHALA_CLOUD_DIR = undefined;
+		setEnv("HOME", oldHome);
+		setEnv("PHALA_CLOUD_API_KEY", oldApiKey);
+		setEnv("PHALA_CLOUD_API_PREFIX", oldApiPrefix);
+		setEnv("PHALA_CLOUD_DIR", oldCloudDir);
 
 		cleanupDir(tempHome);
 	});

--- a/cli/src/core/migrate-storage.test.ts
+++ b/cli/src/core/migrate-storage.test.ts
@@ -40,6 +40,11 @@ function cleanupDir(dir: string): void {
 	}
 }
 
+function setEnv(key: string, value: string | undefined): void {
+	if (value === undefined) delete process.env[key];
+	else process.env[key] = value;
+}
+
 function legacyEncrypt(plain: string): string {
 	const machineParts = [
 		os.hostname(),
@@ -73,19 +78,15 @@ describe("migrateStorage", () => {
 		tempHome = makeTempHome();
 		process.env.HOME = tempHome;
 		process.env.PHALA_CLOUD_DIR = path.join(tempHome, ".phala-cloud");
-		process.env.PHALA_CLOUD_API_PREFIX = undefined;
+		setEnv("PHALA_CLOUD_API_PREFIX", undefined);
 
 		fs.mkdirSync(process.env.PHALA_CLOUD_DIR, { recursive: true });
 	});
 
 	afterEach(() => {
-		if (oldHome !== undefined) process.env.HOME = oldHome;
-		else process.env.HOME = undefined;
-		if (oldApiPrefix !== undefined)
-			process.env.PHALA_CLOUD_API_PREFIX = oldApiPrefix;
-		else process.env.PHALA_CLOUD_API_PREFIX = undefined;
-		if (oldCloudDir !== undefined) process.env.PHALA_CLOUD_DIR = oldCloudDir;
-		else process.env.PHALA_CLOUD_DIR = undefined;
+		setEnv("HOME", oldHome);
+		setEnv("PHALA_CLOUD_API_PREFIX", oldApiPrefix);
+		setEnv("PHALA_CLOUD_DIR", oldCloudDir);
 
 		cleanupDir(tempHome);
 	});

--- a/cli/src/lib/client.user-agent.test.ts
+++ b/cli/src/lib/client.user-agent.test.ts
@@ -7,20 +7,8 @@ mock.module("@phala/cloud", () => ({
 	safeRevokeCurrentApiToken: mock(() => Promise.resolve({ success: true })),
 }));
 
-mock.module("@/src/utils/credentials", () => ({
-	resolveAuth: () => ({
-		apiKey: "phak_test",
-		baseURL: "https://cloud-api.phala.com/api/v1",
-		profile: "default",
-	}),
-}));
-
 mock.module("@/src/core/api-version", () => ({
 	getApiVersionOverride: () => undefined,
-}));
-
-mock.module("@/src/utils/project-config", () => ({
-	getProjectConfig: () => ({}),
 }));
 
 describe("CLI client User-Agent", () => {
@@ -32,9 +20,9 @@ describe("CLI client User-Agent", () => {
 		const { getClient } = await import("./client");
 		const { CLI_USER_AGENT } = await import("@/src/utils/cli-version");
 		await getClient({
-			env: process.env,
+			env: {},
 			projectConfig: {},
-			globalOptions: {},
+			globalOptions: { apiToken: "phak_test" },
 		} as never);
 		expect(createClientMock).toHaveBeenCalled();
 		const config = createClientMock.mock.calls[0]?.[0] as {

--- a/cli/src/utils/credentials.test.ts
+++ b/cli/src/utils/credentials.test.ts
@@ -24,6 +24,11 @@ function cleanupDir(dir: string): void {
 	}
 }
 
+function setEnv(key: string, value: string | undefined): void {
+	if (value === undefined) delete process.env[key];
+	else process.env[key] = value;
+}
+
 describe("credentials", () => {
 	let tempHome: string;
 	let oldHome: string | undefined;
@@ -44,26 +49,19 @@ describe("credentials", () => {
 		tempHome = makeTempHome();
 		process.env.HOME = tempHome;
 		process.env.PHALA_CLOUD_DIR = path.join(tempHome, ".phala-cloud");
-		process.env.PHALA_CLOUD_API_KEY = undefined;
-		process.env.PHALA_CLOUD_API_PREFIX = undefined;
-		process.env.PHALA_OIDC_TOKEN = undefined;
-		process.env.PHALA_CLOUD_WORKSPACE = undefined;
+		setEnv("PHALA_CLOUD_API_KEY", undefined);
+		setEnv("PHALA_CLOUD_API_PREFIX", undefined);
+		setEnv("PHALA_OIDC_TOKEN", undefined);
+		setEnv("PHALA_CLOUD_WORKSPACE", undefined);
 	});
 
 	afterEach(() => {
-		if (oldHome !== undefined) process.env.HOME = oldHome;
-		else process.env.HOME = undefined;
-		if (oldApiKey !== undefined) process.env.PHALA_CLOUD_API_KEY = oldApiKey;
-		else process.env.PHALA_CLOUD_API_KEY = undefined;
-		if (oldApiPrefix !== undefined)
-			process.env.PHALA_CLOUD_API_PREFIX = oldApiPrefix;
-		else process.env.PHALA_CLOUD_API_PREFIX = undefined;
-		if (oldOidc !== undefined) process.env.PHALA_OIDC_TOKEN = oldOidc;
-		else process.env.PHALA_OIDC_TOKEN = undefined;
-		if (oldWorkspace !== undefined) process.env.PHALA_CLOUD_WORKSPACE = oldWorkspace;
-		else process.env.PHALA_CLOUD_WORKSPACE = undefined;
-		if (oldCloudDir !== undefined) process.env.PHALA_CLOUD_DIR = oldCloudDir;
-		else process.env.PHALA_CLOUD_DIR = undefined;
+		setEnv("HOME", oldHome);
+		setEnv("PHALA_CLOUD_API_KEY", oldApiKey);
+		setEnv("PHALA_CLOUD_API_PREFIX", oldApiPrefix);
+		setEnv("PHALA_OIDC_TOKEN", oldOidc);
+		setEnv("PHALA_CLOUD_WORKSPACE", oldWorkspace);
+		setEnv("PHALA_CLOUD_DIR", oldCloudDir);
 
 		cleanupDir(tempHome);
 	});
@@ -324,5 +322,4 @@ describe("credentials", () => {
 		expect(resolved.bearerToken).toBeNull();
 		expect(resolved.tokenSource).toBe("env");
 	});
-
 });


### PR DESCRIPTION
## Summary

Release npm (`cli` patch 1.1.22) failed on `bun test` because the `release` environment injects `PHALA_CLOUD_API_KEY`. That un-skips live e2e tests and leaks into `resolveAuth` unit tests.

- Tests used `process.env.X = undefined` to clear auth env. Node/Bun stringify that to the literal `"undefined"`, so `PHALA_CLOUD_API_PREFIX` became a real prefix and the CLI requested `undefined/auth/me`.
- The User-Agent test replaced the entire credentials module with a mock that always returns `apiKey: "phak_test"`. Under bun 1.4 that mock can leak across files.
- Default `bun test` also ran `test/e2e-full`, which talks to production whenever an API key is present.

## Changes

- Clear and restore process env with `delete` via a small `setEnv` helper in the affected CLI tests.
- Pass `apiToken` into `getClient` instead of mock.module-replacing credentials.
- Ignore `test/e2e-full/**` in the default `test` script. Live e2e stays on `bun run test:e2e`.

## Test plan

- [x] `bun run lint` / `bun run type-check` in `cli/`
- [x] `PHALA_CLOUD_API_KEY=phak_test PHALA_CLOUD_API_PREFIX=https://should-not-leak.example/api/v1 bun run test` — 491 pass, 0 fail, e2e not collected